### PR TITLE
[agent.skill][#37] Add remote branch verification to open-pr skill

### DIFF
--- a/claude/skills/open-pr/SKILL.md
+++ b/claude/skills/open-pr/SKILL.md
@@ -195,9 +195,55 @@ Should I create this PR?
 - If the user requests modifications, update the draft and present again
 - If the user declines, abort PR creation gracefully
 
+### 6.5. Remote Branch Verification
+
+**CRITICAL:** Before creating the PR, verify the current branch exists on the remote repository.
+
+Check if the current branch is tracking a remote branch:
+
+```bash
+# Check if current branch has an upstream branch
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+```
+
+**If the command fails (no upstream branch):**
+1. Get the current branch name:
+   ```bash
+   git branch --show-current
+   ```
+2. Push the branch with tracking:
+   ```bash
+   git push -u origin <branch-name>
+   ```
+3. Confirm to user: "Pushed branch to remote: origin/<branch-name>"
+
+**If the command succeeds (upstream branch exists):**
+1. Check if local is ahead of remote:
+   ```bash
+   git status --porcelain --branch
+   ```
+2. If output contains `[ahead N]`, push changes:
+   ```bash
+   git push
+   ```
+3. If up-to-date, continue to PR creation
+
+**Error handling:**
+- If push fails due to authentication:
+  ```
+  Git push failed. Please check your Git credentials.
+  ```
+- If push fails due to conflicts:
+  ```
+  Cannot push: your branch has diverged from remote.
+  Please resolve conflicts manually with:
+    git pull --rebase origin <branch-name>
+  ```
+- For other push failures: Display the error and abort PR creation
+
 ### 7. GitHub PR Creation
 
-Once confirmed, create the PR using the GitHub CLI:
+Once confirmed and the branch is on remote, create the PR using the GitHub CLI:
 
 ```bash
 gh pr create --title "TITLE_HERE" --body "$(cat <<'EOF'

--- a/docs/test.md
+++ b/docs/test.md
@@ -113,7 +113,13 @@ This document tracks the testing status of AI rules, skills, and commands in thi
 **Dogfeeding Examples**:
 - PR #33: Need to validate if this was created via the command or manually
 
-**Notes**: Needs explicit dogfeeding validation
+**Recent Changes**:
+- Issue #37: Added remote branch verification step (6.5) to prevent PR creation failures when branch only exists locally
+  - Handles three cases: no upstream, local ahead, up-to-date
+  - Includes error handling for authentication and diverged branches
+  - Needs dogfeeding validation to test the new remote branch push logic
+
+**Notes**: Needs explicit dogfeeding validation, especially for the new remote branch verification feature
 
 ---
 
@@ -269,7 +275,7 @@ When dogfeeding new skills/commands:
 
 ## Maintenance
 
-**Last Updated**: 2025-12-24 (Updated with review-standard skill and code-review command validation)
+**Last Updated**: 2025-12-25 (Updated with open-pr skill remote branch verification - issue #37)
 
 **Update Frequency**: After each dogfeeding session or major change to skills/commands
 


### PR DESCRIPTION
## Summary

Added remote branch verification to the `open-pr` skill to prevent PR creation failures when the branch only exists locally. The skill now automatically detects whether the current branch is on the remote, and pushes it if needed before creating the pull request.

## Changes

- Modified `claude/skills/open-pr/SKILL.md:198-242` to add new section 6.5 "Remote Branch Verification"
  - Inserted between step 6 "User Confirmation Phase" and step 7 "GitHub PR Creation"
  - Handles three scenarios: no upstream branch, local ahead of remote, and up-to-date
  - Includes logic to automatically push branch with `git push -u origin <branch-name>` when no upstream exists
  - Pushes unpushed commits with `git push` when local is ahead of remote
  - Comprehensive error handling for authentication failures and diverged branches
- Updated `docs/test.md:116-122, 278` to track the new remote branch verification feature
  - Documented the recent changes to open-pr skill
  - Marked as needing dogfeeding validation to test the new push logic
  - Updated last modified date to 2025-12-25

## Testing

This is a documentation-only change that updates the open-pr skill instructions for AI agents. Testing approach:

**Manual Testing Required:**
- The skill instructions need to be validated through dogfeeding (using the skill to create PRs)
- Key scenarios to test:
  1. Creating PR from a branch with no upstream (should auto-push)
  2. Creating PR from a branch with unpushed commits (should push changes)
  3. Creating PR from an up-to-date branch (should proceed directly)
  4. Error handling for authentication failures and diverged branches

**Pre-commit Tests:**
- All existing automated tests passed (C SDK, C++ SDK, Python SDK, agentize modes)
- No test failures introduced by this documentation change

## Related Issue

Closes #37