### PR TITLE
[bugfix][cli][#201] Fix shell-neutral argument handling for lol/wt commands

### DIFF
--- a/scripts/lol-cli.sh
+++ b/scripts/lol-cli.sh
@@ -32,7 +32,7 @@ lol() {
 
     # Parse subcommand
     local subcommand="$1"
-    shift || true
+    [ $# -gt 0 ] && shift
 
     case "$subcommand" in
         init)

--- a/scripts/wt-cli.sh
+++ b/scripts/wt-cli.sh
@@ -658,7 +658,7 @@ wt() {
 
     # Map wt subcommands to cmd_* functions
     local subcommand="$1"
-    shift || true
+    [ $# -gt 0 ] && shift
 
     case "$subcommand" in
         init)
@@ -716,7 +716,7 @@ wt_cli_main() {
     fi
 
     local cmd="$1"
-    shift || true
+    [ $# -gt 0 ] && shift
 
     case "$cmd" in
         init)


### PR DESCRIPTION
## Summary

Fixed shell-neutral argument handling in the lol and wt CLI commands to prevent zsh from emitting "shift count must be <= $#" errors when invoked without arguments. The commands now handle zero-argument invocations gracefully across both bash and zsh shells.

## Changes

- Modified `scripts/lol-cli.sh:35` to guard shift operation in `lol()` dispatcher
  - Replaced `shift || true` with `[ $# -gt 0 ] && shift`
- Modified `scripts/wt-cli.sh:661` to guard shift operation in `wt()` dispatcher
  - Replaced `shift || true` with `[ $# -gt 0 ] && shift`
- Modified `scripts/wt-cli.sh:719` to guard shift operation in `wt_cli_main()` dispatcher
  - Replaced `shift || true` with `[ $# -gt 0 ] && shift`

## Testing

Manual verification performed:
- Tested `lol` with no arguments in bash (shows help, no errors)
- Tested `wt` (via direct script execution) with no arguments in bash (shows help, no errors)
- Tested `wt()` (sourced function) with no arguments in bash (shows help, no errors)
- All pre-commit tests passed including:
  - Documentation linting
  - Agentize mode validation tests
  - Makefile validation tests
  - C SDK tests
  - C++ SDK tests
  - Python SDK tests
  - Worktree functionality tests
  - Shell script review tests

The solution uses POSIX-compliant `[ $# -gt 0 ]` conditional guard instead of shell-specific constructs, ensuring portability across bash, zsh, dash, and other POSIX shells.

## Related Issue

Fixes #201