### PR TITLE
[bugfix]: Fix external-consensus feature name extraction for refinement reports

### DIFF
--- a/.claude/skills/external-consensus/scripts/external-consensus.sh
+++ b/.claude/skills/external-consensus/scripts/external-consensus.sh
@@ -48,7 +48,13 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # Extract feature name and description from debate report if not provided
 if [ -z "$FEATURE_NAME" ]; then
-    FEATURE_NAME=$(grep "^\*\*Feature\*\*:" "$DEBATE_REPORT_PATH" | head -1 | sed 's/^\*\*Feature\*\*: //' || echo "Unknown Feature")
+    # Try to extract from **Feature**: line (standard debate reports)
+    FEATURE_NAME=$(grep "^\*\*Feature\*\*:" "$DEBATE_REPORT_PATH" | head -1 | sed 's/^\*\*Feature\*\*: //' || echo "")
+
+    # If not found, try **Title**: line (refinement debate reports)
+    if [ -z "$FEATURE_NAME" ]; then
+        FEATURE_NAME=$(grep "^\*\*Title\*\*:" "$DEBATE_REPORT_PATH" | head -1 | sed 's/^\*\*Title\*\*: //' | sed 's/^\[draft\]\[plan\]\[[^]]*\]: //' || echo "Unknown Feature")
+    fi
 fi
 
 if [ -z "$FEATURE_DESCRIPTION" ]; then


### PR DESCRIPTION
## Problem

Issues #148, #149, and #152 all displayed "Unknown Feature" in their consensus plans instead of the actual feature names. The bug was in the `external-consensus.sh` script which only looked for the `**Feature**:` pattern when extracting feature names from debate reports.

## Root Cause

The script assumed all debate reports use the standard format:
```markdown
**Feature**: Add user authentication
```

However, **refinement debate reports** (created by `/refine-issue`) use a different format:
```markdown
**Title**: [draft][plan][feat]: Add user authentication
```

When processing refinement reports, the grep pattern failed to match, resulting in the fallback value "Unknown Feature".

## Solution

Added fallback logic to handle both report formats:

1. First tries `**Feature**:` pattern (standard debate reports)
2. Falls back to `**Title**:` pattern and strips the `[draft][plan][tag]:` prefix (refinement reports)
3. Defaults to "Unknown Feature" only if both patterns fail

## Testing

Manually tested with both report formats:
- ✅ Refinement report (issue #148): Extracted "Add project metadata file (.agentize.yaml)"
- ✅ Standard report: Extracted "Fix SDK Docs and Add Agent Codebase Analysis Rules"

## Changes

- Modified: `.claude/skills/external-consensus/scripts/external-consensus.sh`
  - Added fallback pattern for `**Title**:` extraction
  - Added inline comments explaining the logic
  - Maintained backward compatibility with existing reports

## Impact

- Fixes issues #148, #149, #152
- No breaking changes
- Maintains backward compatibility
- Minimal code change (7 insertions, 1 deletion)

Closes #148
Closes #149  
Closes #152