### PR TITLE
[cli] Update logger timestamp format to compact style

### DIFF
--- a/docs/feat/server.md
+++ b/docs/feat/server.md
@@ -99,7 +99,7 @@ If `gh issue list` fails (e.g., network error, auth issue), the server returns a
 Error messages include source location (file:line:function) for quick debugging:
 
 ```
-[2026-01-09T12:30:47] [ERROR] [__main__.py:163:query_issue_project_status] GraphQL query failed: ...
+[26-01-09-12:30:47] [ERROR] [__main__.py:163:query_issue_project_status] GraphQL query failed: ...
 ```
 
 For additional context (query and variables), set `HANDSOFF_DEBUG=1`:

--- a/python/agentize/server/__main__.py
+++ b/python/agentize/server/__main__.py
@@ -33,7 +33,7 @@ def _log(msg: str, level: str = "INFO") -> None:
     filename = os.path.basename(frame.f_code.co_filename)
     lineno = frame.f_lineno
     func = frame.f_code.co_name
-    timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    timestamp = datetime.now().strftime("%y-%m-%d-%H:%M:%S")
 
     output = f"[{timestamp}] [{level}] [{filename}:{lineno}:{func}] {msg}"
     print(output, file=sys.stderr if level == "ERROR" else sys.stdout)


### PR DESCRIPTION
## Summary

- Update server logger timestamp format from ISO style (`2026-01-10T14:30:47`) to compact style (`26-01-10-14:30:47`)
- Update troubleshooting documentation example to match new format

## Changes

| File | Change |
|------|--------|
| `python/agentize/server/__main__.py` | Update strftime format from `%Y-%m-%dT%H:%M:%S` to `%y-%m-%d-%H:%M:%S` |
| `docs/feat/server.md` | Update example timestamp in troubleshooting section |

## Test plan

- [x] All 86 tests pass (`TEST_SHELLS="bash zsh" make test`)
- [x] Format change is cosmetic only (reduces log line width)
- [x] Documentation example matches implementation

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
