### PR TITLE
[refactor] Extract shared Telegram request helper to telegram_utils

### DIFF
--- a/python/agentize/README.md
+++ b/python/agentize/README.md
@@ -10,6 +10,8 @@ python/agentize/
 ├── cli.py                # Python CLI entrypoint (python -m agentize.cli)
 ├── cli.md                # CLI interface documentation
 ├── shell.py              # Shared shell function invocation utilities
+├── telegram_utils.py     # Shared Telegram API utilities
+├── telegram_utils.md     # Telegram utilities interface documentation
 ├── server/               # Polling server module
 │   └── __main__.py       # Server entry point (python -m agentize.server)
 └── permission/           # PreToolUse hook permission module

--- a/python/agentize/telegram_utils.md
+++ b/python/agentize/telegram_utils.md
@@ -1,5 +1,7 @@
 # Telegram Utilities Interface
 
+Shared utilities for Telegram Bot API integration used by the server and permission modules.
+
 ## External Interface
 
 ### `escape_html(text: str) -> str`
@@ -12,6 +14,76 @@ Escape special HTML characters for Telegram HTML parse mode.
 **Returns:** HTML-safe string with `<`, `>`, and `&` escaped
 
 **Escapes:**
-- `&` -> `&amp;`
-- `<` -> `&lt;`
-- `>` -> `&gt;`
+- `&` → `&amp;`
+- `<` → `&lt;`
+- `>` → `&gt;`
+
+### `telegram_request(...) -> dict | None`
+
+Make an HTTP request to the Telegram Bot API.
+
+```python
+def telegram_request(
+    token: str,
+    method: str,
+    payload: dict | None = None,
+    timeout_sec: int = 10,
+    on_error: Callable[[Exception], None] | None = None,
+    urlopen_fn: Callable[..., Any] | None = None
+) -> dict | None
+```
+
+**Parameters:**
+- `token`: Telegram Bot API token
+- `method`: API method name (e.g., `sendMessage`, `getUpdates`)
+- `payload`: Request payload dict (optional, JSON-encoded when provided)
+- `timeout_sec`: Request timeout in seconds (default: 10)
+- `on_error`: Callback invoked with exception on failure (optional)
+- `urlopen_fn`: Custom URL opener for testing (optional, defaults to `urllib.request.urlopen`)
+
+**Returns:** Parsed JSON response dict on success, `None` on error
+
+**Behavior:**
+- Builds URL: `https://api.telegram.org/bot{token}/{method}`
+- JSON-encodes payload with `Content-Type: application/json` header
+- Returns parsed JSON dict on 2xx response
+- Returns `None` on network/HTTP/JSON errors and calls `on_error` if provided
+
+**Usage:**
+
+```python
+from agentize.telegram_utils import telegram_request
+
+# Basic usage
+result = telegram_request(
+    token="123:ABC",
+    method="sendMessage",
+    payload={"chat_id": "456", "text": "Hello"}
+)
+
+# With error handling
+def handle_error(e):
+    print(f"Telegram error: {e}")
+
+result = telegram_request(
+    token="123:ABC",
+    method="getUpdates",
+    on_error=handle_error
+)
+
+# For testing with injected urlopen
+def mock_urlopen(req, timeout=None):
+    # Return mock response
+    ...
+
+result = telegram_request(
+    token="fake",
+    method="sendMessage",
+    urlopen_fn=mock_urlopen
+)
+```
+
+## Internal Usage
+
+- `python/agentize/server/__main__.py`: Uses `telegram_request` via `send_telegram_message` for notifications
+- `python/agentize/permission/determine.py`: Uses `telegram_request` via `_tg_api_request` for approval workflow

--- a/python/agentize/telegram_utils.py
+++ b/python/agentize/telegram_utils.py
@@ -3,6 +3,11 @@
 Provides common helpers for Telegram API integration.
 """
 
+import json
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+
 
 def escape_html(text: str) -> str:
     """Escape special HTML characters for Telegram HTML parse mode.
@@ -16,3 +21,47 @@ def escape_html(text: str) -> str:
         HTML-safe string
     """
     return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+
+def telegram_request(
+    token: str,
+    method: str,
+    payload: dict | None = None,
+    timeout_sec: int = 10,
+    on_error: Callable[[Exception], None] | None = None,
+    urlopen_fn: Callable[..., Any] | None = None
+) -> dict | None:
+    """Make an HTTP request to the Telegram Bot API.
+
+    Args:
+        token: Telegram Bot API token
+        method: API method name (e.g., 'sendMessage', 'getUpdates')
+        payload: Request payload dict (optional, JSON-encoded when provided)
+        timeout_sec: Request timeout in seconds (default: 10)
+        on_error: Callback invoked with exception on failure (optional)
+        urlopen_fn: Custom URL opener for testing (optional)
+
+    Returns:
+        Parsed JSON response dict on success, None on error
+    """
+    if urlopen_fn is None:
+        urlopen_fn = urllib.request.urlopen
+
+    url = f'https://api.telegram.org/bot{token}/{method}'
+
+    try:
+        if payload:
+            data = json.dumps(payload).encode('utf-8')
+            req = urllib.request.Request(
+                url, data=data,
+                headers={'Content-Type': 'application/json'}
+            )
+        else:
+            req = urllib.request.Request(url)
+
+        with urlopen_fn(req, timeout=timeout_sec) as response:
+            return json.loads(response.read().decode('utf-8'))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as e:
+        if on_error:
+            on_error(e)
+        return None

--- a/tests/cli/test-hook-permission-matching.sh
+++ b/tests/cli/test-hook-permission-matching.sh
@@ -198,8 +198,8 @@ print(f'{action}:{msg_id}')
 ")
 [ "$result" = "deny:67890" ] || test_fail "Expected 'deny:67890', got '$result'"
 
-# Test 17: _tg_api_request guard - returns None when Telegram is disabled
-test_info "Test 17: _tg_api_request returns None when Telegram disabled"
+# Test 23: _tg_api_request guard - returns None when Telegram is disabled
+test_info "Test 23: _tg_api_request returns None when Telegram disabled"
 guard_result=$(python3 -c "
 import os
 import sys


### PR DESCRIPTION
## Summary

- Extract shared `telegram_request()` helper into `telegram_utils.py` with injectable `urlopen_fn` for testing
- Refactor `send_telegram_message()` in server module to use shared helper
- Refactor `_tg_api_request()` in permission module to delegate to shared helper while preserving Telegram-disabled guard
- Add non-networked tests using injected stubs for the new helper

## Test plan

- [x] All 86 tests pass in both bash and zsh (`TEST_SHELLS="bash zsh" make test`)
- [x] New tests (25-26) verify `telegram_request` success and error paths
- [x] Existing Telegram-related tests continue to pass
- [x] Code quality review completed

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
