### PR TITLE
[command] Add feature branch tracking and rebase to sync-master

### DIFF
--- a/.claude/commands/sync-master.md
+++ b/.claude/commands/sync-master.md
@@ -5,17 +5,19 @@ description: Synchronize local main/master branch with upstream (or origin) usin
 
 # Sync Master Command
 
-Synchronize your local main or master branch with the latest changes from the upstream repository.
+Synchronize your local main or master branch with the latest changes from the upstream repository, and rebase your feature branch onto the updated main.
 
 Invoke the command: `/sync-master`
 
 This command will:
 1. Check git status for uncommitted changes
-2. Detect the default branch (main or master)
-3. Checkout to the detected default branch
-4. Detect available remotes (upstream or origin)
-5. Pull latest changes using `--rebase`
-6. Report success or failure
+2. Save the current branch name (if not on main/master)
+3. Detect the default branch (main or master)
+4. Checkout to the detected default branch
+5. Detect available remotes (upstream or origin)
+6. Pull latest changes using `--rebase`
+7. Rebase the saved feature branch onto updated main (if applicable)
+8. Report success or failure
 
 ## Workflow Steps
 
@@ -38,6 +40,22 @@ Please commit or stash your changes before syncing.
 ```
 
 Stop execution.
+
+### Step 1.5: Save Current Branch
+
+Save the current branch name for later rebase:
+
+```bash
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Inform the user:
+
+```
+Saving current branch: <current-branch>
+```
+
+This allows the command to return to the feature branch and rebase it after syncing main.
 
 ### Step 2: Detect Default Branch
 
@@ -102,7 +120,26 @@ Inform the user:
 Pulling latest changes from <detected-remote> with rebase...
 ```
 
-### Step 6: Report Results
+### Step 5.5: Rebase Feature Branch
+
+If the current branch was saved and is different from the detected default branch, rebase it onto the updated main:
+
+```bash
+if [ "$CURRENT_BRANCH" != "$DETECTED_BRANCH" ]; then
+    git checkout "$CURRENT_BRANCH"
+    git rebase "$DETECTED_BRANCH"
+fi
+```
+
+Inform the user:
+
+```
+Rebasing <current-branch> onto <detected-branch>...
+```
+
+If no feature branch was saved (already on main/master), skip this step.
+
+### Step 6: Report Main Sync Results
 
 If successful:
 
@@ -110,10 +147,37 @@ If successful:
 Successfully synchronized <detected-branch> branch with <detected-remote>/<detected-branch>
 ```
 
-If rebase conflicts occur, inform the user:
+If rebase conflicts occur on main, inform the user:
 
 ```
-Error: Rebase conflict detected
+Error: Rebase conflict detected on <detected-branch>
+
+Please resolve conflicts manually:
+1. Fix conflicts in the affected files
+2. Run: git add <resolved-files>
+3. Run: git rebase --continue
+
+Or abort the rebase with: git rebase --abort
+```
+
+Stop execution and let the user handle conflicts.
+
+### Step 7: Report Feature Branch Rebase Results
+
+If a feature branch was rebased:
+
+If successful:
+
+```
+Rebased <current-branch> onto <detected-branch>
+```
+
+If conflicts occur during feature branch rebase, inform the user:
+
+```
+Error: Rebase conflict detected on <current-branch>
+
+This conflict occurred while rebasing your feature branch onto the updated <detected-branch>.
 
 Please resolve conflicts manually:
 1. Fix conflicts in the affected files
@@ -132,5 +196,6 @@ Following the project's philosophy, assume git tools are available and the repos
 Common error scenarios:
 - Uncommitted changes → User must commit or stash
 - Branch not found → Inform user
-- Rebase conflicts → User resolves manually
+- Rebase conflicts on main → User resolves manually, then continue or abort
+- Rebase conflicts on feature branch → User resolves manually on feature branch
 - Remote not configured → Git will error naturally


### PR DESCRIPTION
## Summary

Enhances the `/sync-master` command to automatically rebase the feature branch after syncing main:

- Saves the current branch before checking out main
- Pulls latest changes from upstream
- Rebases the feature branch onto updated main
- Reports comprehensive results for both operations

## Test Strategy

This is a documentation/command file change. The new behavior should be tested manually:

1. On a feature branch, run `/sync-master` - should sync main then rebase feature branch
2. On main branch, run `/sync-master` - should work as before (no feature branch to rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)