### PR TITLE
[bugfix] Fix GitHub Actions workflow not a git repository error

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -87,7 +87,7 @@ jobs:
           echo "$linked_issues" | jq -c '.[]' | while read -r issue; do
             issue_number=$(echo "$issue" | jq -r '.number')
             echo "Closing issue #$issue_number..."
-            gh issue close "$issue_number" --reason "completed"
+            gh issue close "$issue_number" -R "$GITHUB_REPOSITORY" --reason "completed"
             echo "  Issue #$issue_number closed"
           done
 

--- a/templates/github/project-auto-add.yml
+++ b/templates/github/project-auto-add.yml
@@ -87,7 +87,7 @@ jobs:
           echo "$linked_issues" | jq -c '.[]' | while read -r issue; do
             issue_number=$(echo "$issue" | jq -r '.number')
             echo "Closing issue #$issue_number..."
-            gh issue close "$issue_number" --reason "completed"
+            gh issue close "$issue_number" -R "$GITHUB_REPOSITORY" --reason "completed"
             echo "  Issue #$issue_number closed"
           done
 


### PR DESCRIPTION
## Summary

- Add `-R "$GITHUB_REPOSITORY"` flag to `gh issue close` command in GitHub Actions workflow
- Fix applied to both `.github/workflows/project.yaml` and `templates/github/project-auto-add.yml`

The `close-linked-issues` job was failing with "fatal: not a git repository" because `gh issue close` infers the repository from the current directory. Since there's no `actions/checkout` step in this job, adding the `-R` flag explicitly specifies the target repository using the `$GITHUB_REPOSITORY` environment variable (automatically provided by GitHub Actions).

## Test plan

- [x] All 88 project tests pass
- [ ] Manual validation: Merge a PR with linked issue to verify the workflow succeeds
- [ ] Check workflow logs for any errors

Fixes #365

🤖 Generated with [Claude Code](https://claude.ai/code)
