### PR TITLE
[cli][#183] Add conditional post-update hints to lol update

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -85,7 +85,10 @@ Updates the AI-related rules and files in an existing SDK structure without affe
   - `git.default_branch` (if git repository exists)
 - Preserves existing `.agentize.yaml` without overwriting
 - Installs pre-commit hook from `scripts/pre-commit` if available and `.git` directory exists (unless `pre_commit.enabled: false` in metadata)
-- Prints post-update setup hints pointing to framework Makefile targets and documentation (see `docs/architecture/architecture.md` for details)
+- Prints conditional post-update hints based on available resources:
+  - `make test` (if Makefile has `test:` target)
+  - `make setup` (if Makefile has `setup:` target)
+  - Documentation link (if `docs/architecture/architecture.md` exists)
 
 **Difference from `lol init`:**
 - `lol update` only creates the `.claude/` directory and syncs AI configuration files

--- a/scripts/agentize-update.sh
+++ b/scripts/agentize-update.sh
@@ -174,8 +174,43 @@ if [ -d "$AGENTIZE_PROJECT_PATH/.git" ] && [ -f "$AGENTIZE_PROJECT_PATH/scripts/
 fi
 
 echo "SDK updated successfully at $AGENTIZE_PROJECT_PATH"
-echo ""
-echo "Next steps (if you initialized with 'lol init' or SDK Makefile):"
-echo "  - Run tests: make test"
-echo "  - Setup hooks: make setup"
-echo "  - See docs/architecture/architecture.md for details"
+
+# Print context-aware next steps hints
+HINTS_PRINTED=false
+
+# Check for Makefile targets and available resources
+if [ -f "$AGENTIZE_PROJECT_PATH/Makefile" ]; then
+    HAS_TEST_TARGET=$(grep -q '^test:' "$AGENTIZE_PROJECT_PATH/Makefile" && echo "true" || echo "false")
+    HAS_SETUP_TARGET=$(grep -q '^setup:' "$AGENTIZE_PROJECT_PATH/Makefile" && echo "true" || echo "false")
+else
+    HAS_TEST_TARGET=false
+    HAS_SETUP_TARGET=false
+fi
+
+HAS_ARCH_DOC=$([ -f "$AGENTIZE_PROJECT_PATH/docs/architecture/architecture.md" ] && echo "true" || echo "false")
+
+# Print hints header only if we have suggestions
+if [ "$HAS_TEST_TARGET" = "true" ] || [ "$HAS_SETUP_TARGET" = "true" ] || [ "$HAS_ARCH_DOC" = "true" ]; then
+    echo ""
+    echo "Next steps:"
+    HINTS_PRINTED=true
+fi
+
+# Suggest available make targets
+if [ "$HAS_TEST_TARGET" = "true" ]; then
+    echo "  - Run tests: make test"
+fi
+
+if [ "$HAS_SETUP_TARGET" = "true" ]; then
+    echo "  - Setup hooks: make setup"
+fi
+
+# Point to architecture docs if available
+if [ "$HAS_ARCH_DOC" = "true" ]; then
+    echo "  - See docs/architecture/architecture.md for details"
+fi
+
+# If no hints were printed, we're done
+if [ "$HINTS_PRINTED" = "false" ]; then
+    : # No-op, hints header wasn't printed
+fi


### PR DESCRIPTION
## Summary

Added context-aware post-update hints to \`lol update\` that guide users to available framework setup commands and documentation. The hints are conditional based on actual project resources (Makefile targets, documentation files) to avoid suggesting unavailable commands.

Also fixed flaky test failures in Tests 13-15 by properly isolating git environment during pre-commit hook execution.

## Changes

- Modified \`scripts/agentize-update.sh:177-217\` to add conditional hint system that:
  - Checks for \`test:\` and \`setup:\` targets in Makefile
  - Checks for \`docs/architecture/architecture.md\` existence
  - Only prints "Next steps:" header if hints are available
  - Suggests \`make test\`, \`make setup\`, and documentation links based on availability

- Updated \`docs/cli/lol.md:88-91\` to document the conditional hint behavior

- Enhanced \`tests/test-agentize-cli.sh\` with:
  - Added git environment variable unsetting to Tests 13-15 (lines 346-348, 385-387, 426-428) to prevent parent git process interference
  - Added comprehensive Test 16 (lines 455-513) that validates:
    - Test 16a: No hints when Makefile/docs don't exist
    - Test 16b: All hints appear when resources are present
    - Specific hint content verification

## Testing

- Added \`tests/test-agentize-cli.sh:455-513\` (Test 16) to verify conditional hint behavior:
  - Validates hints are NOT shown when Makefile and docs are missing
  - Validates hints ARE shown when Makefile with targets exists
  - Verifies specific hint content (make test, make setup, docs link)

- Fixed test isolation in Tests 13-15 by unsetting git environment variables:
  - Prevents flaky failures during pre-commit hook execution
  - All tests now pass consistently in both direct and hook contexts

- All existing tests continue to pass (verified by pre-commit hook)

- Manually verified hint behavior:
  1. Ran \`lol update\` in project without Makefile - no hints displayed (clean output)
  2. Ran \`lol update\` in project with SDK Makefile - all hints displayed appropriately
  3. Ran \`lol update\` in project with partial resources - only relevant hints shown

## Related Issue

Closes #183