### PR TITLE
[docs][test][agent.command][agent.skill][#214] Remove [draft] prefix mechanism from workflow documentation

### DIFF
--- a/.claude/commands/refine-issue.md
+++ b/.claude/commands/refine-issue.md
@@ -107,7 +107,7 @@ ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
 
 **Validate:**
 - Issue exists (non-zero exit code from gh)
-- Issue is a plan issue (title contains `[plan]` or `[draft][plan]`)
+- Issue is a plan issue (title contains `[plan]`)
 - Issue state (warn if CLOSED)
 
 **Save original plan:**
@@ -291,10 +291,6 @@ Update the issue with the refined plan:
 gh issue edit "$ISSUE_NUMBER" --body-file "$CONSENSUS_PLAN_FILE"
 ```
 
-**Preserve draft status:**
-- If original title had `[draft]` prefix, keep it
-- If not, don't add it
-
 Display summary to user:
 ```
 Refinement complete!
@@ -346,7 +342,7 @@ Stop execution.
 
 ### Issue Not a Plan Issue
 
-Issue title doesn't contain `[plan]` or `[draft][plan]`.
+Issue title doesn't contain `[plan]`.
 
 **Response:**
 ```
@@ -441,7 +437,7 @@ Offer manual review fallback.
 ```
 Fetching issue #42...
 
-Title: [draft][plan][feat] Add user authentication
+Title: [plan][feat] Add user authentication
 Current plan size: 150 lines
 Refinement focus: General improvements
 
@@ -478,7 +474,7 @@ Summary of changes:
 ```
 Fetching issue #42...
 
-Title: [draft][plan][feat] Add user authentication
+Title: [plan][feat] Add user authentication
 Current plan size: 280 lines
 Refinement focus: Focus on reducing complexity
 
@@ -515,7 +511,7 @@ Summary of changes:
 ```
 Fetching issue #42...
 
-Title: [draft][plan][feat] Add user authentication
+Title: [plan][feat] Add user authentication
 Current plan size: 250 lines
 Refinement focus: Add more error handling and edge cases
 

--- a/.claude/commands/tests/ultra-planner.sh
+++ b/.claude/commands/tests/ultra-planner.sh
@@ -49,8 +49,8 @@ export PATH="$TEST_TMP:$PATH"
 echo "Test 1: Placeholder creation extracts ISSUE_NUMBER from URL"
 rm -f "$GH_CAPTURE"
 # Simulate ultra-planner creating placeholder
-"$TEST_TMP/gh-mock.sh" issue create --title "[draft][plan][feat]: $MOCK_FEATURE" --body "Placeholder"
-ISSUE_URL_OUTPUT=$("$TEST_TMP/gh-mock.sh" issue create --title "[draft][plan][feat]: $MOCK_FEATURE" --body "Placeholder")
+"$TEST_TMP/gh-mock.sh" issue create --title "[plan][feat]: $MOCK_FEATURE" --body "Placeholder"
+ISSUE_URL_OUTPUT=$("$TEST_TMP/gh-mock.sh" issue create --title "[plan][feat]: $MOCK_FEATURE" --body "Placeholder")
 ISSUE_NUMBER=$(echo "$ISSUE_URL_OUTPUT" | grep -o '"number": [0-9]*' | grep -o '[0-9]*')
 
 if [ "$ISSUE_NUMBER" = "42" ]; then
@@ -92,10 +92,10 @@ echo "Test 3: Consensus updates existing issue (no second create)"
 rm -f "$GH_CAPTURE"
 
 # Simulate placeholder creation
-"$TEST_TMP/gh-mock.sh" issue create --title "[draft][plan][feat]: $MOCK_FEATURE" --body "Placeholder" > /dev/null
+"$TEST_TMP/gh-mock.sh" issue create --title "[plan][feat]: $MOCK_FEATURE" --body "Placeholder" > /dev/null
 
 # Simulate consensus updating the same issue
-"$TEST_TMP/gh-mock.sh" issue edit 42 --title "[draft][plan][feat]: $MOCK_FEATURE" --body "Final consensus plan" > /dev/null
+"$TEST_TMP/gh-mock.sh" issue edit 42 --title "[plan][feat]: $MOCK_FEATURE" --body "Final consensus plan" > /dev/null
 
 # Verify we have exactly 1 CREATE and 1 EDIT operation
 CREATE_COUNT=$(grep -c "^CREATE$" "$GH_CAPTURE" || true)
@@ -109,16 +109,16 @@ else
     exit 1
 fi
 
-# Test 4: Update preserves [draft] prefix
-echo "Test 4: Issue update preserves [draft][plan] prefix"
+# Test 4: Update preserves [plan] prefix
+echo "Test 4: Issue update preserves [plan] prefix"
 rm -f "$GH_CAPTURE"
-"$TEST_TMP/gh-mock.sh" issue edit 42 --title "[draft][plan][feat]: Updated consensus plan" > /dev/null
+"$TEST_TMP/gh-mock.sh" issue edit 42 --title "[plan][feat]: Updated consensus plan" > /dev/null
 
 UPDATED_TITLE=$(grep "TITLE:" "$GH_CAPTURE" | tail -1 | cut -d' ' -f2-)
-if [[ "$UPDATED_TITLE" == "[draft][plan][feat]:"* ]]; then
-    echo "✓ Test 4 passed: Updated title preserves [draft][plan] prefix"
+if [[ "$UPDATED_TITLE" == "[plan][feat]:"* ]]; then
+    echo "✓ Test 4 passed: Updated title preserves [plan] prefix"
 else
-    echo "✗ Test 4 failed: Expected [draft][plan] prefix, got '$UPDATED_TITLE'"
+    echo "✗ Test 4 failed: Expected [plan] prefix, got '$UPDATED_TITLE'"
     exit 1
 fi
 

--- a/.claude/commands/ultra-planner.md
+++ b/.claude/commands/ultra-planner.md
@@ -142,16 +142,16 @@ Please provide more details:
 
 Ask user for clarification.
 
-### Step 3: Create Placeholder Draft Issue
+### Step 3: Create Placeholder Issue
 
 **REQUIRED SKILL CALL (before agent execution):**
 
-Create a placeholder draft issue to obtain the issue number for artifact naming:
+Create a placeholder issue to obtain the issue number for artifact naming:
 
 ```
 Skill tool parameters:
   skill: "open-issue"
-  args: "--draft --auto"
+  args: "--auto"
 ```
 
 **Provide context to open-issue skill:**
@@ -160,7 +160,7 @@ Skill tool parameters:
 
 **Extract issue number from response:**
 ```bash
-# Expected output: "Draft GitHub issue created: #42"
+# Expected output: "GitHub issue created: #42"
 ISSUE_URL=$(echo "$OPEN_ISSUE_OUTPUT" | grep -o 'https://[^ ]*')
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
 ```
@@ -342,33 +342,30 @@ Consensus plan saved to: {CONSENSUS_PLAN_FILE}
 
 **REQUIRED SKILL CALL:**
 
-Use the Skill tool to invoke the open-issue skill with update, draft, and auto flags:
+Use the Skill tool to invoke the open-issue skill with update and auto flags:
 
 ```
 Skill tool parameters:
   skill: "open-issue"
-  args: "--update ${ISSUE_NUMBER} --draft --auto {CONSENSUS_PLAN_FILE}"
+  args: "--update ${ISSUE_NUMBER} --auto {CONSENSUS_PLAN_FILE}"
 ```
 
 **What this skill does:**
 1. Reads consensus plan from file
 2. Determines appropriate tag from `docs/git-msg-tags.md`
-3. Formats issue with `[draft]` prefix and Problem Statement/Proposed Solution sections
+3. Formats issue with `[plan]` prefix and Problem Statement/Proposed Solution sections
 4. Updates existing issue #${ISSUE_NUMBER} (created in Step 3) using `gh issue edit`
 5. Returns issue number and URL
 
 **Expected output:**
 ```
-Draft issue #${ISSUE_NUMBER} updated with consensus plan.
+Plan issue #${ISSUE_NUMBER} updated with consensus plan.
 
-Title: [draft][plan][tag] {feature name}
+Title: [plan][tag] {feature name}
 URL: {issue_url}
 
-This is a draft plan. To refine it, use:
-  /refine-issue ${ISSUE_NUMBER}
-
-To approve and implement, remove [draft] from the issue title on GitHub, then:
-  /issue-to-impl ${ISSUE_NUMBER}
+To refine: /refine-issue ${ISSUE_NUMBER}
+To implement: /issue-to-impl ${ISSUE_NUMBER}
 ```
 
 Display this output to the user. Command completes successfully.

--- a/.claude/skills/open-issue/SKILL.md
+++ b/.claude/skills/open-issue/SKILL.md
@@ -86,7 +86,6 @@ The open-issue skill takes the following inputs:
    - General requirements (for feature requests)
 
 3. **Optional flags** (via arguments):
-   - `--draft`: Prepend `[draft]` to the title for plan issues (e.g., `[draft][plan][tag]: Title`)
    - `--auto`: Skip user confirmation and create issue automatically (only used by ultra-planner)
    - `--update <issue-number>`: Update an existing issue instead of creating a new one (e.g., `--update 42`)
 
@@ -99,16 +98,13 @@ When this skill is invoked, the AI agent **MUST** follow these steps:
 Check if optional flags are provided in arguments:
 
 ```bash
-DRAFT_MODE=false
 AUTO_MODE=false
 UPDATE_MODE=false
 UPDATE_ISSUE_NUMBER=""
 PLAN_FILE=""
 
 while [ $# -gt 0 ]; do
-  if [ "$1" = "--draft" ]; then
-    DRAFT_MODE=true
-  elif [ "$1" = "--auto" ]; then
+  if [ "$1" = "--auto" ]; then
     AUTO_MODE=true
   elif [ "$1" = "--update" ]; then
     UPDATE_MODE=true
@@ -121,7 +117,6 @@ while [ $# -gt 0 ]; do
 done
 ```
 
-- `DRAFT_MODE=true`: Prepend `[draft]` to title for plan issues
 - `AUTO_MODE=true`: Skip confirmation in Step 4
 - `UPDATE_MODE=true`: Update existing issue instead of creating new one
 - `UPDATE_ISSUE_NUMBER`: The issue number to update (e.g., "42")
@@ -160,7 +155,7 @@ Build the issue following the format specification:
 
 **Title:**
 - Format: `[prefix][tag]: Brief Summary`
-- If `DRAFT_MODE=true` and this is a `[plan]` issue, prepend `[draft]`: `[draft][plan][tag]: Brief Summary`
+- For plan issues: `[plan][tag]: Brief Summary`
 - Keep summary concise (max 80 characters for the summary portion)
 - Ensure the summary clearly describes the issue
 
@@ -244,7 +239,7 @@ EOF
 **Important:**
 - Use `--body-file -` with heredoc to preserve markdown formatting and handle special characters safely
 - The body should include all sections from Description onwards (not the title)
-- For updates: title formatting (including `[draft]` prefix) is applied the same way as for creates
+- For updates: title formatting is applied the same way as for creates
 - After successful creation/update, display the issue URL to the user
 - Confirm: "GitHub issue created successfully: [URL]" or "GitHub issue #N updated successfully: [URL]"
 
@@ -366,15 +361,15 @@ without modifying core code.
 
 ### Example 4: Update Existing Issue (--update mode)
 
-**Context:** Ultra-planner created a placeholder draft issue #42, then consensus plan is ready to update that same issue.
+**Context:** Ultra-planner created a placeholder issue #42, then consensus plan is ready to update that same issue.
 
 **Invocation:**
 ```bash
-open-issue --update 42 --draft <plan-file>
+open-issue --update 42 <plan-file>
 ```
 
 **Behavior:**
 - Uses `gh issue edit 42` instead of `gh issue create`
-- Applies same title formatting logic (includes `[draft][plan][tag]` prefix)
+- Applies same title formatting logic (includes `[plan][tag]` prefix)
 - Updates issue body with final consensus plan
 - Preserves issue number (no duplicate issue created)

--- a/docs/git-msg-tags.md
+++ b/docs/git-msg-tags.md
@@ -26,6 +26,5 @@ This document defines the tags to be used in git commit messages.
 ## Issue Tags
 
 - `plan`: A plan that is created by `/plan-an-issue` (simple) or `/ultra-planner` (complicated) commands.
-  - `draft`: A plan is a draft (not reviewed and approved by a human yet).
 - `discussion`: An issue is created from a summary of a disccussion.
 - `roadmap`: An issue is created from `/roadmapper` command by feeding a `discussion` issue.

--- a/docs/tutorial/01b-ultra-planner.md
+++ b/docs/tutorial/01b-ultra-planner.md
@@ -53,13 +53,13 @@ Consensus: JWT + basic roles (~280 LOC)
 - From Reducer: Removed OAuth2 complexity
 ```
 
-**5. Draft issue auto-updated:**
+**5. Plan issue auto-updated:**
 ```
-Draft issue #42 updated with consensus plan.
+Plan issue #42 updated with consensus plan.
 URL: https://github.com/user/repo/issues/42
 
 To refine: /refine-issue 42
-To implement: Remove [draft] on GitHub, then /issue-to-impl 42
+To implement: /issue-to-impl 42
 ```
 
 ## Refinement with `/refine-issue`

--- a/docs/workflows/ultra-planner.md
+++ b/docs/workflows/ultra-planner.md
@@ -1,16 +1,16 @@
 # Ultra Planner Workflow
 
-Multi-agent debate-based planning workflow for complex features with progressive draft-based refinement.
+Multi-agent debate-based planning workflow for complex features with issue-based refinement.
 
 ## Overview
 
-The ultra-planner workflow creates implementation plans through multi-agent debate and automatically publishes them as draft GitHub issues. This enables early visibility and issue-based refinement without blocking on approval.
+The ultra-planner workflow creates implementation plans through multi-agent debate and automatically publishes them as GitHub issues. This enables early visibility and issue-based refinement.
 
 ## Workflow Diagram
 
 ```mermaid
 graph TD
-    A[User provides requirements] --> B[Create placeholder draft issue]
+    A[User provides requirements] --> B[Create placeholder issue]
     B --> C[Bold-proposer: Research SOTA & propose innovation]
     C --> D
     C --> E
@@ -18,12 +18,11 @@ graph TD
     E[Reducer: Simplify following 'less is more'] --> F
     C --> F
     F[Combined 3-perspective report] --> G
-    G[External consensus: Synthesize plan] --> H[Update draft issue with consensus plan]
-    H --> I{User reviews draft}
+    G[External consensus: Synthesize plan] --> H[Update issue with consensus plan]
+    H --> I{User reviews plan}
     I -->|Refine| J["/refine-issue command"]
     J --> C
-    I -->|Approve| K["Remove draft prefix on GitHub"]
-    K --> L["/issue-to-impl for implementation"]
+    I -->|Implement| K["/issue-to-impl for implementation"]
     I -->|Abandon| Z(Close issue)
 
     style A fill:#ffcccc
@@ -36,27 +35,26 @@ graph TD
     style G fill:#ccddff
     style H fill:#ccddff
     style J fill:#ccddff
-    style K fill:#aaffaa
-    style L fill:#ccddff
+    style K fill:#ccddff
     style Z fill:#dddddd
 ```
 
 ## Key Features
 
-### 1. Automatic Draft Creation
+### 1. Automatic Issue Creation
 
-Ultra-planner creates a draft GitHub issue **before** running the multi-agent debate workflow:
+Ultra-planner creates a GitHub issue **before** running the multi-agent debate workflow:
 
-- **Placeholder created first** - draft issue established immediately after feature validation
+- **Placeholder created first** - issue established immediately after feature validation
 - **Issue-numbered artifacts** - all planning files use `issue-{N}-` prefix from the start
-- **Draft prefix** - title gets `[draft][plan][tag]` format
+- **Plan prefix** - title gets `[plan][tag]` format
 - **Updated after consensus** - same issue is updated with final plan (no second issue created)
 - **Early collaboration** - stakeholders can see issue number and planning progress immediately
 
 **Example:**
 ```
-Created placeholder draft issue: #42
-Title: [draft][plan][feat] Add user authentication
+Created placeholder issue: #42
+Title: [plan][feat] Add user authentication
 URL: https://github.com/user/repo/issues/42
 
 Running multi-agent debate...
@@ -65,7 +63,7 @@ Running multi-agent debate...
 Issue #42 updated with consensus plan.
 
 To refine: /refine-issue 42
-To implement: Remove [draft] on GitHub, then /issue-to-impl 42
+To implement: /issue-to-impl 42
 ```
 
 ### 2. Issue-Based Refinement
@@ -76,7 +74,6 @@ The `/refine-issue` command enables iterative plan improvement:
 - **Runs full debate** - same three-agent workflow as ultra-planner
 - **Accepts refinement focus** - optional inline instructions guide the agents
 - **Updates issue atomically** - replaces body only after consensus completes
-- **Preserves draft status** - keeps `[draft]` prefix until manually removed
 
 **Example (General refinement):**
 ```
@@ -105,14 +102,14 @@ Issue #42 updated with refined plan.
 Summary: Reduced LOC 280→150, removed OAuth2, simplified middleware
 ```
 
-### 3. Manual Approval
+### 3. Review and Implementation
 
-Users approve plans by removing the `[draft]` prefix on GitHub:
+After reviewing a plan issue:
 
-- **Simple UI action** - edit issue title, remove `[draft]`
-- **No CLI required** - approval happens in GitHub web UI
-- **Clear signal** - non-draft issues are ready for implementation
-- **Flexible timing** - approve when ready, no time pressure
+- **Review on GitHub** - examine the plan details in the issue body
+- **Refine if needed** - use `/refine-issue` for improvements
+- **Implement when ready** - use `/issue-to-impl` to start implementation
+- **Flexible timing** - implement when ready, no time pressure
 
 ## Runtime Expectations
 
@@ -140,17 +137,13 @@ Users approve plans by removing the `[draft]` prefix on GitHub:
 
 ## Lifecycle States
 
-1. **Draft Plan** - `[draft][plan][tag]: Title`
+1. **Plan Issue** - `[plan][tag]: Title`
    - Created automatically by ultra-planner
    - Visible to all stakeholders
    - Can be refined via `/refine-issue`
-
-2. **Approved Plan** - `[plan][tag]: Title`
-   - Draft prefix removed manually on GitHub
-   - Ready for implementation
    - Can be implemented via `/issue-to-impl`
 
-3. **Closed/Abandoned** - Issue closed on GitHub
+2. **Closed/Abandoned** - Issue closed on GitHub
    - Plan not pursued
    - Can be reopened later if needed
 
@@ -158,14 +151,14 @@ Users approve plans by removing the `[draft]` prefix on GitHub:
 
 ### `/ultra-planner <feature-description>`
 
-Creates initial plan via multi-agent debate and auto-creates draft issue.
+Creates initial plan via multi-agent debate and auto-creates plan issue.
 
 **Usage:**
 ```
 /ultra-planner Add user authentication with JWT and RBAC
 ```
 
-**Output:** Draft issue URL and refinement/approval instructions
+**Output:** Plan issue URL and refinement/implementation instructions
 
 ### `/refine-issue <issue-number> [refinement-instructions]`
 
@@ -182,7 +175,7 @@ Refines existing plan issue via multi-agent debate and updates issue body.
 
 ### `/issue-to-impl <issue-number>`
 
-Implements approved plan (after removing `[draft]` prefix).
+Implements plan issue.
 
 **Usage:**
 ```
@@ -193,14 +186,14 @@ Implements approved plan (after removing `[draft]` prefix).
 
 ## Comparison to Previous Workflow
 
-| Aspect | Previous | Progressive Draft-Based |
-|--------|----------|------------------------|
+| Aspect | Previous | Issue-Based |
+|--------|----------|-------------|
 | **Issue creation** | After user approval | Automatic after consensus |
-| **Approval step** | CLI prompt | Manual draft removal on GitHub |
+| **Approval step** | CLI prompt | Direct implementation |
 | **Refinement** | CLI flag `--refine` | Issue-based `/refine-issue` |
 | **Collaboration** | Plan files in `.tmp` | GitHub issues from start |
-| **Visibility** | Private until approved | Public drafts immediately |
-| **Workflow** | Approval → Issue → Impl | Draft → Refine* → Approve → Impl |
+| **Visibility** | Private until approved | Public issues immediately |
+| **Workflow** | Approval → Issue → Impl | Issue → Refine* → Impl |
 
 *Refinement is optional and can be done multiple times
 

--- a/tests/handsoff/test-open-issue-draft-non-plan.sh
+++ b/tests/handsoff/test-open-issue-draft-non-plan.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Test: --draft with non-plan issue (bug report)
+# Test: Non-plan issue format (bug report)
 
 source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/../helpers-open-issue.sh"
 
-test_info "--draft with non-plan issue (bug report)"
+test_info "Non-plan issue format (bug report)"
 
-TMP_DIR=$(make_temp_dir "open-issue-draft-non-plan")
+TMP_DIR=$(make_temp_dir "open-issue-non-plan")
 GH_CAPTURE_FILE="$TMP_DIR/gh-capture.txt"
 export GH_CAPTURE_FILE
 
@@ -14,14 +14,14 @@ export GH_CAPTURE_FILE
 setup_gh_mock_open_issue "$TMP_DIR"
 export PATH="$TMP_DIR:$PATH"
 
-# Bug reports should not get [draft] prefix even with --draft flag
+# Bug reports have no [plan] or [draft] prefix
 TITLE="[bugfix]: Fix authentication error"
 "$TMP_DIR/gh" issue create --title "$TITLE" --body "test"
 CAPTURED_TITLE=$(grep "TITLE:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 
 if [ "$CAPTURED_TITLE" = "[bugfix]: Fix authentication error" ]; then
     cleanup_dir "$TMP_DIR"
-    test_pass "Non-plan issues don't get [draft] prefix"
+    test_pass "Non-plan issues have correct format (no [plan] prefix)"
 else
     cleanup_dir "$TMP_DIR"
     test_fail "Expected '[bugfix]: Fix authentication error', got '$CAPTURED_TITLE'"

--- a/tests/handsoff/test-open-issue-update-maintains-format.sh
+++ b/tests/handsoff/test-open-issue-update-maintains-format.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Test: --update maintains [draft][plan][tag] format
+# Test: --update maintains [plan][tag] format
 
 source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/../helpers-open-issue.sh"
 
-test_info "--update maintains [draft][plan][tag] format"
+test_info "--update maintains [plan][tag] format"
 
 TMP_DIR=$(make_temp_dir "open-issue-update-format")
 GH_CAPTURE_FILE="$TMP_DIR/gh-capture.txt"
@@ -15,13 +15,13 @@ setup_gh_mock_open_issue "$TMP_DIR"
 export PATH="$TMP_DIR:$PATH"
 
 # Test update maintains format
-"$TMP_DIR/gh" issue edit 42 --title "[draft][plan][refactor]: Simplified implementation"
+"$TMP_DIR/gh" issue edit 42 --title "[plan][refactor]: Simplified implementation"
 CAPTURED_TITLE=$(grep "TITLE:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 
-if [[ "$CAPTURED_TITLE" == "[draft][plan][refactor]:"* ]]; then
+if [[ "$CAPTURED_TITLE" == "[plan][refactor]:"* ]]; then
     cleanup_dir "$TMP_DIR"
-    test_pass "--update maintains [draft][plan] prefix"
+    test_pass "--update maintains [plan] prefix"
 else
     cleanup_dir "$TMP_DIR"
-    test_fail "Expected title starting with '[draft][plan][refactor]:', got '$CAPTURED_TITLE'"
+    test_fail "Expected title starting with '[plan][refactor]:', got '$CAPTURED_TITLE'"
 fi

--- a/tests/handsoff/test-open-issue-update-mode.sh
+++ b/tests/handsoff/test-open-issue-update-mode.sh
@@ -15,7 +15,7 @@ setup_gh_mock_open_issue "$TMP_DIR"
 export PATH="$TMP_DIR:$PATH"
 
 # Simulate open-issue --update behavior
-"$TMP_DIR/gh" issue edit 42 --title "[draft][plan][feat]: Updated feature title"
+"$TMP_DIR/gh" issue edit 42 --title "[plan][feat]: Updated feature title"
 OPERATION=$(grep "OPERATION:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 ISSUE_NUM=$(grep "ISSUE:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 

--- a/tests/handsoff/test-open-issue-with-draft.sh
+++ b/tests/handsoff/test-open-issue-with-draft.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Test: With --draft flag
+# Test: Plan issue title format
 
 source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/../helpers-open-issue.sh"
 
-test_info "With --draft flag"
+test_info "Plan issue title format"
 
-TMP_DIR=$(make_temp_dir "open-issue-with-draft")
+TMP_DIR=$(make_temp_dir "open-issue-plan-format")
 GH_CAPTURE_FILE="$TMP_DIR/gh-capture.txt"
 export GH_CAPTURE_FILE
 
@@ -14,15 +14,15 @@ export GH_CAPTURE_FILE
 setup_gh_mock_open_issue "$TMP_DIR"
 export PATH="$TMP_DIR:$PATH"
 
-# Test with --draft flag
-TITLE="[draft][plan][feat]: Add test feature"
+# Test plan issue title format (no [draft] prefix)
+TITLE="[plan][feat]: Add test feature"
 "$TMP_DIR/gh" issue create --title "$TITLE" --body "test"
 CAPTURED_TITLE=$(grep "TITLE:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 
-if [ "$CAPTURED_TITLE" = "[draft][plan][feat]: Add test feature" ]; then
+if [ "$CAPTURED_TITLE" = "[plan][feat]: Add test feature" ]; then
     cleanup_dir "$TMP_DIR"
-    test_pass "Title with --draft has [draft] prefix"
+    test_pass "Plan issue title has correct format (no [draft] prefix)"
 else
     cleanup_dir "$TMP_DIR"
-    test_fail "Expected '[draft][plan][feat]: Add test feature', got '$CAPTURED_TITLE'"
+    test_fail "Expected '[plan][feat]: Add test feature', got '$CAPTURED_TITLE'"
 fi

--- a/tests/handsoff/test-open-issue-without-draft.sh
+++ b/tests/handsoff/test-open-issue-without-draft.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Test: Without --draft flag
+# Test: Plan issue baseline format
 
 source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/../helpers-open-issue.sh"
 
-test_info "Without --draft flag"
+test_info "Plan issue baseline format"
 
-TMP_DIR=$(make_temp_dir "open-issue-without-draft")
+TMP_DIR=$(make_temp_dir "open-issue-plan-baseline")
 GH_CAPTURE_FILE="$TMP_DIR/gh-capture.txt"
 export GH_CAPTURE_FILE
 
@@ -14,14 +14,14 @@ export GH_CAPTURE_FILE
 setup_gh_mock_open_issue "$TMP_DIR"
 export PATH="$TMP_DIR:$PATH"
 
-# Test without --draft flag (baseline)
+# Test plan issue baseline format
 TITLE="[plan][feat]: Add test feature"
 "$TMP_DIR/gh" issue create --title "$TITLE" --body "test"
 CAPTURED_TITLE=$(grep "TITLE:" "$GH_CAPTURE_FILE" | cut -d' ' -f2-)
 
 if [ "$CAPTURED_TITLE" = "[plan][feat]: Add test feature" ]; then
     cleanup_dir "$TMP_DIR"
-    test_pass "Title without --draft is correct"
+    test_pass "Plan issue title has correct baseline format"
 else
     cleanup_dir "$TMP_DIR"
     test_fail "Expected '[plan][feat]: Add test feature', got '$CAPTURED_TITLE'"

--- a/tests/handsoff/test-refine-issue-draft-prefix.sh
+++ b/tests/handsoff/test-refine-issue-draft-prefix.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Test: Verify draft prefix is preserved
+# Test: Verify plan prefix is present
 
 source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/../helpers-refine-issue.sh"
 
-test_info "Verify draft prefix is preserved"
+test_info "Verify plan prefix is present"
 
-TMP_DIR=$(make_temp_dir "refine-issue-draft")
+TMP_DIR=$(make_temp_dir "refine-issue-plan")
 
 # Setup gh mock
 setup_gh_mock_refine "$TMP_DIR" "$TMP_DIR"
@@ -16,11 +16,11 @@ export PATH="$TMP_DIR:$PATH"
 ISSUE_JSON=$("$TMP_DIR/gh" issue view 42 --json title,body,state)
 ISSUE_TITLE=$(echo "$ISSUE_JSON" | grep -o '"title": "[^"]*"' | cut -d'"' -f4)
 
-# The title should have [draft] prefix
-if echo "$ISSUE_TITLE" | grep -q "\[draft\]"; then
+# The title should have [plan] prefix (no [draft])
+if echo "$ISSUE_TITLE" | grep -q "\[plan\]" && ! echo "$ISSUE_TITLE" | grep -q "\[draft\]"; then
     cleanup_dir "$TMP_DIR"
-    test_pass "Draft prefix preserved in original issue"
+    test_pass "Plan prefix present in issue (no draft prefix)"
 else
     cleanup_dir "$TMP_DIR"
-    test_fail "Draft prefix missing"
+    test_fail "Expected [plan] prefix without [draft], got '$ISSUE_TITLE'"
 fi

--- a/tests/handsoff/test-refine-issue-fetch-issue.sh
+++ b/tests/handsoff/test-refine-issue-fetch-issue.sh
@@ -16,7 +16,7 @@ export PATH="$TMP_DIR:$PATH"
 ISSUE_JSON=$("$TMP_DIR/gh" issue view 42 --json title,body,state)
 ISSUE_TITLE=$(echo "$ISSUE_JSON" | grep -o '"title": "[^"]*"' | cut -d'"' -f4)
 
-if echo "$ISSUE_TITLE" | grep -q "\[draft\]\[plan\]\[feat\]"; then
+if echo "$ISSUE_TITLE" | grep -q "\[plan\]\[feat\]"; then
     cleanup_dir "$TMP_DIR"
     test_pass "Issue fetched correctly"
 else

--- a/tests/helpers-refine-issue.sh
+++ b/tests/helpers-refine-issue.sh
@@ -12,7 +12,7 @@ if [ "\$1" = "issue" ] && [ "\$2" = "view" ]; then
     # Return mock issue data
     cat <<'ISSUEEOF'
 {
-  "title": "[draft][plan][feat]: Add user authentication",
+  "title": "[plan][feat]: Add user authentication",
   "body": "## Description\\n\\nAdd user authentication with JWT tokens.\\n\\n## Proposed Solution\\n\\n### Implementation Steps\\n1. Add auth middleware\\n2. Create JWT utilities\\n3. Add login endpoint\\n\\nTotal LOC: ~150 (Medium)",
   "state": "OPEN"
 }


### PR DESCRIPTION
## Summary

Removed the `[draft]` prefix mechanism from the ultra-planner workflow, simplifying the plan approval process. Plan issues now consistently use `[plan][tag]` format without requiring manual title editing on GitHub for approval.

## Changes

- Updated `docs/workflows/ultra-planner.md` to remove draft-based lifecycle states and workflow diagram nodes
- Updated `docs/tutorial/01b-ultra-planner.md` to show `[plan][feat]` format in examples  
- Removed `draft` tag from `docs/git-msg-tags.md` issue tags section
- Modified `.claude/commands/ultra-planner.md` to remove `--draft` flag from `open-issue` skill invocations
- Modified `.claude/commands/refine-issue.md` to validate `[plan]` only (not `[draft][plan]`) and remove draft preservation logic
- Updated `.claude/skills/open-issue/SKILL.md` to remove `--draft` flag parsing and `DRAFT_MODE` logic
- Updated `.claude/commands/tests/ultra-planner.sh` to expect `[plan][feat]` titles in all test assertions
- Updated `tests/helpers-refine-issue.sh` mock issue title to `[plan][feat]: Add user authentication`
- Updated 7 test files in `tests/handsoff/` to assert `[plan][tag]` format and remove draft-related wording

## Testing

- All 99 existing tests pass with updated expectations
- Modified `.claude/commands/tests/ultra-planner.sh` to verify:
  - Placeholder creation uses `[plan][feat]` format
  - Issue updates preserve `[plan]` prefix (not `[draft][plan]`)
- Modified `tests/handsoff/test-refine-issue-draft-prefix.sh` to verify `[plan]` prefix is present without `[draft]`
- Modified `tests/handsoff/test-refine-issue-fetch-issue.sh` to expect `[plan][feat]` in fetched titles
- Modified 5 `tests/handsoff/test-open-issue-*.sh` files to verify plan issue title formats without `[draft]` prefix
- Manually verified test suite runs successfully: `make test` (99/99 tests passed)

## Related Issue

Closes #214