### PR TITLE
[refactor][#225] Refactor external-consensus.sh to issue-based interface

### DIFF
--- a/.claude/commands/refine-issue.md
+++ b/.claude/commands/refine-issue.md
@@ -46,8 +46,8 @@ This command fetches an existing GitHub plan issue, runs its content through the
 
 **Files created:**
 - `.tmp/issue-{N}-original.md` - Original issue body
-- `.tmp/debate-report-{timestamp}.md` - Combined three-agent report
-- `.tmp/consensus-plan-{timestamp}.md` - Refined consensus plan
+- `.tmp/issue-{N}-debate.md` - Combined three-agent report
+- `.tmp/issue-{N}-consensus.md` - Refined consensus plan
 
 **GitHub issue:**
 - Updated via `gh issue edit {N} --body-file` with refined plan
@@ -209,12 +209,14 @@ Identify unnecessary complexity and propose simpler alternatives."
 
 ### Step 5: Combine Agent Reports
 
-After all three agents complete, combine their outputs into a single debate report:
+After all three agents complete, combine their outputs into a single debate report.
+
+**IMPORTANT:** Use `.tmp/issue-{N}-debate.md` naming for the debate report to enable issue-number invocation of external-consensus.
 
 **Generate combined report:**
 ```bash
 DATETIME=$(date +"%Y-%m-%d %H:%M")
-DEBATE_REPORT_FILE=".tmp/debate-report-$(date +%Y%m%d-%H%M%S).md"
+DEBATE_REPORT_FILE=".tmp/issue-${ISSUE_NUMBER}-debate.md"
 
 {
     echo "# Multi-Agent Debate Report (Refinement)"
@@ -258,19 +260,21 @@ DEBATE_REPORT_FILE=".tmp/debate-report-$(date +%Y%m%d-%H%M%S).md"
 mv "$DEBATE_REPORT_FILE.tmp" "$DEBATE_REPORT_FILE"
 ```
 
-**Note on filename consistency:** Each filename is generated once using inline `$(date ...)` and stored in a variable. These variables are reused in subsequent steps to ensure all references point to the same files.
+**Note on filename consistency:** The debate report uses `issue-${ISSUE_NUMBER}-debate.md` naming to enable issue-number invocation of external-consensus. Agent report files use timestamps to avoid conflicts across multiple refinements.
 
 ### Step 6: Invoke External Consensus Skill
 
 **REQUIRED SKILL CALL:**
 
-Use the Skill tool to invoke the external-consensus skill:
+Use the Skill tool to invoke the external-consensus skill with issue number:
 
 ```
 Skill tool parameters:
   skill: "external-consensus"
-  args: "{DEBATE_REPORT_FILE}"
+  args: "{ISSUE_NUMBER}"
 ```
+
+Note: The skill will resolve `.tmp/issue-{N}-debate.md` from the issue number (created in Step 5).
 
 **What this skill does:**
 1. Reads the combined debate report from `DEBATE_REPORT_FILE`

--- a/.claude/commands/ultra-planner.md
+++ b/.claude/commands/ultra-planner.md
@@ -246,7 +246,9 @@ Identify unnecessary complexity and propose simpler alternatives."
 
 After all three agents complete, **DO NOT** even try to read their outputs!
 Use `cat` and `heredoc` to combine their outputs into a single debate report
-as below:
+as below.
+
+**IMPORTANT:** Use `.tmp/issue-{N}-debate.md` naming for the debate report to enable issue-number invocation of external-consensus.
 
 **Generate combined report:**
 ```bash
@@ -298,13 +300,15 @@ mv "$DEBATE_REPORT_FILE.tmp" "$DEBATE_REPORT_FILE"
 
 **REQUIRED SKILL CALL:**
 
-Use the Skill tool to invoke the external-consensus skill:
+Use the Skill tool to invoke the external-consensus skill with issue number:
 
 ```
 Skill tool parameters:
   skill: "external-consensus"
-  args: "{DEBATE_REPORT_FILE}"
+  args: "{ISSUE_NUMBER}"
 ```
+
+Note: The skill will resolve `.tmp/issue-{N}-debate.md` from the issue number (created in Step 6).
 
 NOTE: This consensus synthesis can take long time depending on the complexity of the debate report.
 Give it 30 minutes timeout to complete, which is mandatory for **ALL DEBATES**!

--- a/.claude/skills/external-consensus/README.md
+++ b/.claude/skills/external-consensus/README.md
@@ -99,15 +99,17 @@ claude -p \
 
 The skill uses a formalized script (`scripts/external-consensus.sh`) that:
 
-1. Validates the debate report file exists
-2. Extracts feature name/description from the report (if not provided)
-3. Loads and processes the prompt template with variable substitution
-4. Checks if Codex is available (prefers Codex, falls back to Claude Opus)
-5. Invokes external AI with appropriate configuration:
+1. Parses input to detect issue number or path mode
+2. Resolves debate report path (`.tmp/issue-{N}-debate.md` if issue number provided)
+3. Validates the debate report file exists
+4. Extracts feature name/description from the report (if not provided)
+5. Loads and processes the prompt template with variable substitution
+6. Checks if Codex is available (prefers Codex, falls back to Claude Opus)
+7. Invokes external AI with appropriate configuration:
    - **Codex**: gpt-5.2-codex, read-only sandbox, web search, xhigh reasoning
    - **Claude**: Opus model, read-only tools (Read, Grep, Glob, WebSearch, WebFetch)
-6. Saves consensus plan to `.tmp/consensus-plan-{timestamp}.md`
-7. Returns the consensus file path for validation and summary extraction
+8. Saves consensus plan to `.tmp/issue-{N}-consensus.md` (issue mode) or `.tmp/consensus-plan-{timestamp}.md` (path mode)
+9. Returns the consensus file path for validation and summary extraction
 
 ## Notes
 

--- a/.claude/skills/external-consensus/SKILL.md
+++ b/.claude/skills/external-consensus/SKILL.md
@@ -114,10 +114,13 @@ When invoked, this skill:
 
 ## Inputs
 
-This skill expects:
-- **Combined report file**: Path to debate report (e.g., `.tmp/debate-report-20251225.md`)
-- **Feature name**: Short name for the feature
-- **Feature description**: Brief description of what user wants to build
+This skill accepts either:
+- **Issue number**: GitHub issue number (e.g., `42`). Resolves to `.tmp/issue-{N}-debate.md`
+- **Combined report file**: Path to debate report (e.g., `.tmp/issue-42-debate.md`)
+
+Optional arguments:
+- **Feature name**: Short name for the feature (auto-extracted if not provided)
+- **Feature description**: Brief description of what user wants to build (auto-extracted if not provided)
 
 ## Outputs
 
@@ -133,10 +136,19 @@ This skill expects:
 Direct invocation - the script handles everything and outputs summary:
 
 ```bash
-# Simple invocation: script auto-extracts feature info and outputs summary
+# Issue-number mode: script resolves .tmp/issue-{N}-debate.md
+.claude/skills/external-consensus/scripts/external-consensus.sh 42
+
+# Issue-number mode with explicit feature name and description (optional)
+.claude/skills/external-consensus/scripts/external-consensus.sh \
+    42 \
+    "Review-Standard Simplification" \
+    "Simplify skill while adding scoring"
+
+# Path mode: traditional invocation (backward compatible)
 .claude/skills/external-consensus/scripts/external-consensus.sh .tmp/issue-42-debate.md
 
-# With explicit feature name and description (optional)
+# Path mode with explicit feature name and description (optional)
 .claude/skills/external-consensus/scripts/external-consensus.sh \
     .tmp/issue-42-debate.md \
     "Review-Standard Simplification" \
@@ -158,7 +170,7 @@ Direct invocation - the script handles everything and outputs summary:
 10. Displays summary information on stderr for user review
 
 **Required inputs:**
-- Path to combined debate report (required)
+- Issue number OR path to combined debate report (required)
 - Feature name (optional, auto-extracted from report)
 - Feature description (optional, auto-extracted from report)
 
@@ -243,6 +255,12 @@ The `external-consensus.sh` script handles most error scenarios internally. Here
 
 The script validates that the debate report file exists. If not, it exits with:
 
+**Issue-number mode:**
+```
+Error: Debate report file not found: .tmp/issue-{N}-debate.md
+```
+
+**Path mode:**
 ```
 Error: Debate report file not found: {file_path}
 ```

--- a/tests/handsoff/test-external-consensus-issue-interface.sh
+++ b/tests/handsoff/test-external-consensus-issue-interface.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Test: external-consensus.sh issue-number and path modes argument parsing
+
+source "$(dirname "$0")/../common.sh"
+
+# Override PROJECT_ROOT to use current worktree instead of AGENTIZE_HOME
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+test_info "Testing external-consensus.sh argument parsing for issue-number and path modes"
+
+# Setup: Create test debate reports
+ISSUE_NUMBER=42
+DEBATE_REPORT_FILE="$PROJECT_ROOT/.tmp/issue-${ISSUE_NUMBER}-debate.md"
+
+mkdir -p "$PROJECT_ROOT/.tmp"
+cat > "$DEBATE_REPORT_FILE" << 'EOF'
+# Multi-Agent Debate Report
+
+**Feature**: Test Feature
+**Generated**: 2026-01-04 12:00
+
+This document combines three perspectives from our multi-agent debate-based planning system.
+EOF
+
+# Test Case 1: Verify issue-number mode resolves correct path
+test_info "Test 1: Issue-number mode path resolution"
+
+# The script should try to read .tmp/issue-42-debate.md when given "42"
+# We verify this by checking that it doesn't fail with "file not found" error
+if timeout 2 "$PROJECT_ROOT/.claude/skills/external-consensus/scripts/external-consensus.sh" "$ISSUE_NUMBER" 2>&1 | grep -q "Error: Debate report file not found"; then
+    test_fail "Issue-number mode: script failed to find debate report at expected path"
+fi
+
+# If the script proceeds past the file check (which it should since we created the file),
+# it will start the external review process. We timeout after 2 seconds, which is expected.
+test_info "✓ Issue-number mode resolved .tmp/issue-{N}-debate.md correctly"
+
+# Test Case 2: Verify path mode accepts explicit paths
+test_info "Test 2: Path mode with explicit debate report path"
+
+PATH_DEBATE_REPORT="$PROJECT_ROOT/.tmp/custom-debate-report.md"
+cp "$DEBATE_REPORT_FILE" "$PATH_DEBATE_REPORT"
+
+if timeout 2 "$PROJECT_ROOT/.claude/skills/external-consensus/scripts/external-consensus.sh" "$PATH_DEBATE_REPORT" 2>&1 | grep -q "Error: Debate report file not found: $PATH_DEBATE_REPORT"; then
+    test_fail "Path mode: script rejected valid debate report path"
+fi
+
+test_info "✓ Path mode accepted explicit debate report path"
+
+# Test Case 3: Error handling for missing debate report
+test_info "Test 3: Error handling for missing debate report in issue-number mode"
+
+MISSING_ISSUE=999
+rm -f "$PROJECT_ROOT/.tmp/issue-${MISSING_ISSUE}-debate.md"
+
+# The script should exit with error and show the resolved path
+if "$PROJECT_ROOT/.claude/skills/external-consensus/scripts/external-consensus.sh" "$MISSING_ISSUE" 2>&1 | grep -q "issue-${MISSING_ISSUE}-debate.md"; then
+    test_info "✓ Error message shows resolved path for missing file"
+else
+    test_fail "Expected error message not shown"
+fi
+
+# Test Case 4: Usage message documents both modes
+test_info "Test 4: Usage message includes both modes"
+
+if "$PROJECT_ROOT/.claude/skills/external-consensus/scripts/external-consensus.sh" 2>&1 | grep -q "issue-number|debate-report-path"; then
+    test_info "✓ Usage message documents both issue-number and path modes"
+else
+    test_fail "Usage message missing dual-mode documentation"
+fi
+
+# Cleanup
+rm -f "$DEBATE_REPORT_FILE" "$PATH_DEBATE_REPORT"
+pkill -9 -f "codex exec" 2>/dev/null || true
+
+test_pass "All external-consensus argument parsing tests passed"


### PR DESCRIPTION
## Summary

Refactored the `external-consensus.sh` script to accept GitHub issue numbers as the primary interface while maintaining full backward compatibility with path-based invocation. Commands can now invoke the skill with `external-consensus 42` instead of `external-consensus .tmp/issue-42-debate.md`, simplifying the interface for `/ultra-planner` and `/refine-issue` workflows.

## Changes

- Modified `.claude/skills/external-consensus/scripts/external-consensus.sh:28-66` to add dual-mode argument parsing:
  - Detects numeric arguments as issue numbers and resolves to `.tmp/issue-{N}-debate.md`
  - Preserves backward compatibility with explicit path arguments
  - Updates usage message and error handling for both modes
- Updated `.claude/skills/external-consensus/SKILL.md:114-255` to document both interface modes:
  - Added issue-number input description
  - Provided usage examples for both modes
  - Updated error handling documentation
- Updated `.claude/skills/external-consensus/README.md:99-112` to reflect dual-mode parsing logic in "How It Works" section
- Modified `.claude/commands/ultra-planner.md:246-309` to use issue-number invocation:
  - Step 6 standardizes debate report naming to `.tmp/issue-{N}-debate.md`
  - Step 7 passes issue number instead of file path
- Modified `.claude/commands/refine-issue.md:46-277` to use issue-number invocation:
  - Step 5 updates debate report filename to issue-based pattern
  - Step 6 passes issue number instead of file path
- Added `tests/handsoff/test-external-consensus-issue-interface.sh` with comprehensive test coverage:
  - Test case 1: Issue-number mode path resolution
  - Test case 2: Path mode backward compatibility
  - Test case 3: Error handling for missing debate reports
  - Test case 4: Usage message validation

## Testing

- Added `tests/handsoff/test-external-consensus-issue-interface.sh` to verify:
  - Issue-number mode correctly resolves `.tmp/issue-{N}-debate.md` paths
  - Path mode accepts explicit debate report paths unchanged
  - Error messages show resolved paths for missing files
  - Usage documentation reflects both modes
- All tests passed successfully with comprehensive coverage of both interface modes
- Code review completed with ✅ APPROVED status

## Related Issue

Closes #225
