### PR TITLE
[bugfix][#46] Fix Makefile validation for mode-specific parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,8 @@ test:
 
 # Agentize target - creates SDK for projects
 agentize:
-	@if [ -z "$(AGENTIZE_PROJECT_NAME)" ]; then \
-		echo "Error: AGENTIZE_PROJECT_NAME is required"; \
-		exit 1; \
-	fi
 	@if [ -z "$(AGENTIZE_PROJECT_PATH)" ]; then \
 		echo "Error: AGENTIZE_PROJECT_PATH is required"; \
-		exit 1; \
-	fi
-	@if [ -z "$(AGENTIZE_PROJECT_LANG)" ]; then \
-		echo "Error: AGENTIZE_PROJECT_LANG is required"; \
-		exit 1; \
-	fi
-	@# Check if language template exists
-	@if [ ! -d "templates/$(AGENTIZE_PROJECT_LANG)" ]; then \
-		echo "Error: Template for language '$(AGENTIZE_PROJECT_LANG)' not found"; \
-		echo "Available languages: c, cxx, python"; \
 		exit 1; \
 	fi
 	@# Set default mode to init if not specified
@@ -29,12 +15,25 @@ agentize:
 	if [ -z "$$MODE" ]; then MODE="init"; fi; \
 	SOURCE_PATH=$(AGENTIZE_SOURCE_PATH); \
 	if [ -z "$$SOURCE_PATH" ]; then SOURCE_PATH="src"; fi; \
-	echo "Creating SDK for project: $(AGENTIZE_PROJECT_NAME)"; \
-	echo "Language: $(AGENTIZE_PROJECT_LANG)"; \
 	echo "Mode: $$MODE"; \
 	echo "Target path: $(AGENTIZE_PROJECT_PATH)"; \
-	echo "Source path: $$SOURCE_PATH"; \
 	if [ "$$MODE" = "init" ]; then \
+		if [ -z "$(AGENTIZE_PROJECT_NAME)" ]; then \
+			echo "Error: AGENTIZE_PROJECT_NAME is required for init mode"; \
+			exit 1; \
+		fi; \
+		if [ -z "$(AGENTIZE_PROJECT_LANG)" ]; then \
+			echo "Error: AGENTIZE_PROJECT_LANG is required for init mode"; \
+			exit 1; \
+		fi; \
+		if [ ! -d "templates/$(AGENTIZE_PROJECT_LANG)" ]; then \
+			echo "Error: Template for language '$(AGENTIZE_PROJECT_LANG)' not found"; \
+			echo "Available languages: c, cxx, python"; \
+			exit 1; \
+		fi; \
+		echo "Creating SDK for project: $(AGENTIZE_PROJECT_NAME)"; \
+		echo "Language: $(AGENTIZE_PROJECT_LANG)"; \
+		echo "Source path: $$SOURCE_PATH"; \
 		echo "Initializing SDK structure..."; \
 		if [ -d "$(AGENTIZE_PROJECT_PATH)" ]; then \
 			if [ -n "$$(ls -A '$(AGENTIZE_PROJECT_PATH)' 2>/dev/null)" ]; then \
@@ -84,7 +83,41 @@ agentize:
 		cp -r "$(AGENTIZE_PROJECT_PATH)/.claude" "$(AGENTIZE_PROJECT_PATH)/.claude.backup"; \
 		cp -r claude/* "$(AGENTIZE_PROJECT_PATH)/.claude/"; \
 		echo "  Updated .claude/settings.json, commands, skills, and hooks"; \
-		echo "  Existing CLAUDE.md and docs/git-msg-tags.md were preserved"; \
+		if [ ! -f "$(AGENTIZE_PROJECT_PATH)/docs/git-msg-tags.md" ]; then \
+			echo "  Creating missing docs/git-msg-tags.md..."; \
+			DETECTED_LANG=""; \
+			if [ -f "$(AGENTIZE_PROJECT_PATH)/requirements.txt" ] || \
+			   [ -f "$(AGENTIZE_PROJECT_PATH)/pyproject.toml" ] || \
+			   [ -n "$$(find '$(AGENTIZE_PROJECT_PATH)' -maxdepth 2 -name '*.py' -print -quit 2>/dev/null)" ]; then \
+				DETECTED_LANG="python"; \
+			elif [ -f "$(AGENTIZE_PROJECT_PATH)/CMakeLists.txt" ]; then \
+				if grep -q "project.*CXX" "$(AGENTIZE_PROJECT_PATH)/CMakeLists.txt" 2>/dev/null; then \
+					DETECTED_LANG="cxx"; \
+				else \
+					DETECTED_LANG="c"; \
+				fi; \
+			fi; \
+			if [ -n "$$DETECTED_LANG" ]; then \
+				echo "    Detected language: $$DETECTED_LANG"; \
+				mkdir -p "$(AGENTIZE_PROJECT_PATH)/docs"; \
+				if [ "$$DETECTED_LANG" = "python" ]; then \
+					sed -e "/{{#if_python}}/d" \
+					    -e "/{{\/if_python}}/d" \
+					    -e "/{{#if_c_or_cxx}}/,/{{\/if_c_or_cxx}}/d" \
+					    templates/claude/docs/git-msg-tags.md.template > "$(AGENTIZE_PROJECT_PATH)/docs/git-msg-tags.md"; \
+				else \
+					sed -e "/{{#if_python}}/,/{{\/if_python}}/d" \
+					    -e "/{{#if_c_or_cxx}}/d" \
+					    -e "/{{\/if_c_or_cxx}}/d" \
+					    templates/claude/docs/git-msg-tags.md.template > "$(AGENTIZE_PROJECT_PATH)/docs/git-msg-tags.md"; \
+				fi; \
+				echo "    Created docs/git-msg-tags.md"; \
+			else \
+				echo "    Warning: Could not detect project language, skipping git-msg-tags.md creation"; \
+			fi; \
+		else \
+			echo "  Existing CLAUDE.md and docs/git-msg-tags.md were preserved"; \
+		fi; \
 		echo "SDK updated successfully at $(AGENTIZE_PROJECT_PATH)"; \
 	else \
 		echo "Error: Invalid mode '$$MODE'. Supported modes: init, update"; \

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -27,6 +27,18 @@ else
 fi
 echo ""
 
+# Test Makefile parameter validation logic
+echo ">>> Testing Makefile parameter validation..."
+TOTAL_TESTS=$((TOTAL_TESTS + 1))
+if bash "$SCRIPT_DIR/test-makefile-validation.sh"; then
+    echo "✓ Makefile validation tests passed"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+else
+    echo "✗ Makefile validation tests failed"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+fi
+echo ""
+
 # Test C SDK
 echo ">>> Testing C SDK..."
 TOTAL_TESTS=$((TOTAL_TESTS + 1))

--- a/tests/test-makefile-validation.sh
+++ b/tests/test-makefile-validation.sh
@@ -1,0 +1,416 @@
+#!/bin/bash
+
+# Test suite for Makefile agentize target validation logic
+# Tests mode-specific parameter requirements and git-msg-tags.md handling
+
+set -e
+
+# Color codes for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=6
+
+# Root directory of the project
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Helper function to print test status
+print_test_header() {
+    echo ""
+    echo "=================================================="
+    echo "TEST: $1"
+    echo "=================================================="
+}
+
+print_pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+print_fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+print_info() {
+    echo -e "${YELLOW}ℹ INFO${NC}: $1"
+}
+
+# Helper function to cleanup test directories
+cleanup_test_dir() {
+    local test_dir="$1"
+    if [ -d "$test_dir" ]; then
+        rm -rf "$test_dir"
+        print_info "Cleaned up test directory: $test_dir"
+    fi
+}
+
+# Helper function to run make command and capture output
+run_make() {
+    local output_file="$1"
+    shift
+    make -C "$PROJECT_ROOT" "$@" > "$output_file" 2>&1
+    return $?
+}
+
+#####################################################################
+# TC1: Init mode without LANG parameter (should fail)
+#####################################################################
+test_init_without_lang() {
+    print_test_header "TC1: Init mode without LANG parameter (should fail)"
+
+    local test_dir="/tmp/test_init_no_lang_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Run make without AGENTIZE_PROJECT_LANG in init mode
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_MODE="init"
+    local exit_code=$?
+    set -e
+
+    # Verify it failed
+    if [ $exit_code -ne 0 ]; then
+        # Check error message mentions LANG requirement
+        if grep -q "AGENTIZE_PROJECT_LANG" "$output_file"; then
+            print_pass "Init mode correctly requires AGENTIZE_PROJECT_LANG parameter"
+        else
+            print_fail "Error message doesn't mention AGENTIZE_PROJECT_LANG requirement"
+            cat "$output_file"
+        fi
+    else
+        print_fail "Init mode should fail without AGENTIZE_PROJECT_LANG, but succeeded"
+        cat "$output_file"
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# TC2: Update mode without LANG parameter (should succeed)
+#####################################################################
+test_update_without_lang() {
+    print_test_header "TC2: Update mode without LANG parameter (should succeed)"
+
+    local test_dir="/tmp/test_update_no_lang_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Setup: Create a valid SDK structure first
+    print_info "Setting up: Creating initial SDK structure"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_PROJECT_LANG="python" \
+        AGENTIZE_MODE="init"
+    local setup_exit=$?
+    set -e
+
+    if [ $setup_exit -ne 0 ]; then
+        print_fail "Setup failed: Could not create initial SDK structure"
+        cat "$output_file"
+        cleanup_test_dir "$test_dir"
+        rm -f "$output_file"
+        return
+    fi
+
+    # Test: Update without LANG or NAME
+    print_info "Testing: Update mode without LANG or NAME parameters"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_MODE="update"
+    local exit_code=$?
+    set -e
+
+    # Verify it succeeded
+    if [ $exit_code -eq 0 ]; then
+        print_pass "Update mode succeeded without AGENTIZE_PROJECT_LANG or NAME"
+    else
+        print_fail "Update mode should succeed without LANG/NAME, but failed"
+        cat "$output_file"
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# TC3: Update mode creates missing git-msg-tags.md
+#####################################################################
+test_update_creates_git_tags() {
+    print_test_header "TC3: Update mode creates missing git-msg-tags.md"
+
+    local test_dir="/tmp/test_update_git_tags_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Setup: Create SDK structure
+    print_info "Setting up: Creating SDK with Python template"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_PROJECT_LANG="python" \
+        AGENTIZE_MODE="init"
+    local setup_exit=$?
+    set -e
+
+    if [ $setup_exit -ne 0 ]; then
+        print_fail "Setup failed: Could not create initial SDK structure"
+        cat "$output_file"
+        cleanup_test_dir "$test_dir"
+        rm -f "$output_file"
+        return
+    fi
+
+    # Remove git-msg-tags.md
+    print_info "Removing git-msg-tags.md to simulate missing file"
+    rm -f "$test_dir/docs/git-msg-tags.md"
+
+    # Test: Update should recreate the file
+    print_info "Testing: Update mode recreates missing git-msg-tags.md"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_MODE="update"
+    local exit_code=$?
+    set -e
+
+    # Verify file was created
+    if [ $exit_code -eq 0 ] && [ -f "$test_dir/docs/git-msg-tags.md" ]; then
+        # Check for Python-specific content (deps tag) and absence of C/C++ build tag
+        if grep -q '`deps`' "$test_dir/docs/git-msg-tags.md" && ! grep -q '`build`' "$test_dir/docs/git-msg-tags.md"; then
+            print_pass "Update mode recreated git-msg-tags.md with Python-specific content"
+        else
+            print_fail "git-msg-tags.md was created but lacks Python-specific content"
+            cat "$test_dir/docs/git-msg-tags.md"
+        fi
+    else
+        print_fail "Update mode did not recreate missing git-msg-tags.md"
+        cat "$output_file"
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# TC4: Update mode preserves existing git-msg-tags.md
+#####################################################################
+test_update_preserves_git_tags() {
+    print_test_header "TC4: Update mode preserves existing git-msg-tags.md"
+
+    local test_dir="/tmp/test_update_preserve_tags_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Setup: Create SDK structure
+    print_info "Setting up: Creating SDK with C template"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_PROJECT_LANG="c" \
+        AGENTIZE_MODE="init"
+    local setup_exit=$?
+    set -e
+
+    if [ $setup_exit -ne 0 ]; then
+        print_fail "Setup failed: Could not create initial SDK structure"
+        cat "$output_file"
+        cleanup_test_dir "$test_dir"
+        rm -f "$output_file"
+        return
+    fi
+
+    # Modify git-msg-tags.md with custom content
+    print_info "Adding custom content to git-msg-tags.md"
+    echo "# Custom tags - DO NOT OVERWRITE" > "$test_dir/docs/git-msg-tags.md"
+    echo "custom-tag: Custom modification description" >> "$test_dir/docs/git-msg-tags.md"
+
+    # Test: Update should preserve custom content
+    print_info "Testing: Update mode preserves existing git-msg-tags.md"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_MODE="update"
+    local exit_code=$?
+    set -e
+
+    # Verify custom content is preserved
+    if [ $exit_code -eq 0 ] && grep -q "# Custom tags - DO NOT OVERWRITE" "$test_dir/docs/git-msg-tags.md"; then
+        if grep -q "custom-tag:" "$test_dir/docs/git-msg-tags.md"; then
+            print_pass "Update mode preserved custom git-msg-tags.md content"
+        else
+            print_fail "Custom content partially lost"
+            cat "$test_dir/docs/git-msg-tags.md"
+        fi
+    else
+        print_fail "Update mode did not preserve existing git-msg-tags.md"
+        cat "$output_file"
+        if [ -f "$test_dir/docs/git-msg-tags.md" ]; then
+            cat "$test_dir/docs/git-msg-tags.md"
+        fi
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# TC5: Init mode with invalid LANG (should fail)
+#####################################################################
+test_init_invalid_lang() {
+    print_test_header "TC5: Init mode with invalid LANG (should fail)"
+
+    local test_dir="/tmp/test_invalid_lang_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Run make with invalid language
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_PROJECT_LANG="rust" \
+        AGENTIZE_MODE="init"
+    local exit_code=$?
+    set -e
+
+    # Verify it failed with appropriate error message
+    if [ $exit_code -ne 0 ]; then
+        # Check error message mentions template not found
+        if grep -qi "template.*not found\|invalid.*language" "$output_file" || \
+           grep -q "rust" "$output_file"; then
+            print_pass "Init mode correctly rejects invalid language 'rust'"
+        else
+            print_fail "Error message doesn't clearly indicate template/language issue"
+            cat "$output_file"
+        fi
+    else
+        print_fail "Init mode should fail with invalid language, but succeeded"
+        cat "$output_file"
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# TC6: Update mode infers LANG from existing structure
+#####################################################################
+test_update_infers_lang() {
+    print_test_header "TC6: Update mode infers LANG from existing structure"
+
+    local test_dir="/tmp/test_infer_lang_$$"
+    local output_file="/tmp/test_output_$$"
+
+    cleanup_test_dir "$test_dir"
+
+    # Setup: Create Python SDK
+    print_info "Setting up: Creating Python SDK"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_NAME="test_proj" \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_PROJECT_LANG="python" \
+        AGENTIZE_MODE="init"
+    local setup_exit=$?
+    set -e
+
+    if [ $setup_exit -ne 0 ]; then
+        print_fail "Setup failed: Could not create initial SDK structure"
+        cat "$output_file"
+        cleanup_test_dir "$test_dir"
+        rm -f "$output_file"
+        return
+    fi
+
+    # Remove git-msg-tags.md to trigger recreation with language detection
+    print_info "Removing git-msg-tags.md to trigger language detection"
+    rm -f "$test_dir/docs/git-msg-tags.md"
+
+    # Test: Update without LANG should infer Python from structure
+    print_info "Testing: Update mode infers Python from project structure"
+    set +e
+    run_make "$output_file" agentize \
+        AGENTIZE_PROJECT_PATH="$test_dir" \
+        AGENTIZE_MODE="update"
+    local exit_code=$?
+    set -e
+
+    # Verify Python template was used
+    if [ $exit_code -eq 0 ] && [ -f "$test_dir/docs/git-msg-tags.md" ]; then
+        # Python template should have `deps` but not `build`
+        if grep -q '`deps`' "$test_dir/docs/git-msg-tags.md" && ! grep -q '`build`' "$test_dir/docs/git-msg-tags.md"; then
+            print_pass "Update mode correctly inferred Python and used Python template"
+        else
+            print_fail "Wrong template used (expected Python template with deps, no build)"
+            cat "$test_dir/docs/git-msg-tags.md"
+        fi
+    else
+        print_fail "Update mode did not recreate git-msg-tags.md with language inference"
+        cat "$output_file"
+    fi
+
+    cleanup_test_dir "$test_dir"
+    rm -f "$output_file"
+}
+
+#####################################################################
+# Main test execution
+#####################################################################
+main() {
+    echo "======================================================="
+    echo "Makefile Validation Logic Test Suite"
+    echo "======================================================="
+    echo ""
+    echo "Testing mode-specific parameter requirements and"
+    echo "git-msg-tags.md handling in agentize target"
+    echo ""
+
+    # Run all test cases
+    test_init_without_lang
+    test_update_without_lang
+    test_update_creates_git_tags
+    test_update_preserves_git_tags
+    test_init_invalid_lang
+    test_update_infers_lang
+
+    # Print summary
+    echo ""
+    echo "======================================================="
+    echo "Test Summary"
+    echo "======================================================="
+    echo "Total tests: $TESTS_TOTAL"
+    echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [ $TESTS_FAILED -eq 0 ]; then
+        echo -e "${GREEN}All tests passed!${NC}"
+        exit 0
+    else
+        echo -e "${RED}Some tests failed.${NC}"
+        exit 1
+    fi
+}
+
+# Run main function
+main


### PR DESCRIPTION
## Summary

Fixed the Makefile's agentize target to use mode-specific parameter validation and automatically handle missing git-msg-tags.md files in update mode. The validation logic now correctly requires `AGENTIZE_PROJECT_NAME` and `AGENTIZE_PROJECT_LANG` only for init mode, while update mode only requires `AGENTIZE_PROJECT_PATH`.

## Changes

- Modified `Makefile:9-33` to move parameter validation into mode-specific blocks
  - Moved `AGENTIZE_PROJECT_NAME` validation from global scope to init mode only
  - Moved `AGENTIZE_PROJECT_LANG` validation from global scope to init mode only
  - Moved language template existence check to init mode only
  - Kept only `AGENTIZE_PROJECT_PATH` validation as required for all modes
  - Updated error messages to clearly indicate mode-specific requirements
- Modified `Makefile:86-118` to add git-msg-tags.md detection and creation in update mode
  - Detects project language from structure (`.py` files for Python, `CMakeLists.txt` for C/C++)
  - Creates missing git-msg-tags.md from template with language-specific tags
  - Preserves existing git-msg-tags.md files if present
- Created `tests/test-makefile-validation.sh` with comprehensive test coverage
  - TC1: Init mode requires AGENTIZE_PROJECT_LANG parameter
  - TC2: Update mode works without LANG/NAME parameters
  - TC3: Update mode creates missing git-msg-tags.md with language detection
  - TC4: Update mode preserves existing git-msg-tags.md
  - TC5: Init mode rejects invalid language templates
  - TC6: Update mode infers language from project structure
- Modified `tests/test-all.sh:30-40` to integrate new test suite into test runner

## Testing

- Added `tests/test-makefile-validation.sh` (416 LOC) with 6 comprehensive test cases
- All 6 new tests passing (6/6)
- All existing tests continue to pass (5/5 test suites)
- Verified through pre-commit hook that all test suites run successfully
- Manually tested both init and update modes:
  1. Init mode correctly requires LANG parameter
  2. Update mode successfully runs without LANG/NAME parameters
  3. Update mode correctly creates missing git-msg-tags.md with Python-specific tags
  4. Update mode correctly creates missing git-msg-tags.md with C/C++-specific tags
  5. Update mode preserves custom git-msg-tags.md content

## Related Issue

Closes #46