### PR TITLE
[agent.command][#91] Refactor ultra-planner and clarify milestone completion workflow

### DIFF
--- a/.claude/commands/ultra-planner.md
+++ b/.claude/commands/ultra-planner.md
@@ -146,7 +146,8 @@ Task tool parameters:
 **Wait for agent completion** (blocking operation, do not proceed to Step 4 until done).
 
 **Extract output:**
-- Save the agent's full response to `.tmp/bold-proposal-$TIMESTAMP.md`
+- Generate filename: `BOLD_FILE=".tmp/bold-proposal-$(date +%Y%m%d-%H%M%S).md"`
+- Save the agent's full response to `$BOLD_FILE`
 - Also store in variable `BOLD_PROPOSAL` for passing to critique and reducer agents in Step 4
 
 ### Step 4: Invoke Critique and Reducer Agents
@@ -190,8 +191,10 @@ Identify unnecessary complexity and propose simpler alternatives."
 **Wait for both agents to complete** (blocking operation).
 
 **Extract outputs:**
-- Save critique agent's response to `.tmp/critique-output-$TIMESTAMP.md`
-- Save reducer agent's response to `.tmp/reducer-output-$TIMESTAMP.md`
+- Generate filename: `CRITIQUE_FILE=".tmp/critique-output-$(date +%Y%m%d-%H%M%S).md"`
+- Save critique agent's response to `$CRITIQUE_FILE`
+- Generate filename: `REDUCER_FILE=".tmp/reducer-output-$(date +%Y%m%d-%H%M%S).md"`
+- Save reducer agent's response to `$REDUCER_FILE`
 
 **Expected agent outputs:**
 - Bold proposer: Innovative proposal with SOTA research
@@ -204,10 +207,9 @@ After all three agents complete, combine their outputs into a single debate repo
 
 **Generate combined report:**
 ```bash
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 FEATURE_NAME=$(echo "$FEATURE_DESC" | head -c 50)
 DATETIME=$(date +"%Y-%m-%d %H:%M")
-OUTPUT_FILE=".tmp/debate-report-$TIMESTAMP.md"
+DEBATE_REPORT_FILE=".tmp/debate-report-$(date +%Y%m%d-%H%M%S).md"
 
 {
     echo "# Multi-Agent Debate Report"
@@ -224,28 +226,30 @@ OUTPUT_FILE=".tmp/debate-report-$TIMESTAMP.md"
     echo ""
     echo "## Part 1: Bold Proposer Report"
     echo ""
-    cat ".tmp/bold-proposal-$TIMESTAMP.md"
+    cat "$BOLD_FILE"
     echo ""
     echo "---"
     echo ""
     echo "## Part 2: Proposal Critique Report"
     echo ""
-    cat ".tmp/critique-output-$TIMESTAMP.md"
+    cat "$CRITIQUE_FILE"
     echo ""
     echo "---"
     echo ""
     echo "## Part 3: Proposal Reducer Report"
     echo ""
-    cat ".tmp/reducer-output-$TIMESTAMP.md"
+    cat "$REDUCER_FILE"
     echo ""
     echo "---"
     echo ""
     echo "## Next Steps"
     echo ""
     echo "This combined report will be reviewed by an external consensus agent (Codex or Claude Opus) to synthesize a final, balanced implementation plan."
-} > "$OUTPUT_FILE.tmp"
-mv "$OUTPUT_FILE.tmp" "$OUTPUT_FILE"
+} > "$DEBATE_REPORT_FILE.tmp"
+mv "$DEBATE_REPORT_FILE.tmp" "$DEBATE_REPORT_FILE"
 ```
+
+**Note on filename consistency:** Each filename is generated once using inline `$(date ...)` and stored in a variable (`$BOLD_FILE`, `$CRITIQUE_FILE`, `$REDUCER_FILE`, `$DEBATE_REPORT_FILE`). These variables are reused in subsequent steps to ensure all references point to the same files, avoiding timestamp drift from multiple date command invocations.
 
 **Extract key summaries for user display:**
 


### PR DESCRIPTION
## Summary

Refactored the ultra-planner command to use inline date substitution for consistent file references, and clarified the milestone completion workflow by documenting the delivery commit requirement across multiple commands.

## Changes

- Modified `claude/commands/ultra-planner.md:149-252` to use inline `$(date ...)` with variable storage
  - Prevents timestamp drift from multiple date command invocations
  - Ensures all file references point to the same files (`$BOLD_FILE`, `$CRITIQUE_FILE`, `$REDUCER_FILE`, `$DEBATE_REPORT_FILE`)
- Added `claude/commands/pull-request.md:1-293` new command for streamlined review and PR creation workflow
  - Integrates existing `/code-review` command and `open-pr` skill
  - Supports `--open` flag for immediate PR creation after review
  - Provides clear error handling and next-step guidance
- Updated `claude/commands/issue-to-impl.md:227-253` to clarify delivery commit requirement
  - Documents when and how to create delivery commits on completion
  - Distinguishes delivery commits from milestone checkpoints
- Updated `claude/commands/miles2miles.md:200-226` with same delivery commit clarification
- Modified `claude/skills/milestone/SKILL.md:473-511` to document completion behavior
  - Clarifies that no milestone is created when all tests pass
  - Specifies delivery commit requirements (purpose=delivery, no --no-verify)
- Updated `docs/milestone-workflow.md:309-332` to document review and PR workflow
  - Added Option A (manual workflow) and Option B (convenience wrapper)
  - Explains `/pull-request` command usage patterns
- Updated `claude/commands/README.md:26` to include new pull-request command
- Fixed typo in `README.md:20` (options.md → OPTIONS.md)

## Testing

- All changes are documentation-only (no code changes)
- Documentation follows project conventions from `claude/commands/CLAUDE.md`
- Pull-request command follows same structure as existing commands
- Code review passed with ✅ APPROVED status (no critical issues)
- Documentation linter has pre-existing failures (not introduced by this PR)

## Related Issue

Closes #91
