### PR TITLE
[agent.workflow][docs][#140] Remove .claude/hands-off.json fallback, use CLAUDE_HANDSOFF only

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -35,12 +35,12 @@ For ultra-planner and issue-to-impl workflows, you can enable hands-off mode to 
 
 **Enable:**
 ```bash
-echo '{"enabled": true}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=true
 ```
 
 **Disable:**
 ```bash
-echo '{"enabled": false}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=false
 ```
 
 See individual command docs (ultra-planner.md, issue-to-impl.md) for safety boundaries and troubleshooting.

--- a/.claude/commands/issue-to-impl.md
+++ b/.claude/commands/issue-to-impl.md
@@ -426,14 +426,12 @@ Stop execution.
 
 **To enable:**
 ```bash
-# Create or update .claude/hands-off.json
-echo '{"enabled": true}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=true
 ```
 
 **To disable:**
 ```bash
-# Set enabled to false
-echo '{"enabled": false}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=false
 ```
 
 **Safety boundaries:**
@@ -444,4 +442,4 @@ echo '{"enabled": false}' > .claude/hands-off.json
 
 **Troubleshooting:**
 - If workflow gets stuck: Check `.tmp/claude-hooks/auto-approvals.log` for decisions
-- To force manual mode: Set `enabled: false` in `.claude/hands-off.json`
+- To force manual mode: Set `CLAUDE_HANDSOFF=false`

--- a/.claude/commands/ultra-planner.md
+++ b/.claude/commands/ultra-planner.md
@@ -509,14 +509,12 @@ URL: https://github.com/user/repo/issues/42
 
 **To enable:**
 ```bash
-# Create or update .claude/hands-off.json
-echo '{"enabled": true}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=true
 ```
 
 **To disable:**
 ```bash
-# Set enabled to false
-echo '{"enabled": false}' > .claude/hands-off.json
+export CLAUDE_HANDSOFF=false
 ```
 
 **Safety boundaries:**
@@ -527,7 +525,7 @@ echo '{"enabled": false}' > .claude/hands-off.json
 
 **Troubleshooting:**
 - If workflow gets stuck: Check `.tmp/claude-hooks/auto-approvals.log` for decisions
-- To force manual mode: Set `enabled: false` in `.claude/hands-off.json`
+- To force manual mode: Set `CLAUDE_HANDSOFF=false`
 
 ## Notes
 

--- a/.claude/hands-off.json
+++ b/.claude/hands-off.json
@@ -1,3 +1,0 @@
-{
-  "enabled": false
-}

--- a/.claude/hooks/permission-request.sh
+++ b/.claude/hooks/permission-request.sh
@@ -5,7 +5,7 @@
 
 # Check if hands-off mode is enabled
 is_hands_off_enabled() {
-    # Check CLAUDE_HANDSOFF environment variable first
+    # Check CLAUDE_HANDSOFF environment variable
     if [[ -n "${CLAUDE_HANDSOFF}" ]]; then
         local value
         value=$(echo "${CLAUDE_HANDSOFF}" | tr '[:upper:]' '[:lower:]')
@@ -18,17 +18,7 @@ is_hands_off_enabled() {
         fi
     fi
 
-    # Fallback to .claude/hands-off.json if env var is unset
-    local json_file=".claude/hands-off.json"
-    if [[ -f "$json_file" ]]; then
-        local enabled
-        enabled=$(grep -o '"enabled"[[:space:]]*:[[:space:]]*true' "$json_file")
-        if [[ -n "$enabled" ]]; then
-            return 0  # enabled via JSON
-        fi
-    fi
-
-    return 1  # disabled by default
+    return 1  # disabled by default (fail-closed)
 }
 
 # Determine permission decision based on tool and operation

--- a/tests/fixtures/permission-request/README.md
+++ b/tests/fixtures/permission-request/README.md
@@ -11,12 +11,12 @@ The permission hook uses `CLAUDE_HANDSOFF` as the primary configuration method f
 - `CLAUDE_HANDSOFF=true` (case-insensitive) → Safe read operations are auto-allowed
 - `CLAUDE_HANDSOFF=false` (case-insensitive) → Always ask for permission
 - `CLAUDE_HANDSOFF=<invalid>` → Treat as disabled (always ask)
-- Unset → Falls back to `.claude/hands-off.json` if present, otherwise asks
+- Unset → Always ask for permission (fail-closed)
 
 ### Test Cases
 
 1. **Enabled hands-off**: `CLAUDE_HANDSOFF=true` + safe read → `allow`
 2. **Disabled hands-off**: `CLAUDE_HANDSOFF=false` + safe read → `ask`
 3. **Invalid value**: `CLAUDE_HANDSOFF=maybe` + safe read → `ask` (fail-closed)
-4. **Backward compatibility**: Unset env var + JSON enabled → `allow`
+4. **Unset variable**: Unset env var + safe read → `ask` (fail-closed)
 5. **Destructive protection**: `CLAUDE_HANDSOFF=true` + destructive bash → `deny` or `ask`

--- a/tests/test-claude-permission-hook.sh
+++ b/tests/test-claude-permission-hook.sh
@@ -108,25 +108,18 @@ test_handsoff_true_destructive() {
     unset CLAUDE_HANDSOFF
 }
 
-# Test 6: Unset env var + .claude/hands-off.json enabled → allow (backward compat)
-test_json_fallback() {
-    echo "Test 6: JSON fallback when env var is unset"
+# Test 6: Unset env var + safe read → ask (fail-closed)
+test_handsoff_unset() {
+    echo "Test 6: CLAUDE_HANDSOFF unset with safe read operation"
     unset CLAUDE_HANDSOFF
-
-    # Create temporary hands-off.json
-    local json_file="$PROJECT_ROOT/.claude/hands-off.json"
-    echo '{"enabled": true}' > "$json_file"
 
     local result
     result=$(run_hook "Read" "Read configuration file" '{"file_path": "/tmp/test.txt"}')
 
-    # Cleanup
-    rm -f "$json_file"
-
-    if [[ "$result" == "allow" ]]; then
-        echo "✓ PASS: JSON fallback works when env var is unset"
+    if [[ "$result" == "ask" ]]; then
+        echo "✓ PASS: Unset env var results in 'ask' (fail-closed)"
     else
-        echo "✗ FAIL: Expected 'allow', got '$result'"
+        echo "✗ FAIL: Expected 'ask', got '$result'"
         exit 1
     fi
 }
@@ -146,7 +139,7 @@ main() {
     echo
     test_handsoff_true_destructive
     echo
-    test_json_fallback
+    test_handsoff_unset
     echo
 
     echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

Removed the JSON file fallback configuration for hands-off mode, making `CLAUDE_HANDSOFF` environment variable the sole configuration method. This simplifies the configuration interface by eliminating dual-source complexity and making hands-off mode setup more explicit and predictable with fail-closed behavior.

## Changes

- Removed `.claude/hands-off.json` from repository (deprecated configuration file)
- Modified `.claude/hooks/permission-request.sh:8-31` to remove JSON fallback logic, keeping only `CLAUDE_HANDSOFF` environment variable with fail-closed behavior
- Updated `.claude/commands/README.md:36-44` to replace JSON configuration examples with `export CLAUDE_HANDSOFF=true/false`
- Updated `.claude/commands/issue-to-impl.md:427-447` to replace JSON configuration examples with environment variable exports
- Updated `.claude/commands/ultra-planner.md:510-530` to replace JSON configuration examples with environment variable exports
- Modified `tests/test-claude-permission-hook.sh:111-125` to replace JSON fallback test with explicit unset environment variable test
- Updated `tests/fixtures/permission-request/README.md:14,21` to reflect env-var-only behavior and remove JSON fallback documentation

## Testing

- Modified `tests/test-claude-permission-hook.sh` to replace backward compatibility test with new unset test:
  - Test 6 now verifies unset `CLAUDE_HANDSOFF` results in "ask" (fail-closed behavior)
  - All 6 permission hook tests pass:
    - ✓ `CLAUDE_HANDSOFF=true` enables hands-off mode
    - ✓ `CLAUDE_HANDSOFF=false` yields "ask"
    - ✓ Invalid values treated as disabled (fail-closed)
    - ✓ Case-insensitive parsing
    - ✓ Destructive operations not auto-allowed
    - ✓ Unset env var yields "ask" (fail-closed)
- Verified zero `hands-off.json` references remain in codebase using `rg "hands-off\.json"`
- Code review passed with "APPROVED" status

## Related Issue

Closes #140
