### PR TITLE
[docs][#162] Clarify AGENTIZE_HOME vs PROJECT_ROOT path resolution

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,3 +1,23 @@
 - When writing any scripts, **AVOID** being shell-specific.
   - The most common thing I can foresee is that `BASH_SOURCE[0]` or `$0` between zsh and bash to get the current script name.
-    Use `AGENTIZE_HOME` as a absolute path to refer to the root of this project instead.
+
+## Path Variables: AGENTIZE_HOME vs PROJECT_ROOT
+
+Scripts in this SDK use two distinct path resolution mechanisms:
+
+**AGENTIZE_HOME** (Static, from `setup.sh`)
+- Exported by `setup.sh` as an absolute path to the agentize SDK installation
+- Used for referencing agentize SDK assets (scripts, templates, `.claude/` configs)
+- Example: `source "$AGENTIZE_HOME/scripts/wt-cli.sh"`
+- Set once during `make setup`, persists across shell sessions
+
+**PROJECT_ROOT** (Dynamic, git-based)
+- Resolved at runtime via `git rev-parse --git-common-dir` (see `wt_resolve_repo_root()` in `scripts/wt-cli.sh`)
+- Used when operating on user repositories or worktrees
+- Works correctly inside linked worktrees (resolves to main repo root, not worktree path)
+- Example: `git -C "$repo_root" worktree add ...`
+
+**When to use each:**
+- Use `AGENTIZE_HOME` for SDK-internal operations (sourcing libraries, accessing templates)
+- Use git-based resolution (`wt_resolve_repo_root`) for project-specific operations (worktree management, repo queries)
+- Avoid `$0` / `BASH_SOURCE[0]` for path resolution in cross-shell contexts


### PR DESCRIPTION
## Summary

Added documentation clarifying the distinction between two path resolution mechanisms used in the agentize SDK: `AGENTIZE_HOME` (static, exported by `setup.sh`) and `PROJECT_ROOT` (dynamic, resolved via git). This addresses confusion about when to use each mechanism in shell scripts.

## Changes

- Modified `scripts/CLAUDE.md:1-23` to add "Path Variables: AGENTIZE_HOME vs PROJECT_ROOT" section
  - Documented `AGENTIZE_HOME` as static environment variable from `setup.sh` for SDK-internal operations
  - Documented `PROJECT_ROOT` as dynamic git-based resolution via `wt_resolve_repo_root()` for project-specific operations
  - Added clear usage examples for each mechanism
  - Provided guidance on when to use each approach
  - Reinforced avoidance of shell-specific syntax (`$0`, `BASH_SOURCE[0]`)

## Testing

- Verified documentation linter passes: `scripts/lint-documentation.sh` exits with code 0
- Validated against success criteria:
  1. ✅ `scripts/CLAUDE.md` clearly distinguishes `AGENTIZE_HOME` vs `PROJECT_ROOT`
  2. ✅ References git-based resolution (`wt_resolve_repo_root` / `git rev-parse --git-common-dir`)
  3. ✅ Wording consistent with `docs/cli/wt.md` and `docs/tutorial/03-advanced-usage.md`
- Code review passed with no critical issues or warnings

## Related Issue

Closes #162