### PR TITLE
[refactor][cli][#261] Simplify branch naming to issue-<no> format

### DIFF
--- a/.claude/commands/issue-to-impl.md
+++ b/.claude/commands/issue-to-impl.md
@@ -36,7 +36,7 @@ Orchestrate the complete implementation workflow from a GitHub issue with an imp
 ## Outputs
 
 **Branch created:**
-- New development branch: `issue-{N}-{brief-title}`
+- New development branch: `issue-{N}`
 
 **Files created/modified:**
 - Documentation files (from plan Step 1)
@@ -85,13 +85,11 @@ git branch --show-current
 
 **Otherwise, invoke:** `fork-dev-branch` skill
 **Input:** Issue number from Step 1
-**Output:** New branch `issue-{N}-{brief-title}`, switched to that branch
+**Output:** New branch `issue-{N}`, switched to that branch
 
 **Skill handles:**
-- Fetching issue title via `gh issue view {N} --json title,state`
-- Validating issue exists and is open
-- Creating branch name from title
-- Executing `git checkout -b issue-{N}-{brief-title}`
+- Validating issue exists and is open via `gh issue view {N} --json state`
+- Executing `git checkout -b issue-{N}`
 
 **Error handling:**
 - Issue not found → Stop, display error to user
@@ -371,21 +369,21 @@ Wait for user confirmation before proceeding.
 **Scenario 1: Branch matches requested issue**
 ```bash
 git branch --show-current
-# Output: issue-42-some-feature
+# Output: issue-42
 # Requested issue: 42
 ```
 
 **Response:**
 Step 2 detects match. Step 3 skips branch creation and outputs:
 ```
-Already on issue-42 branch: issue-42-some-feature
+Already on issue-42 branch
 ```
 Continue to Step 4.
 
 **Scenario 2: Branch mismatch (on issue-M, requesting issue-N where M ≠ N)**
 ```bash
 git branch --show-current
-# Output: issue-45-other-feature
+# Output: issue-45
 # Requested issue: 42
 ```
 

--- a/.claude/skills/fork-dev-branch/SKILL.md
+++ b/.claude/skills/fork-dev-branch/SKILL.md
@@ -6,30 +6,26 @@ description: Create a development branch for a given GitHub issue with standardi
 # Fork Dev Branch
 
 This skill instructs AI agents on how to create a development branch for implementing
-a GitHub issue. The branch name follows the standard format: `issue-<number>-<brief-title>`.
+a GitHub issue. The branch name follows the standard format: `issue-<number>`.
 
 ## Branch Naming Convention
 
 Branches created by this skill must follow this exact format:
 
 ```
-issue-<number>-<brief-title>
+issue-<number>
 ```
 
 Where:
 - `<number>`: The GitHub issue number (without the `#` symbol)
-- `<brief-title>`: A brief, hyphen-separated description of the issue
-  - Lowercase only
-  - Use hyphens to separate words
-  - Maximum 5 words (preferably 3-4)
-  - No special characters except hyphens
-  - Must be meaningful and descriptive
 
 **Examples:**
-- `issue-42-add-typescript-support`
-- `issue-15-fix-precommit-hook`
-- `issue-67-create-open-pr-skill`
-- `issue-23-refactor-sdk-templates`
+- `issue-42`
+- `issue-15`
+- `issue-67`
+- `issue-23`
+
+**Rationale:** GitHub issues provide full context (title, description, labels, etc.). Branch names only need the issue number for identification. This simplifies branch creation and treats issues as the single source of truth.
 
 ## Workflow for AI Agents
 
@@ -50,38 +46,17 @@ gh issue view <issue-number> --json state,title
 
 If the issue is closed or doesn't exist, inform the user and abort.
 
-### 2. Generate Branch Title
-
-Fetch the issue details and create a concise branch title:
-
-```bash
-gh issue view <issue-number>
-```
-
-Convert the issue title to branch format:
-- Remove tag prefix (e.g., `[plan][feat]:` → empty)
-- Convert to lowercase, replace spaces with hyphens
-- Remove special characters (except hyphens)
-- Keep 3-5 words maximum
-
-**Title conversion examples:**
-- `[plan][feat]: Add TypeScript SDK support` → `add-typescript-support`
-- `[bugfix]: Pre-commit hook fails` → `fix-precommit-hook`
-- `[agent.skill]: Create open-pr skill` → `create-open-pr-skill`
-
-If unclear or too long, confirm with user before proceeding.
-
-### 3. Create Branch
+### 2. Create Branch
 
 Create and switch to the new branch:
 
 ```bash
-git checkout -b issue-<number>-<brief-title>
+git checkout -b issue-<number>
 ```
 
 Confirm success:
 ```
-Successfully created and switched to branch: issue-<number>-<brief-title>
+Successfully created and switched to branch: issue-<number>
 ```
 
 ## Examples
@@ -96,12 +71,10 @@ User: Create a dev branch for issue #42
 Agent: [Runs gh issue view 42]
 Agent: I'll create a branch for issue #42: "Add TypeScript SDK template support"
 
-Suggested branch name: issue-42-add-typescript-support
-
 Creating branch...
-[Runs: git checkout -b issue-42-add-typescript-support]
+[Runs: git checkout -b issue-42]
 
-Successfully created and switched to branch: issue-42-add-typescript-support
+Successfully created and switched to branch: issue-42
 ```
 
 ### Example 2: Bugfix Branch
@@ -114,12 +87,10 @@ User: fork a branch for #15
 Agent: [Runs gh issue view 15]
 Agent: I'll create a branch for issue #15: "Pre-commit hook fails to run tests"
 
-Suggested branch name: issue-15-fix-precommit-hook
-
 Creating branch...
-[Runs: git checkout -b issue-15-fix-precommit-hook]
+[Runs: git checkout -b issue-15]
 
-Successfully created and switched to branch: issue-15-fix-precommit-hook
+Successfully created and switched to branch: issue-15
 ```
 
 ### Example 3: Error - Invalid Issue Number

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -44,7 +44,7 @@ The milestone skill takes the following inputs (extracted from context):
 
 1. **Current branch context**
    - Branch name (extracted from: `git branch --show-current`)
-   - Must be a development branch matching pattern: `issue-{N}-{brief-title}`
+   - Must be a development branch matching pattern: `issue-{N}` or `issue-{N}-*` (wildcard for backward compatibility)
    - Issue number extracted from branch name
 
 2. **Plan reference**
@@ -372,7 +372,7 @@ Create the file `.milestones/issue-{N}-milestone-{M}.md`:
 ```markdown
 # Milestone {M} for Issue #{N}
 
-**Branch:** issue-{N}-{brief-title}
+**Branch:** issue-{N}
 **Created:** {current-datetime}
 **LOC Implemented:** ~{cumulative_loc} lines
 **Test Status:** {passed}/{total} tests passed
@@ -541,14 +541,14 @@ All 8 tests passing. Ready for code review.
 git branch --show-current
 ```
 
-If branch does not match pattern `issue-{N}-*`:
+If branch does not match pattern `issue-{N}` or `issue-{N}-*`:
 
 ```
 Error: Not on a development branch.
 
 Current branch: {branch-name}
 
-You must be on a development branch (issue-{N}-{brief-title}) to use the milestone skill.
+You must be on a development branch (issue-{N}) to use the milestone skill.
 
 Please run /issue-to-impl to start implementation on a proper development branch.
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ General-purpose git worktree helper for **bare repositories**:
 wt init                  # Initialize worktree environment (run once per bare repo)
 wt goto main             # Change directory to main worktree
 wt goto 42               # Change directory to issue-42 worktree
-wt spawn 42              # Create worktree for issue #42
+wt spawn 42              # Create issue-42 branch and worktree
 wt list                  # List all worktrees
 wt remove 42             # Remove worktree for issue #42
 wt prune                 # Clean up stale worktree metadata

--- a/docs/cli/wt.md
+++ b/docs/cli/wt.md
@@ -24,8 +24,8 @@ After running `make setup` and sourcing `setup.sh`, the `wt` command is availabl
   - Uses `WT_DEFAULT_BRANCH` environment variable if set, otherwise defaults to `main` or `master`
 - `wt goto <issue-no>|main`: changes directory to the worktree target
   - `wt goto main`: changes to `trees/main`
-  - `wt goto <issue-no>`: changes to `trees/issue-<issue-no>-*`
-  - Both `main` and `issue-<issue-no>-` should be auto-completable
+  - `wt goto <issue-no>`: changes to `trees/issue-<issue-no>` (wildcard pattern `issue-<issue-no>*` used for compatibility)
+  - Both `main` and `issue-<issue-no>` should be auto-completable
 - `wt spawn <issue-no>`: create a new worktree for the given issue number from the `main` branch
   - Before creating the worktree, it rebases onto the latest default branch from the bare repo
   - `--no-agent`: skip automatic Claude invocation after worktree creation
@@ -118,8 +118,8 @@ $ wt --complete spawn-flags
 
 $ wt --complete goto-targets
 main
-issue-42-add-feature
-issue-45-fix-bug
+issue-42
+issue-45
 ```
 
 This helper is used by the zsh completion system and can be used by other shells in the future.

--- a/docs/tutorial/02-issue-to-impl.md
+++ b/docs/tutorial/02-issue-to-impl.md
@@ -36,7 +36,7 @@ Replace `42` with your issue number from Tutorial 01.
 When you run `/issue-to-impl`:
 
 **1. Branch Creation**
-- Creates: `issue-42-brief-description`
+- Creates: `issue-42`
 - Switches to that branch
 
 **2. Sync with origin/<default>**
@@ -71,7 +71,7 @@ When you run `/issue-to-impl`:
 ```
 User: /issue-to-impl 42
 
-Agent: Creating branch issue-42-add-typescript-support...
+Agent: Creating branch issue-42...
 Agent: Syncing with origin/main...
   - Fetched latest changes
   - Rebased onto origin/main (clean)
@@ -209,7 +209,7 @@ User: Continue from the latest milestone
 [... Successfully synchronized ...]
 
 # 5. Rebase your branch
-git checkout issue-42-add-typescript-support
+git checkout issue-42
 git rebase main
 
 # 6. Create PR
@@ -260,7 +260,7 @@ See `docs/milestone-workflow.md` for complete documentation.
 
 **"Not on development branch"**
 - You're on `main` or wrong branch
-- Solution: Run `git checkout issue-42-brief-title` or start with `/issue-to-impl`
+- Solution: Run `git checkout issue-42` or start with `/issue-to-impl`
 
 **"Rebase conflict detected"**
 - Your changes conflict with main branch

--- a/docs/workflows/milestone.md
+++ b/docs/workflows/milestone.md
@@ -78,7 +78,7 @@ Milestone documents are stored in `.milestones/issue-{N}-milestone-{M}.md` where
 ```markdown
 # Milestone {M} for Issue #{N}
 
-**Branch:** issue-{N}-{brief-title}
+**Branch:** issue-{N}
 **Created:** YYYY-MM-DD HH:MM:SS
 **LOC Implemented:** ~XXX lines
 **Test Status:** X/Y tests passed
@@ -146,7 +146,7 @@ If issue number is not provided, it will be extracted from conversation context.
 **Example:**
 ```
 User: /issue-to-impl 42
-Agent: Creating branch for issue #42...
+Agent: Creating branch issue-42...
 Agent: Updating documentation...
 Agent: Creating test cases...
 Agent: Creating Milestone 1 (0/8 tests pass)...
@@ -219,7 +219,7 @@ User: /open-issue
 ```
 User: /issue-to-impl 42
 
-Agent: Creating branch issue-42-add-typescript-support...
+Agent: Creating branch issue-42...
 Agent: Updating documentation...
   - docs/typescript-support.md created
   - README.md updated
@@ -350,7 +350,7 @@ You're trying to resume from a milestone on a branch without milestones.
 
 You're on `main` or another non-development branch.
 
-**Solution**: Switch to your development branch (issue-{N}-*) or start with `/issue-to-impl`.
+**Solution**: Switch to your development branch (issue-{N}) or start with `/issue-to-impl`.
 
 ### "Milestone file corrupted"
 

--- a/src/cli/wt.sh
+++ b/src/cli/wt.sh
@@ -269,22 +269,8 @@ cmd_spawn() {
     local default_branch
     default_branch=$(wt_get_default_branch)
 
-    # Get issue title for branch name
+    # Create branch name from issue number only
     local branch_name="issue-$issue_no"
-    if command -v gh >/dev/null 2>&1; then
-        local issue_title
-        issue_title=$(gh issue view "$issue_no" --json title --jq '.title' 2>/dev/null | \
-                      tr '[:upper:]' '[:lower:]' | \
-                      sed 's/[^a-z0-9]/-/g' | \
-                      sed 's/--*/-/g' | \
-                      sed 's/^-//' | \
-                      sed 's/-$//' | \
-                      cut -c1-50)
-
-        if [ -n "$issue_title" ]; then
-            branch_name="issue-$issue_no-$issue_title"
-        fi
-    fi
 
     local worktree_path="$trees_dir/$branch_name"
 


### PR DESCRIPTION
## Summary

Simplified branch naming convention from `issue-<no>-<brief-title>` to `issue-<no>` format across the entire codebase. This change removes unnecessary complexity (~15 LOC) by treating GitHub issues as the single source of truth for context, while maintaining backward compatibility through wildcard pattern matching.

## Changes

- Modified `src/cli/wt.sh:272-273` to remove title fetching/sanitization logic and use `issue-$issue_no` unconditionally
- Updated `.claude/skills/fork-dev-branch/SKILL.md` to document minimal `issue-{N}` format and remove title generation workflow
- Modified `.claude/skills/milestone/SKILL.md` to accept both `issue-{N}` and `issue-{N}-*` patterns for backward compatibility
- Updated `.claude/commands/issue-to-impl.md` to reflect simplified branch naming in all workflow steps
- Modified `README.md` to update `wt` command examples with simplified format
- Updated `docs/cli/wt.md` to use `issue-<no>` examples and document wildcard compatibility
- Modified `docs/tutorial/02-issue-to-impl.md` to update all tutorial examples with `issue-42` format
- Updated `docs/workflows/milestone.md` to reflect minimal branch naming in milestone documentation

## Testing

- Verified all 72 existing tests pass in both bash and zsh
- No new tests required - existing `test-wt-goto.sh` validates wildcard pattern resolution works with both old and new formats
- Manual verification that `wt spawn 42` creates `issue-42` branch (not `issue-42-title`)

## Related Issue

Closes #261