### PR TITLE
[docs][#172] Add Next Steps guidance to milestone workflow

### DIFF
--- a/.claude/commands/miles2miles.md
+++ b/.claude/commands/miles2miles.md
@@ -187,9 +187,17 @@ Milestone {M+1} created at {new-LOC} LOC ({passed}/{total} tests passed).
 
 Work remaining: ~{estimated} LOC
 Tests failing: {list}
-
-Next Step: /miles2miles .milestones/issue-{N}-milestone-{M+1}.md
 ```
+
+**Next Steps:**
+
+To continue implementation from this checkpoint:
+```
+/miles2miles .milestones/issue-{N}-milestone-{M+1}.md
+```
+
+Or run `/miles2miles` without arguments to auto-detect the latest milestone on the current branch.
+
 Command outputs the new milestone file path for next invocation.
 
 **Output B: All tests pass (completion)**

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -451,12 +451,17 @@ Display message to user:
 ```
 Milestone {M} created at {cumulative_loc} LOC ({passed}/{total} tests passed).
 
-Next steps:
-1. Start a new session
-2. Run /miles2miles to resume implementation from this checkpoint
-
 Work remaining: ~{estimated_remaining_loc} LOC
 ```
+
+**Next Steps:**
+
+To resume implementation from this checkpoint:
+```
+/miles2miles .milestones/issue-{N}-milestone-{M}.md
+```
+
+Or run `/miles2miles` without arguments to auto-detect the latest milestone on the current branch
 
 ---
 


### PR DESCRIPTION
## Summary

Added concise "Next Steps" sections to milestone skill output specification and miles2miles command documentation to explicitly guide users on how to continue implementation after a milestone is created. This addresses user confusion about the continuation command by making `/miles2miles <milestone-file>` visible at key workflow transition points.

## Changes

- Modified `.claude/skills/milestone/SKILL.md:447-464` to add explicit "Next Steps" section with `/miles2miles` command and file path placeholder
- Updated `.claude/commands/miles2miles.md:184-201` to add "Next Steps" section showing continuation command with both explicit file path usage and auto-detect behavior

## Testing

No automated tests required for documentation-only change. Manual verification performed:
1. Confirmed "Next Steps" appears under Step 7 in `.claude/skills/milestone/SKILL.md`
2. Confirmed "Next Steps" appears in Output A section of `.claude/commands/miles2miles.md`
3. Verified wording aligns with existing docs by mentioning optional auto-detect behavior (`/miles2miles` without args)
4. Checked consistency with placeholder format `.milestones/issue-{N}-milestone-{M}.md` from current docs

## Related Issue

Closes #172