### PR TITLE
[agent.skill][#71] Add explicit guardrails preventing milestone file commits

### DIFF
--- a/claude/.claude
+++ b/claude/.claude
@@ -1,0 +1,1 @@
+/Users/were/repos/agentize/.claude

--- a/claude/commands/issue-to-impl.md
+++ b/claude/commands/issue-to-impl.md
@@ -130,9 +130,24 @@ gh issue view {issue-number} --json body --jq '.body'
 
 ### Step 6: Create Milestone 1
 
-**Stage files:**
+**Stage files with verification:**
 ```bash
+# Stage all changes
 git add .
+
+# CRITICAL: Verify staged files before proceeding
+git diff --cached --name-only
+```
+
+**Pre-commit checklist:**
+- [ ] Documentation files staged (e.g., README.md, docs/*.md)
+- [ ] Test files staged (e.g., tests/*.sh)
+- [ ] NO `.milestones/` files staged (these are local-only checkpoints)
+
+**If `.milestones/` files appear in staged files:**
+```bash
+# Unstage milestone files immediately
+git restore --staged .milestones/
 ```
 
 **Create milestone document:**

--- a/claude/skills/milestone/SKILL.md
+++ b/claude/skills/milestone/SKILL.md
@@ -371,13 +371,52 @@ Create the file `.milestones/issue-{N}-milestone-{M}.md`:
 [Test Status section from Step 4]
 ```
 
-**IMPORTANT**: This milestone document is for local checkpoint tracking only. It should NOT be committed to git (it's already excluded via `.gitignore`).
+**CRITICAL: Local-Only Checkpoint Files**
+
+Milestone documents in `.milestones/` are LOCAL CHECKPOINT FILES ONLY:
+
+- **DO NOT** stage these files: `git add .milestones/` is FORBIDDEN
+- **DO NOT** force-add these files: `git add -f .milestones/*` is FORBIDDEN
+- **DO NOT** commit these files under any circumstances
+- These files are automatically excluded by `.gitignore` when using `git add .`
+
+**Why `.milestones/` files must remain local:**
+1. They are working notes for resuming implementation between sessions
+2. They contain partial progress states not suitable for repository history
+3. `.gitignore` already excludes them to prevent accidental staging
+4. Only completed implementation code/tests/docs should be committed
+
+**Verification:** Before creating any commit, verify staged files:
+```bash
+git diff --cached --name-only
+```
+If you see any `.milestones/` files listed, **STOP** and unstage them:
+```bash
+git restore --staged .milestones/
+```
 
 ### Step 6: Create Milestone Commit
 
 Use the `commit-msg` skill with milestone flag:
 
-**CRITICAL**: Only commit implementation changes (code, tests, docs), NOT the milestone report file.
+**CRITICAL - Pre-Commit Verification:**
+
+Before invoking `commit-msg`, verify what will be staged:
+```bash
+# Stage implementation changes only
+git add .
+
+# Verify staged files (milestone files should NOT appear)
+git diff --cached --name-only
+```
+
+**Requirements:**
+- **MUST stage**: Implementation code, tests, documentation
+- **MUST NOT stage**: `.milestones/issue-{N}-milestone-{M}.md` (local checkpoint only)
+- If `.milestones/` files appear in `git diff --cached`, unstage them immediately:
+  ```bash
+  git restore --staged .milestones/
+  ```
 
 **Invoke commit-msg skill with:**
 - Purpose: milestone
@@ -731,4 +770,4 @@ After milestone skill signals completion, user can invoke `/open-pr` to create a
 
 10. **Test status is gold**: Milestone documents exist primarily to track test progress toward completion
 
-11. **Milestone documents are local-only**: Milestone files in `.milestones/` are excluded from git (via `.gitignore`) and should NEVER be committed. They exist only as local checkpoints for resuming work.
+11. **Milestone documents are local-only**: Milestone files in `.milestones/` are excluded from git (via `.gitignore`) and MUST NEVER be staged or committed. They exist only as local checkpoints for resuming work. Always verify staged files before committing.


### PR DESCRIPTION
## Summary

Added explicit AI-facing documentation guardrails to prevent agents from attempting
to stage or commit milestone checkpoint files. This addresses the issue where AI agents
implementing the milestone skill were not clearly instructed to avoid committing files
in `.milestones/`, despite `.gitignore` excluding them.

## Changes

- Modified `.claude/skills/milestone/SKILL.md` to add:
  - "CRITICAL: Local-Only Checkpoint Files" section explaining that `.milestones/` files must never be staged or committed
  - "CRITICAL - Pre-Commit Verification" checklist in Step 6 with commands to verify staged files before committing
  - Updated important notes (#11) to emphasize verification before committing
- Modified `.claude/commands/issue-to-impl.md` to add:
  - Staging verification steps in Step 6 (Create Milestone 1)
  - Pre-commit checklist to ensure milestone files are not staged
  - Commands to unstage `.milestones/` files if they appear in staged changes
- Added `claude/.claude` symlink (worktree structure)

Total: ~63 LOC added across documentation files

## Testing

This is a documentation-only change with no automated tests required per the implementation plan.

Manual verification approach documented in the plan:
1. Create a file under `.milestones/` and run `git add .` → file does not stage (verified by `.gitignore`)
2. Run `git diff --cached --name-only` → `.milestones/` files absent
3. Documentation explicitly forbids `git add -f .milestones/foo.md`

All existing pre-commit tests passed successfully:
- ✓ Agentize mode validation tests
- ✓ Makefile validation tests
- ✓ C SDK tests
- ✓ C++ SDK tests
- ✓ Python SDK tests
- ✓ Worktree tests

## Related Issue

Closes #71