### PR TITLE
[bugfix][hooks] Fix TG_APPROVAL_TIMEOUT_SEC not applied correctly

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use.py"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use.py",
+            "timeout": 7200
           }
         ]
       }

--- a/docs/workflows/handsoff.md
+++ b/docs/workflows/handsoff.md
@@ -97,7 +97,8 @@ When configured, enables remote approval of tool usage via Telegram. When a PreT
 **`TG_APPROVAL_TIMEOUT_SEC`**
 - **Purpose:** Maximum wait time for Telegram response
 - **Default:** `60` seconds
-- **Example:** `export TG_APPROVAL_TIMEOUT_SEC=120`
+- **Maximum:** `7200` seconds (2 hours) - limited by hook timeout in `.claude/settings.json`
+- **Example:** `export TG_APPROVAL_TIMEOUT_SEC=1800` (30 minutes)
 
 **`TG_POLL_INTERVAL_SEC`**
 - **Purpose:** Interval between Telegram API polls


### PR DESCRIPTION
## Summary

- Add `timeout: 7200` to PreToolUse hook configuration to allow hook execution up to 2 hours
- Update documentation to clarify `TG_APPROVAL_TIMEOUT_SEC` maximum value and provide realistic example

## Problem

The `TG_APPROVAL_TIMEOUT_SEC` environment variable was not being applied correctly. When set to 1800 seconds (30 minutes), the timeout still ended at 60 seconds because Claude Code's default hook execution timeout would kill the `pre-tool-use.py` process before the internal polling could complete.

## Solution

Added explicit `timeout: 7200` to the PreToolUse hook configuration in `.claude/settings.json`, matching the existing `BASH_MAX_TIMEOUT_MS` ceiling. This allows users to configure Telegram approval windows up to 2 hours.

## Test plan

- [x] All 77 tests pass (`TEST_SHELLS="bash" make test`)
- [x] Code quality review passed
- [ ] Manual verification: Set `TG_APPROVAL_TIMEOUT_SEC=120` and confirm approval window stays open beyond 60 seconds

Closes #312

🤖 Generated with [Claude Code](https://claude.ai/code)
