### PR TITLE
[agent.skill][#72] Port open-pr and open-issue to --body-file

### DIFF
--- a/claude/.claude
+++ b/claude/.claude
@@ -1,0 +1,1 @@
+/Users/were/repos/agentize/.claude

--- a/claude/skills/open-issue/SKILL.md
+++ b/claude/skills/open-issue/SKILL.md
@@ -179,14 +179,13 @@ Should I create this issue?
 Once confirmed, create the issue using the GitHub CLI:
 
 ```bash
-gh issue create --title "TITLE_HERE" --body "$(cat <<'EOF'
+gh issue create --title "TITLE_HERE" --body-file - <<'EOF'
 BODY_CONTENT_HERE
 EOF
-)"
 ```
 
 **Important:**
-- Use heredoc (`<<'EOF' ... EOF`) to preserve markdown formatting
+- Use `--body-file -` with heredoc to preserve markdown formatting and handle special characters safely
 - The body should include all sections from Description onwards (not the title)
 - After successful creation, display the issue URL to the user
 - Confirm: "GitHub issue created successfully: [URL]"

--- a/claude/skills/open-pr/SKILL.md
+++ b/claude/skills/open-pr/SKILL.md
@@ -246,14 +246,13 @@ git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
 Once confirmed and the branch is on remote, create the PR using the GitHub CLI:
 
 ```bash
-gh pr create --title "TITLE_HERE" --body "$(cat <<'EOF'
+gh pr create --title "TITLE_HERE" --body-file - <<'EOF'
 BODY_CONTENT_HERE
 EOF
-)"
 ```
 
 **Important:**
-- Use heredoc (`<<'EOF' ... EOF`) to preserve markdown formatting
+- Use `--body-file -` with heredoc to preserve markdown formatting and handle special characters safely
 - The body should include all sections from Summary onwards (not the title)
 - The PR will be created against the default branch (usually main/master)
 - After successful creation, display the PR URL to the user


### PR DESCRIPTION
## Summary

Updated both `open-pr` and `open-issue` skills to use `--body-file -` with heredoc stdin instead of command substitution. This change fixes potential failures from special characters like `--`, backticks, and `$()` in PR/issue body content that could be misinterpreted as CLI options by the `gh` command.

## Changes

- Modified `claude/skills/open-pr/SKILL.md:249` to replace `--body "$(cat <<'EOF' ... EOF)"` with `--body-file - <<'EOF' ... EOF`
- Modified `claude/skills/open-issue/SKILL.md:182` to replace `--body "$(cat <<'EOF' ... EOF)"` with `--body-file - <<'EOF' ... EOF`
- Updated "Important" guidance in both files (lines 255 and 188 respectively) to explicitly mention `--body-file -` with heredoc pattern
- Added `claude/.claude` symlink for skill configuration

## Testing

Manual verification performed:
- Verified `open-pr` uses `gh pr create --body-file - <<'EOF'` at line 249
- Verified `open-issue` uses `gh issue create --body-file - <<'EOF'` at line 182
- Confirmed both "Important" notes correctly reference the new `--body-file -` pattern
- All 3 success criteria from issue plan met

## Related Issue

Closes #72
