### PR TITLE
[agent.command][#43] Add /agent-review command for agent-based code review

### DIFF
--- a/claude/agents/README.md
+++ b/claude/agents/README.md
@@ -15,4 +15,4 @@ Agents provide isolated execution environments for complex, multi-step tasks. Ea
 
 ## Available Agents
 
-- `code-review.md`: Comprehensive code review with enhanced quality standards using Opus model for long context analysis
+- `code-quality-reviewer.md`: Comprehensive code review with enhanced quality standards using Opus model for long context analysis

--- a/claude/agents/code-quality-reviewer.md
+++ b/claude/agents/code-quality-reviewer.md
@@ -1,12 +1,12 @@
 ---
-name: code-review
+name: code-quality-reviewer
 description: Comprehensive code review with enhanced quality standards using Opus for long context analysis
 tools: Read, Grep, Glob, Bash
 model: opus
 skills: review-standard
 ---
 
-# Code Review Agent
+# Code Quality Reviewer
 
 You are a comprehensive code review agent that performs thorough analysis of code changes using enhanced quality standards.
 

--- a/claude/commands/README.md
+++ b/claude/commands/README.md
@@ -16,6 +16,8 @@ Commands provide a simple interface to invoke complex workflows or skills. Each 
 
 ## Available Commands
 
+- `agent-review.md`: Review code changes via agent with isolated context and Opus model
+- `code-review.md`: Review code changes from current HEAD to main/HEAD following review standards
 - `git-commit.md`: Invokes the commit-msg skill to create commits with meaningful messages following project standards
 - `make-a-plan.md`: Creates comprehensive implementation plans following design-first TDD approach
 - `issue-to-impl.md`: Orchestrates full implementation workflow from issue to completion (creates branch, docs, tests, and first milestone)

--- a/claude/commands/agent-review.md
+++ b/claude/commands/agent-review.md
@@ -1,0 +1,59 @@
+---
+name: agent-review
+description: Review code changes via agent with isolated context and Opus model
+---
+
+# Agent Review Command
+
+Execute code review using the code-quality-reviewer agent in isolated context with Opus model for enhanced long context analysis.
+
+Invoke the command: /agent-review
+
+## Inputs
+
+**From current branch:**
+- All changes between main and HEAD (handled by agent)
+
+## Outputs
+
+**Terminal output:**
+- Comprehensive code review report from code-quality-reviewer agent
+- Same format as /code-review with 3-phase analysis
+
+## Agent Integration
+
+### Step 1: Invoke Code-Quality-Reviewer Agent
+
+Use Task tool to invoke the code-quality-reviewer agent:
+
+**Task Tool Parameters:**
+- `subagent_type: 'code-quality-reviewer'`
+- `prompt: "Review changes on current branch"`
+- `description: "Comprehensive code review"`
+
+The agent will:
+- Validate current branch (not main)
+- Get changed files and full diff
+- Execute review-standard skill (all 3 phases)
+- Generate structured review report
+
+### Step 2: Display Agent Report
+
+Present the agent's review report to the user.
+
+The report includes:
+- Phase 1: Documentation Quality Review
+- Phase 2: Code Quality & Reuse Review
+- Phase 3: Advanced Code Quality Review
+- Overall Assessment with actionable recommendations
+
+## Comparison with /code-review
+
+| Feature | /agent-review | /code-review |
+|---------|---------------|--------------|
+| **Execution** | Isolated agent context | Main conversation |
+| **Model** | Opus (long context) | Current model |
+| **Best for** | Large diffs (>500 lines) | Small diffs |
+| **Context** | Clean, focused | Full conversation |
+
+Both use the same review-standard skill and produce equivalent quality reviews.

--- a/claude/commands/code-review.md
+++ b/claude/commands/code-review.md
@@ -9,7 +9,7 @@ Execute the review-standard skill to perform comprehensive code review of change
 
 Invoke the skill: /code-review
 
-**Note**: For large diffs or comprehensive reviews requiring long context analysis, consider using the `code-review` agent which runs on Opus model in isolated context. The agent provides the same review standards with enhanced capacity for thorough analysis.
+**Note**: For large diffs or comprehensive reviews requiring long context analysis, consider using the `code-quality-reviewer` agent which runs on Opus model in isolated context. The agent provides the same review standards with enhanced capacity for thorough analysis.
 
 ## Inputs
 

--- a/docs/test/code-review-agent.md
+++ b/docs/test/code-review-agent.md
@@ -4,7 +4,7 @@ Test coverage for the code-review agent created in issue #38.
 
 ## Module Under Test
 
-`claude/agents/code-review.md` - Comprehensive code review agent using Opus model
+`claude/agents/code-quality-reviewer.md` - Comprehensive code review agent using Opus model
 
 ## Test Status
 
@@ -17,7 +17,7 @@ Test coverage for the code-review agent created in issue #38.
 **Test**: Verify agent YAML frontmatter is correct
 
 **Validation**:
-- [ ] `name: code-review` is set
+- [ ] `name: code-quality-reviewer` is set
 - [ ] `description` is clear and actionable
 - [ ] `tools: Read, Grep, Glob, Bash` are specified
 - [ ] `model: opus` is specified
@@ -32,7 +32,7 @@ Test coverage for the code-review agent created in issue #38.
 **Test**: Verify agent can be invoked via Task tool
 
 **Validation**:
-- [ ] Agent can be called with `Task tool` and `subagent_type='code-review'`
+- [ ] Agent can be called with `Task tool` and `subagent_type='code-quality-reviewer'`
 - [ ] Agent initializes with Opus model
 - [ ] Agent loads review-standard skill
 - [ ] Agent has access to specified tools


### PR DESCRIPTION
## Summary

Added a new `/agent-review` command that invokes the code-quality-reviewer agent for comprehensive code reviews in isolated context using the Opus model. The agent was renamed from `code-review` to `code-quality-reviewer` to avoid naming conflicts with the existing `/code-review` command.

## Changes

- Created `claude/commands/agent-review.md` (59 lines)
  - Simple command wrapper that invokes code-quality-reviewer agent via Task tool
  - Includes comparison table showing when to use `/agent-review` vs `/code-review`
  - Agent runs in isolated context with Opus model for enhanced long context analysis
- Renamed agent file: `claude/agents/code-review.md` → `claude/agents/code-quality-reviewer.md`
  - Updated agent name in YAML frontmatter: `code-review` → `code-quality-reviewer`
  - Updated agent title: "Code Review Agent" → "Code Quality Reviewer"
  - Avoids redundant naming (@agent-code-quality-reviewer instead of @agent-agent-reviewer)
- Updated `claude/agents/README.md:18` to reference new agent filename
- Updated `claude/commands/README.md:19-20` to add agent-review and code-review entries
- Updated `claude/commands/code-review.md:12` to reference code-quality-reviewer agent
- Updated `docs/test/code-review-agent.md` (lines 7, 20, 35) to use new agent name and subagent_type

## Testing

- All pre-commit tests passed successfully:
  - Agentize mode validation tests (6 tests)
  - C SDK tests with different source paths (2 tests)
  - C++ SDK tests with different source paths (2 tests)
  - Python SDK tests (1 test)
- Total: 11 tests passed, 0 failed
- No test modifications were required as the changes are purely additive (new command) and rename-based (agent file)

## Related Issue

Closes #43