### PR TITLE
[refactor][cli]: Convert lol_cmd_* functions to pure positional arguments

### DIFF
--- a/scripts/agentize-project.sh
+++ b/scripts/agentize-project.sh
@@ -4,7 +4,7 @@
 # This is a compatibility wrapper that delegates to the canonical implementation
 # in src/cli/lol.sh. Direct script execution is preserved for backwards compatibility.
 #
-# Environment variables:
+# Environment variables (for backward compatibility - will be converted to positional args):
 #   AGENTIZE_PROJECT_MODE      - Mode (create, associate, automation)
 #   AGENTIZE_PROJECT_ORG       - Organization (for create)
 #   AGENTIZE_PROJECT_TITLE     - Project title (for create)
@@ -30,5 +30,20 @@ else
     exit 1
 fi
 
-# Execute the project command
-lol_cmd_project
+# Convert environment variables to positional arguments for backward compatibility
+# lol_cmd_project <mode> [arg1] [arg2]
+case "$AGENTIZE_PROJECT_MODE" in
+    create)
+        lol_cmd_project "create" "$AGENTIZE_PROJECT_ORG" "$AGENTIZE_PROJECT_TITLE"
+        ;;
+    associate)
+        lol_cmd_project "associate" "$AGENTIZE_PROJECT_ASSOCIATE"
+        ;;
+    automation)
+        lol_cmd_project "automation" "$AGENTIZE_PROJECT_WRITE_PATH"
+        ;;
+    *)
+        echo "Error: AGENTIZE_PROJECT_MODE must be set to 'create', 'associate', or 'automation'" >&2
+        exit 1
+        ;;
+esac

--- a/src/cli/lol.md
+++ b/src/cli/lol.md
@@ -100,12 +100,17 @@ Subshell command functions called by main dispatcher. Each runs in a subshell to
 
 Initialize new SDK project with templates.
 
-**Environment variables (set by lol()):**
-- `AGENTIZE_PROJECT_NAME`: Project name (required)
-- `AGENTIZE_PROJECT_LANG`: Project language (required)
-- `AGENTIZE_PROJECT_PATH`: Target path (defaults to current directory)
-- `AGENTIZE_SOURCE_PATH`: Source code path (optional)
-- `AGENTIZE_METADATA_ONLY`: If "1", create only metadata file
+**Signature:**
+```bash
+lol_cmd_init <project_path> <project_name> <project_lang> [source_path] [metadata_only]
+```
+
+**Parameters:**
+- `project_path`: Target project directory path (required)
+- `project_name`: Project name for template substitutions (required)
+- `project_lang`: Project language - python, c, cxx (required)
+- `source_path`: Source code path relative to project root (optional, defaults to "src")
+- `metadata_only`: If "1", create only metadata file (optional, defaults to "0")
 
 **Operations:**
 1. Validate required parameters
@@ -124,8 +129,13 @@ Initialize new SDK project with templates.
 
 Update existing project with latest agentize configuration.
 
-**Environment variables (set by lol()):**
-- `AGENTIZE_PROJECT_PATH`: Target path (required)
+**Signature:**
+```bash
+lol_cmd_update <project_path>
+```
+
+**Parameters:**
+- `project_path`: Target project directory path (required)
 
 **Operations:**
 1. Validate project path exists
@@ -163,12 +173,20 @@ Upgrade agentize installation via git pull.
 
 GitHub Projects v2 integration.
 
-**Environment variables (set by lol()):**
-- `AGENTIZE_PROJECT_MODE`: Mode (create, associate, automation)
-- `AGENTIZE_PROJECT_ORG`: Organization (for create)
-- `AGENTIZE_PROJECT_TITLE`: Project title (for create)
-- `AGENTIZE_PROJECT_ASSOCIATE`: org/id argument (for associate)
-- `AGENTIZE_PROJECT_WRITE_PATH`: Output path (for automation)
+**Signature:**
+```bash
+lol_cmd_project <mode> [arg1] [arg2] [arg3]
+```
+
+**Parameters:**
+- `mode`: Operation mode - create, associate, automation (required)
+- For `create` mode:
+  - `arg1`: Organization (optional, defaults to repo owner)
+  - `arg2`: Project title (optional, defaults to repo name)
+- For `associate` mode:
+  - `arg1`: org/id argument (required, e.g., "Synthesys-Lab/3")
+- For `automation` mode:
+  - `arg1`: Write path for workflow file (optional, outputs to stdout if not specified)
 
 **Modes:**
 

--- a/tests/cli/test-agentize-modes-init-empty-dir.sh
+++ b/tests/cli/test-agentize-modes-init-empty-dir.sh
@@ -10,10 +10,7 @@ TMP_DIR=$(make_temp_dir "mode-test-init-empty-dir")
 # Creating SDK in empty existing directory
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_mode_2"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_mode_2" "python"
 )
 
 if [ ! -d "$TMP_DIR/.claude" ]; then

--- a/tests/cli/test-agentize-modes-init-nonempty-dir-fails.sh
+++ b/tests/cli/test-agentize-modes-init-nonempty-dir-fails.sh
@@ -11,10 +11,7 @@ touch "$TMP_DIR/existing-file.txt"
 # Attempting to create SDK in non-empty directory (should fail)
 if (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_mode_3"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_mode_3" "python"
 ) 2>&1 | grep -q "exists and is not empty"; then
     cleanup_dir "$TMP_DIR"
     test_pass "init mode correctly rejects non-empty directory"

--- a/tests/cli/test-agentize-modes-init-nonexistent-dir.sh
+++ b/tests/cli/test-agentize-modes-init-nonexistent-dir.sh
@@ -11,10 +11,7 @@ rm -rf "$TMP_DIR"
 # Creating SDK in non-existent directory
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_mode_1"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_mode_1" "python"
 )
 
 if [ ! -d "$TMP_DIR" ]; then

--- a/tests/cli/test-agentize-modes-update-creates-claude.sh
+++ b/tests/cli/test-agentize-modes-update-creates-claude.sh
@@ -11,8 +11,7 @@ touch "$TMP_DIR/some-file.txt"
 # Updating directory without SDK structure (should create .claude/)
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 )
 
 # Verify .claude/ was created

--- a/tests/cli/test-agentize-modes-update-nonexistent-dir-fails.sh
+++ b/tests/cli/test-agentize-modes-update-nonexistent-dir-fails.sh
@@ -11,8 +11,7 @@ rm -rf "$TMP_DIR"
 # Attempting to update non-existent directory (should fail)
 if (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 ) 2>&1 | grep -q "does not exist"; then
     test_pass "update mode correctly rejects non-existent directory"
 else

--- a/tests/cli/test-agentize-modes-update-preserves-user-files.sh
+++ b/tests/cli/test-agentize-modes-update-preserves-user-files.sh
@@ -10,10 +10,7 @@ TMP_DIR=$(make_temp_dir "mode-test-update-preserves-user-files")
 # First creating a valid SDK
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_mode_7"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_mode_7" "python"
 )
 
 # Add custom user files
@@ -25,8 +22,7 @@ echo "# My Custom Command" > "$TMP_DIR/.claude/commands/my-custom-command/COMMAN
 # Running update to sync template files
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 )
 
 # Verify custom user files still exist

--- a/tests/cli/test-agentize-modes-update-valid-sdk.sh
+++ b/tests/cli/test-agentize-modes-update-valid-sdk.sh
@@ -10,10 +10,7 @@ TMP_DIR=$(make_temp_dir "mode-test-update-valid-sdk")
 # First creating a valid SDK
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_mode_6"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_mode_6" "python"
 )
 
 # Modify a file in .claude/ to verify backup
@@ -22,8 +19,7 @@ echo "# Modified by test" >> "$TMP_DIR/.claude/settings.json"
 # Now updating the SDK
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 )
 
 # Verify backup was created

--- a/tests/lint/test-makefile-init-invalid-lang.sh
+++ b/tests/lint/test-makefile-init-invalid-lang.sh
@@ -12,10 +12,7 @@ OUTPUT_FILE="$TMP_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="rust"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_proj" "rust"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e

--- a/tests/lint/test-makefile-init-without-lang.sh
+++ b/tests/lint/test-makefile-init-without-lang.sh
@@ -12,24 +12,23 @@ OUTPUT_FILE="$TMP_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_init
+    # Call without lang parameter - should fail
+    lol_cmd_init "$TMP_DIR" "test_proj"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e
 
 # Verify it failed
 if [ $exit_code -ne 0 ]; then
-    # Check error message mentions LANG requirement
-    if grep -q "AGENTIZE_PROJECT_LANG" "$OUTPUT_FILE"; then
+    # Check error message mentions lang requirement
+    if grep -q "project_lang is required" "$OUTPUT_FILE"; then
         cleanup_dir "$TMP_DIR"
-        test_pass "Init mode correctly requires AGENTIZE_PROJECT_LANG parameter"
+        test_pass "Init mode correctly requires project_lang parameter"
     else
         cleanup_dir "$TMP_DIR"
-        test_fail "Error message doesn't mention AGENTIZE_PROJECT_LANG requirement"
+        test_fail "Error message doesn't mention project_lang requirement"
     fi
 else
     cleanup_dir "$TMP_DIR"
-    test_fail "Init mode should fail without AGENTIZE_PROJECT_LANG, but succeeded"
+    test_fail "Init mode should fail without project_lang, but succeeded"
 fi

--- a/tests/lint/test-makefile-update-creates-git-tags.sh
+++ b/tests/lint/test-makefile-update-creates-git-tags.sh
@@ -13,11 +13,7 @@ OUTPUT_FILE="$OUTPUT_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_proj" "python"
 ) > "$OUTPUT_FILE" 2>&1
 setup_exit=$?
 set -e
@@ -35,9 +31,7 @@ rm -f "$TMP_DIR/docs/git-msg-tags.md"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e

--- a/tests/lint/test-makefile-update-infers-lang.sh
+++ b/tests/lint/test-makefile-update-infers-lang.sh
@@ -13,11 +13,7 @@ OUTPUT_FILE="$OUTPUT_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_proj" "python"
 ) > "$OUTPUT_FILE" 2>&1
 setup_exit=$?
 set -e
@@ -35,9 +31,7 @@ rm -f "$TMP_DIR/docs/git-msg-tags.md"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e

--- a/tests/lint/test-makefile-update-preserves-git-tags.sh
+++ b/tests/lint/test-makefile-update-preserves-git-tags.sh
@@ -13,11 +13,7 @@ OUTPUT_FILE="$OUTPUT_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="c"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_proj" "c"
 ) > "$OUTPUT_FILE" 2>&1
 setup_exit=$?
 set -e
@@ -36,9 +32,7 @@ echo "custom-tag: Custom modification description" >> "$TMP_DIR/docs/git-msg-tag
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e

--- a/tests/lint/test-makefile-update-without-lang.sh
+++ b/tests/lint/test-makefile-update-without-lang.sh
@@ -13,11 +13,7 @@ OUTPUT_FILE="$OUTPUT_DIR/output.txt"
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_NAME="test_proj"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_proj" "python"
 ) > "$OUTPUT_FILE" 2>&1
 setup_exit=$?
 set -e
@@ -32,9 +28,7 @@ fi
 set +e
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_HOME="$PROJECT_ROOT"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    lol_cmd_update
+    lol_cmd_update "$TMP_DIR"
 ) > "$OUTPUT_FILE" 2>&1
 exit_code=$?
 set -e

--- a/tests/sdk/test-c-sdk-custom-lib.sh
+++ b/tests/sdk/test-c-sdk-custom-lib.sh
@@ -10,11 +10,7 @@ TMP_DIR=$(make_temp_dir "c-sdk-test-lib")
 # Creating C SDK with custom source path (lib/)
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-c-sdk-lib"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="c"
-    export AGENTIZE_SOURCE_PATH="lib"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test-c-sdk-lib" "c" "lib"
 )
 
 # Verify lib/ directory exists and src/ does not

--- a/tests/sdk/test-c-sdk-default-src.sh
+++ b/tests/sdk/test-c-sdk-default-src.sh
@@ -10,10 +10,7 @@ TMP_DIR=$(make_temp_dir "c-sdk-test-src")
 # Creating C SDK with default source path
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-c-sdk-src"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="c"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test-c-sdk-src" "c"
 )
 
 # Verify src/ directory exists

--- a/tests/sdk/test-c-sdk.sh
+++ b/tests/sdk/test-c-sdk.sh
@@ -22,10 +22,7 @@ rm -rf "$TMP_DIR_SRC"
 echo "Creating C SDK with default source path..."
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-c-sdk-src"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR_SRC"
-    export AGENTIZE_PROJECT_LANG="c"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR_SRC" "test-c-sdk-src" "c"
 )
 
 # Verify src/ directory exists
@@ -99,11 +96,7 @@ rm -rf "$TMP_DIR_LIB"
 echo "Creating C SDK with custom source path (lib/)..."
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-c-sdk-lib"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR_LIB"
-    export AGENTIZE_PROJECT_LANG="c"
-    export AGENTIZE_SOURCE_PATH="lib"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR_LIB" "test-c-sdk-lib" "c" "lib"
 )
 
 # Verify lib/ directory exists and src/ does not

--- a/tests/sdk/test-cxx-sdk-custom-lib.sh
+++ b/tests/sdk/test-cxx-sdk-custom-lib.sh
@@ -10,11 +10,7 @@ TMP_DIR=$(make_temp_dir "cxx-sdk-test-lib")
 # Creating C++ SDK with custom source path (lib/)
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-cxx-sdk-lib"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="cxx"
-    export AGENTIZE_SOURCE_PATH="lib"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test-cxx-sdk-lib" "cxx" "lib"
 )
 
 # Verify lib/ directory exists and src/ does not

--- a/tests/sdk/test-cxx-sdk-default-src.sh
+++ b/tests/sdk/test-cxx-sdk-default-src.sh
@@ -10,10 +10,7 @@ TMP_DIR=$(make_temp_dir "cxx-sdk-test-src")
 # Creating C++ SDK with default source path
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-cxx-sdk-src"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="cxx"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test-cxx-sdk-src" "cxx"
 )
 
 # Verify src/ directory exists

--- a/tests/sdk/test-cxx-sdk.sh
+++ b/tests/sdk/test-cxx-sdk.sh
@@ -22,10 +22,7 @@ rm -rf "$TMP_DIR_SRC"
 echo "Creating C++ SDK with default source path..."
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-cxx-sdk-src"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR_SRC"
-    export AGENTIZE_PROJECT_LANG="cxx"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR_SRC" "test-cxx-sdk-src" "cxx"
 )
 
 # Verify src/ directory exists
@@ -99,11 +96,7 @@ rm -rf "$TMP_DIR_LIB"
 echo "Creating C++ SDK with custom source path (lib/)..."
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test-cxx-sdk-lib"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR_LIB"
-    export AGENTIZE_PROJECT_LANG="cxx"
-    export AGENTIZE_SOURCE_PATH="lib"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR_LIB" "test-cxx-sdk-lib" "cxx" "lib"
 )
 
 # Verify lib/ directory exists and src/ does not

--- a/tests/sdk/test-python-sdk.sh
+++ b/tests/sdk/test-python-sdk.sh
@@ -16,10 +16,7 @@ rm -rf "$TMP_DIR"
 echo "Creating Python SDK..."
 (
     source "$PROJECT_ROOT/scripts/lol-cli.sh"
-    export AGENTIZE_PROJECT_NAME="test_python_sdk"
-    export AGENTIZE_PROJECT_PATH="$TMP_DIR"
-    export AGENTIZE_PROJECT_LANG="python"
-    lol_cmd_init
+    lol_cmd_init "$TMP_DIR" "test_python_sdk" "python"
 )
 
 # Verify test_python_sdk/ directory exists (project_name renamed)


### PR DESCRIPTION
## Summary

- Refactor internal `lol_cmd_*` shell function interfaces to use **only positional arguments** with no environment variable fallbacks
- Update all 20+ test files to call functions with positional args directly
- Update documentation to reflect new function signatures

## Changes

### Core Implementation (`src/cli/lol.sh`)
- `lol_cmd_init()` now accepts: `<project_path> <project_name> <project_lang> [source_path] [metadata_only]`
- `lol_cmd_update()` now accepts: `<project_path>`
- `lol_cmd_project()` now accepts: `<mode> [arg1] [arg2]`
- Parser functions handle CLI arg processing and call commands with positional args

### Documentation (`src/cli/lol.md`)
- Updated function signatures to document positional parameters

### Wrapper Script (`scripts/agentize-project.sh`)
- Added env-var-to-positional-arg conversion for backward compatibility

### Test Files (20 files updated)
- Converted from `export AGENTIZE_PROJECT_*; lol_cmd_*` to `lol_cmd_* "$arg1" "$arg2" ...`

## What's Preserved
- `AGENTIZE_HOME` global env var (like `$PATH`)
- `AGENTIZE_GH_API` test fixture infrastructure
- E2E tests use wrapper script which handles env var conversion

## Test plan

- [x] All 77 tests pass in bash
- [x] All 77 tests pass in zsh
- [x] Code quality review passed

🤖 Generated with [Claude Code](https://claude.ai/code)
