### PR TITLE
[refactor] Consolidate shell function invocation utilities

### DIFF
--- a/python/agentize/README.md
+++ b/python/agentize/README.md
@@ -9,6 +9,9 @@ python/agentize/
 ├── __init__.py           # Package root
 ├── cli.py                # Python CLI entrypoint (python -m agentize.cli)
 ├── cli.md                # CLI interface documentation
+├── shell.py              # Shared shell function invocation utilities
+├── server/               # Polling server module
+│   └── __main__.py       # Server entry point (python -m agentize.server)
 └── permission/           # PreToolUse hook permission module
     ├── __init__.py       # Exports determine()
     ├── determine.py      # Main permission logic
@@ -25,7 +28,22 @@ python/agentize/
 python -m agentize.cli <command> [options]
 ```
 
-The Python CLI delegates to shell functions via `bash -lc` with `AGENTIZE_HOME` set. It provides argparse-style parsing while preserving shell as the canonical implementation. See `cli.md` for interface details.
+The Python CLI delegates to shell functions via the shared `shell.py` module with `AGENTIZE_HOME` set. It provides argparse-style parsing while preserving shell as the canonical implementation. See `cli.md` for interface details.
+
+### Shell Utilities
+
+```python
+from agentize.shell import get_agentize_home, run_shell_function
+
+# Auto-detect AGENTIZE_HOME
+home = get_agentize_home()
+
+# Run shell functions with AGENTIZE_HOME set
+result = run_shell_function("wt spawn 123", capture_output=True)
+print(result.returncode, result.stdout)
+```
+
+The `shell.py` module provides a unified interface for invoking shell functions from Python. It handles `AGENTIZE_HOME` auto-detection and sources `setup.sh` before running commands.
 
 ### Permission Module
 

--- a/python/agentize/cli.py
+++ b/python/agentize/cli.py
@@ -11,42 +11,14 @@ Usage:
 
 import argparse
 import os
-import subprocess
 import sys
-from pathlib import Path
 
-
-def get_agentize_home() -> str:
-    """Get AGENTIZE_HOME from environment or derive from repo root."""
-    if "AGENTIZE_HOME" in os.environ:
-        return os.environ["AGENTIZE_HOME"]
-
-    # Try to derive from this file's location
-    # cli.py is at python/agentize/cli.py, so repo root is ../../..
-    cli_path = Path(__file__).resolve()
-    repo_root = cli_path.parent.parent.parent
-    if (repo_root / "Makefile").exists() and (repo_root / "src" / "cli" / "lol.sh").exists():
-        return str(repo_root)
-
-    raise RuntimeError(
-        "AGENTIZE_HOME not set and could not be derived.\n"
-        "Please set AGENTIZE_HOME to point to your agentize repository."
-    )
+from agentize.shell import get_agentize_home, run_shell_function
 
 
 def run_shell_command(cmd: str, agentize_home: str) -> int:
     """Run a shell command with AGENTIZE_HOME set."""
-    env = os.environ.copy()
-    env["AGENTIZE_HOME"] = agentize_home
-
-    # Source setup.sh and run the command
-    full_cmd = f'source "$AGENTIZE_HOME/setup.sh" && {cmd}'
-
-    result = subprocess.run(
-        ["bash", "-lc", full_cmd],
-        env=env,
-        cwd=os.getcwd(),
-    )
+    result = run_shell_function(cmd, agentize_home=agentize_home)
     return result.returncode
 
 

--- a/python/agentize/server/__main__.md
+++ b/python/agentize/server/__main__.md
@@ -66,6 +66,4 @@ Check if a worktree exists for the given issue number.
 
 Spawn a new worktree for the given issue via `wt spawn`.
 
-### `_run_wt(args: str, capture_output: bool = False) -> subprocess.CompletedProcess`
-
-Run wt command via bash (wt is a shell function, not an executable).
+Note: Uses `run_shell_function()` from `agentize.shell` for shell invocation.

--- a/python/agentize/server/__main__.py
+++ b/python/agentize/server/__main__.py
@@ -18,6 +18,8 @@ import urllib.error
 from datetime import datetime
 from pathlib import Path
 
+from agentize.shell import run_shell_function
+
 
 def _log(msg: str, level: str = "INFO") -> None:
     """Log with timestamp and source location."""
@@ -231,27 +233,16 @@ def filter_ready_issues(items: list[dict]) -> list[int]:
     return ready
 
 
-def _run_wt(args: str, capture_output: bool = False) -> subprocess.CompletedProcess:
-    """Run wt command via bash (wt is a shell function, not an executable)."""
-    agentize_home = os.environ.get('AGENTIZE_HOME', '')
-    if not agentize_home:
-        raise RuntimeError("AGENTIZE_HOME not set")
-    return subprocess.run(
-        ['bash', '-c', f'source "{agentize_home}/setup.sh" && wt {args}'],
-        capture_output=capture_output, text=True
-    )
-
-
 def worktree_exists(issue_no: int) -> bool:
     """Check if a worktree exists for the given issue number."""
-    result = _run_wt(f'resolve {issue_no}', capture_output=True)
+    result = run_shell_function(f'wt resolve {issue_no}', capture_output=True)
     return result.returncode == 0
 
 
 def spawn_worktree(issue_no: int) -> bool:
     """Spawn a new worktree for the given issue."""
     print(f"Spawning worktree for issue #{issue_no}...")
-    result = _run_wt(f'spawn {issue_no} --headless')
+    result = run_shell_function(f'wt spawn {issue_no} --headless')
     return result.returncode == 0
 
 

--- a/python/agentize/shell.py
+++ b/python/agentize/shell.py
@@ -1,0 +1,53 @@
+"""Utilities for invoking shell functions from Python."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def get_agentize_home() -> str:
+    """Get AGENTIZE_HOME from environment or derive from repo root."""
+    if "AGENTIZE_HOME" in os.environ:
+        return os.environ["AGENTIZE_HOME"]
+
+    # Try to derive from this file's location
+    # shell.py is at python/agentize/shell.py, so repo root is ../../..
+    shell_path = Path(__file__).resolve()
+    repo_root = shell_path.parent.parent.parent
+    if (repo_root / "Makefile").exists() and (repo_root / "src" / "cli" / "lol.sh").exists():
+        return str(repo_root)
+
+    raise RuntimeError(
+        "AGENTIZE_HOME not set and could not be derived.\n"
+        "Please set AGENTIZE_HOME to point to your agentize repository."
+    )
+
+
+def run_shell_function(
+    cmd: str,
+    *,
+    capture_output: bool = False,
+    agentize_home: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a shell function with AGENTIZE_HOME set.
+
+    Args:
+        cmd: The shell command to run (e.g., "wt spawn 123", "lol_cmd_version")
+        capture_output: Whether to capture stdout/stderr
+        agentize_home: Override AGENTIZE_HOME (defaults to auto-detection)
+
+    Returns:
+        CompletedProcess with result
+    """
+    home = agentize_home or get_agentize_home()
+    env = os.environ.copy()
+    env["AGENTIZE_HOME"] = home
+
+    full_cmd = f'source "$AGENTIZE_HOME/setup.sh" && {cmd}'
+
+    return subprocess.run(
+        ["bash", "-c", full_cmd],
+        env=env,
+        capture_output=capture_output,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- Create shared `python/agentize/shell.py` module with `get_agentize_home()` and `run_shell_function()` utilities
- Update `cli.py` and `server/__main__.py` to use the shared module, removing duplicate implementations
- Update documentation to reflect the consolidated architecture

## Test Plan

- [x] Run `TEST_SHELLS="bash zsh" make test` - all 82 tests pass
- [x] Manual test: `python -m agentize.cli --version` works
- [x] Manual test: `python -m agentize.cli init` without `--path` flag uses current directory correctly
- [x] Code quality review passed

Closes #332

🤖 Generated with [Claude Code](https://claude.ai/code)
