### PR TITLE
[docs][agent.workflow][#141] Fix SDK docs and add agent codebase analysis rules

### DIFF
--- a/.claude/agents/bold-proposer.md
+++ b/.claude/agents/bold-proposer.md
@@ -47,12 +47,16 @@ grep -r "pattern_name" --include="*.md" --include="*.sh"
 
 # Understand project structure
 ls -la .claude/{agents,skills,commands}/
+
+# Check docs/ for current command interfaces
+grep -r "relevant_command" docs/
 ```
 
 Read relevant files to understand:
 - Current architecture patterns
 - Existing conventions
 - Integration points
+- **Search `docs/` for current commands and interfaces; cite specific files checked**
 
 ### Step 3: Propose Bold Solution
 
@@ -114,6 +118,10 @@ Your proposal should be structured as:
 - [Insight 1 with source]
 - [Insight 2 with source]
 - [Insight 3 with source]
+
+**Files checked for current implementation:**
+- [File path 1]: [What was verified]
+- [File path 2]: [What was verified]
 
 ## Proposed Solution
 

--- a/.claude/agents/proposal-critique.md
+++ b/.claude/agents/proposal-critique.md
@@ -49,6 +49,9 @@ grep -r "pattern_name" --include="*.md" --include="*.sh"
 # Check for conflicts
 grep -r "similar_feature" --include="*.md"
 
+# Check docs/ for current command interfaces
+grep -r "relevant_command" docs/
+
 # Understand constraints
 cat CLAUDE.md README.md
 ```
@@ -58,6 +61,7 @@ Read relevant files to verify:
 - File locations follow conventions
 - Dependencies are acceptable
 - No naming conflicts exist
+- **Search `docs/` for current commands and interfaces; cite specific files checked**
 
 ### Step 3: Challenge Assumptions
 
@@ -108,6 +112,12 @@ Your critique should be structured as:
 ## Executive Summary
 
 [2-3 sentence assessment of the proposal's overall feasibility]
+
+## Files Checked
+
+**Documentation and codebase verification:**
+- [File path 1]: [What was verified]
+- [File path 2]: [What was verified]
 
 ## Assumption Validation
 

--- a/.claude/agents/proposal-reducer.md
+++ b/.claude/agents/proposal-reducer.md
@@ -74,6 +74,9 @@ Check how similar problems are solved simply:
 # Find existing simple implementations
 grep -r "similar_feature" --include="*.md" --include="*.sh"
 
+# Check docs/ for current command interfaces
+grep -r "relevant_command" docs/
+
 # Check project conventions
 cat CLAUDE.md README.md
 ```
@@ -82,6 +85,7 @@ Look for:
 - Existing patterns to reuse
 - Simple successful implementations
 - Project conventions to follow
+- **Search `docs/` for current commands and interfaces; cite specific files checked**
 
 ### Step 4: Generate Simplified Proposal
 
@@ -101,6 +105,12 @@ Your simplified proposal should be structured as:
 ## Simplification Summary
 
 [2-3 sentence explanation of how this simplifies the original]
+
+## Files Checked
+
+**Documentation and codebase verification:**
+- [File path 1]: [What was verified]
+- [File path 2]: [What was verified]
 
 ## Core Problem Restatement
 

--- a/.claude/skills/external-consensus/external-review-prompt.md
+++ b/.claude/skills/external-consensus/external-review-prompt.md
@@ -22,6 +22,7 @@ Review all three perspectives and synthesize a **balanced, consensus implementat
 3. **Balances innovation with pragmatism**
 4. **Maintains simplicity** while not sacrificing essential features
 5. **Addresses critical risks** identified in the critique
+6. **Verifies documentation accuracy** - ensure proposals cite `docs/` for current command interfaces
 
 ## Input: Combined Report
 
@@ -43,6 +44,12 @@ Generate a final implementation plan following this structure:
 ## Consensus Summary
 
 [2-3 sentences explaining the balanced approach chosen]
+
+## Files Verified
+
+**Documentation and codebase checked by agents:**
+- [File path 1]: [What was verified]
+- [File path 2]: [What was verified]
 
 ## Design Decisions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Learn Agentize step-by-step in 15 minutes total (3-5 min per tutorial):
 
 - `git-msg-tags.md` - Git commit message tag standards
 - `milestone-workflow.md` - Milestone-based implementation workflow
-- `options.md` - Configuration options for `make agentize`
+- `options.md` - Configuration options for the `lol` CLI
 - `sdk.md` - SDK generation and template system
 - `test.md` - Testing framework and validation
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,10 +1,10 @@
 # SDK Structure and Creation
 
-This document describes the file structure of SDKs created by `make agentize` and the behavior of initialization and update modes.
+This document describes the file structure of SDKs created by the `lol` CLI and the behavior of initialization and update modes.
 
 ## Created SDK File Structure
 
-When you run `make agentize` with `AGENTIZE_MODE=init`, the following structure is created in your target project:
+When you run `lol init`, the following structure is created in your target project:
 
 ```
 your-project/
@@ -55,18 +55,10 @@ The `init` mode creates a new SDK project from scratch. It validates directory s
 
 ```bash
 # Create new SDK in non-existent directory
-make agentize \
-   AGENTIZE_PROJECT_NAME="my_project" \
-   AGENTIZE_PROJECT_PATH="/path/to/my_project" \
-   AGENTIZE_PROJECT_LANG="python" \
-   AGENTIZE_MODE="init"
+lol init --name my_project --lang python --path /path/to/my_project
 
 # Error: Will fail if directory exists and contains files
-make agentize \
-   AGENTIZE_PROJECT_NAME="my_project" \
-   AGENTIZE_PROJECT_PATH="/existing/non-empty/dir" \
-   AGENTIZE_PROJECT_LANG="python" \
-   AGENTIZE_MODE="init"
+lol init --name my_project --lang python --path /existing/non-empty/dir
 # Output: Error: Directory '/existing/non-empty/dir' exists and is not empty.
 ```
 
@@ -106,19 +98,14 @@ The `update` mode refreshes the Claude Code configuration (`.claude/`) while pre
 ### Example
 
 ```bash
-# Update existing SDK
-make agentize \
-   AGENTIZE_PROJECT_NAME="my_project" \
-   AGENTIZE_PROJECT_PATH="/path/to/my_project" \
-   AGENTIZE_PROJECT_LANG="python" \
-   AGENTIZE_MODE="update"
+# Update existing SDK from project root or any subdirectory
+lol update
+
+# Or specify explicit path
+lol update --path /path/to/my_project
 
 # Error: Will fail if not a valid SDK
-make agentize \
-   AGENTIZE_PROJECT_NAME="my_project" \
-   AGENTIZE_PROJECT_PATH="/some/random/dir" \
-   AGENTIZE_PROJECT_LANG="python" \
-   AGENTIZE_MODE="update"
+lol update --path /some/random/dir
 # Output: Error: Directory '/some/random/dir' is not a valid SDK structure.
 #         Missing '.claude/' directory.
 ```
@@ -173,11 +160,7 @@ update .claude/ with latest files
 
 ```bash
 # 1. Initialize SDK for C project
-make agentize \
-   AGENTIZE_PROJECT_NAME="mylib" \
-   AGENTIZE_PROJECT_PATH="$HOME/projects/mylib" \
-   AGENTIZE_PROJECT_LANG="c" \
-   AGENTIZE_MODE="init"
+lol init --name mylib --lang c --path $HOME/projects/mylib
 
 # 2. Navigate to project
 cd $HOME/projects/mylib
@@ -193,15 +176,11 @@ claude code
 cd /path/to/agentize
 git pull origin main
 
-# Update your SDK project
-make agentize \
-   AGENTIZE_PROJECT_NAME="mylib" \
-   AGENTIZE_PROJECT_PATH="$HOME/projects/mylib" \
-   AGENTIZE_PROJECT_LANG="c" \
-   AGENTIZE_MODE="update"
+# Update your SDK project from project root or any subdirectory
+cd $HOME/projects/mylib
+lol update
 
 # Review changes
-cd $HOME/projects/mylib
 diff -r .claude .claude.backup  # See what changed
 
 # If you had customizations, selectively restore them
@@ -254,7 +233,7 @@ Error: Directory '/path/to/project' is not a valid SDK structure.
 Missing '.claude/' directory.
 ```
 
-**Solution:** This directory was not created with `make agentize`. Use `init` mode instead.
+**Solution:** This directory was not created with the `lol` CLI. Use `lol init` instead.
 
 ### Error: Project path does not exist
 

--- a/docs/tutorial/00-initialize.md
+++ b/docs/tutorial/00-initialize.md
@@ -11,11 +11,7 @@ This tutorial shows you how to set up the Agentize framework in your project.
 For a fresh project starting with the Agentize framework:
 
 ```bash
-make agentize \
-   AGENTIZE_PROJECT_NAME="my_project" \
-   AGENTIZE_PROJECT_PATH="/path/to/new/project" \
-   AGENTIZE_PROJECT_LANG="c" \
-   AGENTIZE_MODE="init"
+lol init --name my_project --lang c --path /path/to/new/project
 ```
 
 This creates the initial SDK structure with:
@@ -29,11 +25,11 @@ This creates the initial SDK structure with:
 To add Agentize to your existing codebase or update the framework rules:
 
 ```bash
-make agentize \
-   AGENTIZE_PROJECT_NAME="existing_project" \
-   AGENTIZE_PROJECT_PATH="/path/to/existing/project" \
-   AGENTIZE_PROJECT_LANG="python" \
-   AGENTIZE_MODE="update"
+# From project root or any subdirectory
+lol update
+
+# Or specify explicit path
+lol update --path /path/to/existing/project
 ```
 
 This mode:


### PR DESCRIPTION
## Summary

Updated SDK documentation to reflect the current `lol` CLI interface (replacing outdated `make agentize` references) and enhanced planning agents to explicitly require docs/ scanning and file citation for more accurate proposals.

## Changes

- Modified `docs/sdk.md` to replace all `make agentize` command examples with `lol init` and `lol update` CLI syntax
- Updated `docs/tutorial/00-initialize.md` to use modern `lol` CLI commands in initialization examples
- Updated `docs/README.md` to reference `lol` CLI instead of `make agentize` in configuration options
- Enhanced `.claude/agents/bold-proposer.md` to add docs/ verification requirement and file citation output section
- Enhanced `.claude/agents/proposal-critique.md` to add docs/ scanning step and files checked section
- Enhanced `.claude/agents/proposal-reducer.md` to add docs/ verification requirement and file citation section
- Updated `.claude/skills/external-consensus/external-review-prompt.md` to include docs/ verification task and files verified section

## Testing

Manual verification completed:
- Verified no `make agentize` references remain in docs/ directory
- Confirmed all SDK command examples use current `lol` CLI syntax
- Verified all three planning agents (bold-proposer, proposal-critique, proposal-reducer) include explicit requirements to check docs/ for current commands and cite files inspected
- Confirmed external-consensus prompt includes documentation verification requirement

## Related Issue

Closes #141