### PR TITLE
[bugfix][hooks][tests] Fix Telegram test isolation - guard API requests

### DIFF
--- a/python/agentize/README.md
+++ b/python/agentize/README.md
@@ -50,3 +50,7 @@ The permission module evaluates Claude Code tool use requests and returns allow/
 | `TG_APPROVAL_TIMEOUT_SEC` | Telegram approval timeout (default: 60) |
 | `TG_POLL_INTERVAL_SEC` | Telegram polling interval (default: 5) |
 | `TG_ALLOWED_USER_IDS` | Comma-separated list of allowed Telegram user IDs |
+
+### Test Isolation
+
+Tests automatically clear Telegram-related environment variables (`AGENTIZE_USE_TG`, `TG_API_TOKEN`, `TG_CHAT_ID`, `TG_ALLOWED_USER_IDS`, `TG_APPROVAL_TIMEOUT_SEC`, `TG_POLL_INTERVAL_SEC`) via `tests/common.sh` to prevent external API calls during test runs. The Telegram API request functions also include an internal guard that returns `None` immediately when Telegram is disabled.

--- a/python/agentize/permission/determine.py
+++ b/python/agentize/permission/determine.py
@@ -157,8 +157,12 @@ def _tg_api_request(token: str, method: str, payload: Optional[Dict[str, Any]] =
         session_id: Session ID for logging (optional)
 
     Returns:
-        dict: API response or None on error
+        dict: API response or None on error/disabled
     """
+    # Safety guard: return immediately if Telegram is disabled
+    if not _is_telegram_enabled():
+        return None
+
     url = f'https://api.telegram.org/bot{token}/{method}'
     try:
         if payload:

--- a/tests/cli/test-hook-permission-matching.sh
+++ b/tests/cli/test-hook-permission-matching.sh
@@ -198,4 +198,21 @@ print(f'{action}:{msg_id}')
 ")
 [ "$result" = "deny:67890" ] || test_fail "Expected 'deny:67890', got '$result'"
 
+# Test 17: _tg_api_request guard - returns None when Telegram is disabled
+test_info "Test 17: _tg_api_request returns None when Telegram disabled"
+guard_result=$(python3 -c "
+import os
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/python')
+# Ensure Telegram is disabled
+os.environ.pop('AGENTIZE_USE_TG', None)
+from agentize.permission.determine import _tg_api_request, _is_telegram_enabled
+# Verify Telegram is disabled
+assert not _is_telegram_enabled(), 'Telegram should be disabled'
+# Call _tg_api_request - should return None without making any HTTP request
+result = _tg_api_request('fake_token', 'sendMessage', {'chat_id': '123', 'text': 'test'})
+print('None' if result is None else 'ERROR')
+")
+[ "$guard_result" = "None" ] || test_fail "Expected 'None' when Telegram disabled, got '$guard_result'"
+
 test_pass "PreToolUse hook permission matching works correctly"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -5,6 +5,13 @@
 set -e
 
 # ============================================================
+# Test isolation: Clear Telegram environment variables
+# ============================================================
+# Prevents tests from accidentally sending Telegram API requests
+# when developer environments have these variables set
+unset AGENTIZE_USE_TG TG_API_TOKEN TG_CHAT_ID TG_ALLOWED_USER_IDS TG_APPROVAL_TIMEOUT_SEC TG_POLL_INTERVAL_SEC
+
+# ============================================================
 # Project root detection
 # ============================================================
 


### PR DESCRIPTION
## Summary

- Fix Telegram test isolation by clearing TG_* environment variables in tests/common.sh
- Add defense-in-depth guards in _tg_api_request() and tg_api_request() functions
- Add Test 17 to verify guard behavior returns None when Telegram is disabled
- Document test isolation behavior in python/agentize/README.md

## Test plan

- [x] Run `tests/cli/test-hook-permission-matching.sh` - All 17 tests pass including new Test 17
- [x] Run `TEST_SHELLS="bash zsh" make test` - All 77 tests pass in both shells
- [x] Verify guard returns None without making HTTP requests when Telegram is disabled

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
