### PR TITLE
[agent.workflow] Use AGENTIZE_HOME for hook metadata storage

### DIFF
--- a/.claude/hooks/pre-tool-use.md
+++ b/.claude/hooks/pre-tool-use.md
@@ -116,7 +116,7 @@ This prevents hook failures from blocking Claude Code execution.
 ## Logging Behavior
 
 When `HANDSOFF_DEBUG=1`:
-- Writes tool usage to `.tmp/hooked-sessions/tool-used.txt`
+- Writes tool usage to `$AGENTIZE_HOME/.tmp/hooked-sessions/tool-used.txt` (falls back to worktree-local `.tmp/` if `AGENTIZE_HOME` is unset)
 - Format: `[timestamp] [session_id] [workflow] tool | target`
 - Preserved regardless of permission decision
 

--- a/docs/envvar.md
+++ b/docs/envvar.md
@@ -6,8 +6,10 @@ Centralized reference for all environment variables used in Agentize.
 
 | Variable | Required | Type | Default | Description |
 |----------|----------|------|---------|-------------|
-| `AGENTIZE_HOME` | Yes | Path | - | Root path of the Agentize installation. Auto-detected by `setup.sh`. |
+| `AGENTIZE_HOME` | Yes | Path | - | Root path of the Agentize installation. Auto-detected by `setup.sh`. Used by hooks for centralized state storage in `$AGENTIZE_HOME/.tmp/`. |
 | `PYTHONPATH` | No | Path | - | Extended by `setup.sh` to include `$AGENTIZE_HOME/python`. |
+
+**Hook path resolution:** When `AGENTIZE_HOME` is set, hooks store session state and logs in `$AGENTIZE_HOME/.tmp/hooked-sessions/`. This enables workflow continuations across worktree switches. If `AGENTIZE_HOME` is unset, hooks use a "soft" fallback: first attempting repo root derivation (via `Makefile` and `src/cli/lol.sh` markers), then falling back to the current worktree (`.`).
 
 ## Handsoff Mode
 

--- a/docs/feat/core/handsoff.md
+++ b/docs/feat/core/handsoff.md
@@ -207,7 +207,7 @@ tail -f ${AGENTIZE_HOME:-.}/.tmp/hook-debug.log
 **Example log entries:**
 ```
 [2026-01-07T10:15:23] [abc123] Writing state: {'workflow': 'ultra-planner', 'state': 'initial', 'continuation_count': 0}
-[2026-01-07T10:20:45] [abc123] Found existing state file: .tmp/hooked-sessions/abc123.json
+[2026-01-07T10:20:45] [abc123] Found existing state file: $AGENTIZE_HOME/.tmp/hooked-sessions/abc123.json
 [2026-01-07T10:20:45] [abc123] Updating state for continuation: {'workflow': 'ultra-planner', 'state': 'initial', 'continuation_count': 1}
 ```
 
@@ -270,7 +270,7 @@ See [.claude/hooks/pre-tool-use.md](../../.claude/hooks/pre-tool-use.md) for int
 
 **Key logic:**
 - Detects workflow commands: `/ultra-planner`, `/issue-to-impl`
-- Creates `.tmp/hooked-sessions/{session_id}.json` with initial state
+- Creates `$AGENTIZE_HOME/.tmp/hooked-sessions/{session_id}.json` with initial state (falls back to worktree-local `.tmp/` if `AGENTIZE_HOME` is unset)
 - Sets `continuation_count = 0`
 
 ### `stop.py`
@@ -279,7 +279,7 @@ See [.claude/hooks/pre-tool-use.md](../../.claude/hooks/pre-tool-use.md) for int
 - **Location:** `.claude/hooks/stop.py`
 
 **Key logic:**
-- Reads session state from `.tmp/hooked-sessions/{session_id}.json`
+- Reads session state from `$AGENTIZE_HOME/.tmp/hooked-sessions/{session_id}.json` (falls back to worktree-local `.tmp/` if `AGENTIZE_HOME` is unset)
 - Checks `continuation_count < HANDSOFF_MAX_CONTINUATIONS`
 - Increments `continuation_count`
 - Injects workflow-specific continuation prompt


### PR DESCRIPTION
## Summary

- Update remaining documentation references to use `$AGENTIZE_HOME/.tmp/hooked-sessions/` paths

**Note:** The core implementation was already merged to main. This PR contains only supplementary documentation updates for:
- `pre-tool-use.md` - logging behavior section
- `docs/envvar.md` - hook path resolution explanation
- `docs/feat/core/handsoff.md` - additional path references

Closes #355

## Test plan

- [x] Hook permission tests pass
- [x] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)