### PR TITLE
[cli][docs] Remove redundant wt main legacy alias

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -75,7 +75,7 @@ This development workflow uses bare repos for multiple worktrees:
 
 ### Worktree Management
 
-- Switch to main worktree: `wt main`
+- Switch to main worktree: `wt goto main`
 - Create worktree for issue: `wt spawn <issue-number>`
   - NOTE: `spawn` is an all-in-one command that creates the worktree, `cd`s into it, and launches Claude Code with the issue implementation prompt
   - Example: `wt spawn 42`

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -17,7 +17,7 @@ The `install` script for one-command Agentize installation. Documents installati
 The `lol` command interface for creating AI-powered SDKs and managing GitHub Projects v2. Documents `lol apply` (unified init/update entrypoint), `lol init` (SDK initialization), `lol update` (SDK updates), `lol upgrade` (agentize installation upgrade), `lol version` (version information), `lol project` (GitHub Projects integration), all command flags (--name, --lang, --path, --source, --metadata-only, --create, --associate, --automation, --init, --update), template system integration, and zsh completion support.
 
 ### wt.md
-The `wt` command interface for git worktree management. Documents `wt init` (worktree initialization), `wt spawn` (issue-based worktree creation), `wt main` (switch to main worktree), `.agentize.yaml` metadata integration, and zsh completion support.
+The `wt` command interface for git worktree management. Documents `wt init` (worktree initialization), `wt spawn` (issue-based worktree creation), `wt goto` (navigate to worktrees), `.agentize.yaml` metadata integration, and zsh completion support.
 
 ## Usage
 

--- a/src/cli/wt.sh
+++ b/src/cli/wt.sh
@@ -584,10 +584,6 @@ wt() {
                     ;;
             esac
             ;;
-        main)
-            # Legacy alias for goto main
-            cmd_goto "main" "$@"
-            ;;
         *)
             echo "Error: Unknown command: $command" >&2
             echo "Run 'wt help' for usage information" >&2


### PR DESCRIPTION
## Summary

- Remove undocumented `wt main` legacy alias from `src/cli/wt.sh`
- Update `docs/architecture/architecture.md` to reference `wt goto main`
- Update `docs/cli/README.md` to reference `wt goto` command

## Test plan

- [x] Verify `wt main` returns "Error: Unknown command: main"
- [x] Verify `wt goto main` continues to work
- [x] Run existing tests (`test-wt-goto.sh`, `test-wt-complete-commands.sh`)
- [x] Run full test suite (`TEST_SHELLS="bash zsh" make test`) - 77/77 tests pass

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
