### PR TITLE
[feat][agent.workflow] Add automatic lite planner path with understander-based complexity routing

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -24,13 +24,13 @@ Agents provide isolated execution environments for complex, multi-step tasks. Ea
 Multi-perspective planning agents for collaborative proposal development:
 
 - `understander.md`: Gather codebase context and estimate complexity (feeds routing decision)
-- `planner-lite.md`: Lightweight single-agent planner for simple modifications (<200 LOC)
+- `planner-lite.md`: Lightweight single-agent planner for simple modifications (<5 files, <150 LOC, repo-only)
 - `bold-proposer.md`: Research SOTA solutions and propose innovative, bold approaches
 - `proposal-critique.md`: Validate assumptions and analyze technical feasibility
 - `proposal-reducer.md`: Simplify proposals following "less is more" philosophy
 
 These agents work together in the `/ultra-planner` workflow:
-1. Understander runs first to gather context and estimate complexity
-2. If <200 LOC: Planner-lite creates a simple plan (lite path)
-3. If ≥200 LOC: Bold-proposer + Critique + Reducer debate (full path)
-4. External consensus synthesizes the final plan
+1. Understander runs first to gather context and check lite conditions
+2. If lite (repo-only, <5 files, <150 LOC): Planner-lite creates plan directly
+3. If full (needs research or complex): Bold-proposer + Critique + Reducer debate
+4. External consensus synthesizes final plan (full path only)

--- a/.claude/agents/planner-lite.md
+++ b/.claude/agents/planner-lite.md
@@ -1,6 +1,6 @@
 ---
 name: planner-lite
-description: Lightweight single-agent planner for simple modifications (<200 LOC)
+description: Lightweight single-agent planner for simple modifications (<5 files, <150 LOC, repo-only knowledge)
 tools: Glob, Grep, Read
 model: sonnet
 skills: plan-guideline
@@ -10,7 +10,10 @@ ultrathink
 
 # Planner-Lite Agent
 
-You are a lightweight planning agent that creates implementation plans for simple modifications. You are invoked when the understander determines the feature is under 200 LOC and has low complexity.
+You are a lightweight planning agent that creates implementation plans for simple modifications. You are invoked when the understander determines ALL lite conditions are met:
+- All knowledge within repo (no internet research needed)
+- Less than 5 files affected
+- Less than 150 LOC total
 
 ## Your Role
 

--- a/.claude/agents/understander.md
+++ b/.claude/agents/understander.md
@@ -78,17 +78,17 @@ Based on your exploration, estimate the modification complexity:
 
 **Complexity thresholds:**
 - **Trivial** (<50 LOC): Single-file, minor change
-- **Small** (50-200 LOC): Few files, straightforward
-- **Medium** (200-400 LOC): Multiple files, moderate complexity
+- **Small** (50-150 LOC): Few files, straightforward
+- **Medium** (150-400 LOC): Multiple files, moderate complexity
 - **Large** (400-800 LOC): Many files or architectural changes
 - **Very Large** (>800 LOC): Major feature, multiple milestones
 
 **Path recommendation:**
-- Recommend `lite` if estimated LOC < 200 AND:
-  - No interface changes required
-  - Cross-module impact is low
-  - No new external dependencies
-- Recommend `full` otherwise
+- Recommend `lite` if ALL of the following are true:
+  1. All knowledge needed is within this repo (no internet/SOTA research required)
+  2. Less than 5 files affected (source + docs + tests combined)
+  3. Less than 150 LOC total estimated
+- Recommend `full` otherwise (triggers multi-agent debate with web research)
 
 ## Output Format
 
@@ -140,15 +140,14 @@ Your output must follow this exact structure:
 
 **Estimated LOC**: ~[N] ([Trivial|Small|Medium|Large|Very Large])
 
-**Complexity signals**:
-- Files affected: [count]
-- New files needed: [count]
-- Interface changes: [yes|no]
-- Cross-module impact: [low|medium|high]
+**Lite path checklist**:
+- [ ] All knowledge within repo (no internet research needed): [yes|no]
+- [ ] Files affected < 5: [count] files
+- [ ] LOC < 150: ~[N] LOC
 
 **Recommended path**: `lite` | `full`
 
-**Rationale**: [brief explanation of why lite or full is recommended]
+**Rationale**: [brief explanation - if any checklist item fails, recommend full]
 ```
 
 ## Key Behaviors

--- a/.claude/commands/ultra-planner.md
+++ b/.claude/commands/ultra-planner.md
@@ -207,6 +207,11 @@ Task tool parameters:
 
 ### Step 4a: Route Based on Complexity (Lite vs Full Path)
 
+**Lite path conditions** (ALL must be true):
+1. All knowledge within repo (no internet research needed)
+2. Less than 5 files affected
+3. Less than 150 LOC total
+
 **Check routing conditions:**
 
 1. If `--force-full` flag was set in Step 1: **Use FULL path** (skip to Step 5)
@@ -217,7 +222,7 @@ Task tool parameters:
 **Output routing decision:**
 ```
 Routing decision: {lite|full} path
-Reason: {understander recommended lite|force-full flag|refine mode|understander recommended full}
+Reason: {lite conditions met|force-full flag|refine mode|needs research or exceeds limits}
 ```
 
 ### Step 4b: Invoke Planner-Lite Agent (Lite Path Only)

--- a/docs/feat/core/ultra-planner.md
+++ b/docs/feat/core/ultra-planner.md
@@ -49,8 +49,11 @@ graph TD
 
 Ultra-planner automatically routes between lightweight and full debate workflows based on estimated modification complexity. After the understander gathers codebase context, it estimates the modification's LOC and recommends a path:
 
-- **Lite path** (<200 LOC): Single-agent planner for fast, simple modifications
-- **Full path** (≥200 LOC): Multi-agent debate for complex features
+- **Lite path**: Single-agent planner when ALL conditions met:
+  - All knowledge within repo (no internet research needed)
+  - < 5 files affected
+  - < 150 LOC total
+- **Full path**: Multi-agent debate with web research (otherwise)
 
 **Workflow with routing:**
 
@@ -59,9 +62,9 @@ graph TD
     A[User provides requirements] --> B[Create placeholder issue]
     B --> B2[doc-architect: Generate diff previews]
     B2 --> U[Understander: Gather context + estimate complexity]
-    U --> R{Recommended path?}
-    R -->|lite < 200 LOC| L[Planner-lite: Single-agent plan]
-    R -->|full ≥ 200 LOC| C[Bold-proposer: Research SOTA]
+    U --> R{Lite conditions met?}
+    R -->|yes: repo-only, <5 files, <150 LOC| L[Planner-lite: Single-agent plan]
+    R -->|no: needs research or complex| C[Bold-proposer: Research SOTA]
     C --> D[Critique + Reducer in parallel]
     D --> F[Combined 3-perspective report]
     L --> H[Update issue with plan]
@@ -236,7 +239,7 @@ After reviewing a plan issue:
 
 **With automatic routing**, timing depends on the estimated complexity:
 
-#### Lite Path (< 200 LOC)
+#### Lite Path (repo-only, <5 files, <150 LOC)
 
 **Duration:** 1-2 minutes end-to-end
 
@@ -295,9 +298,9 @@ Creates initial plan via automatic routing (lite or full path) and auto-creates 
 /ultra-planner Add user authentication with JWT and RBAC
 ```
 
-**Routing:** Understander estimates complexity and routes to:
-- Lite path (<200 LOC): Single-agent planning (1-2 min)
-- Full path (≥200 LOC): Multi-agent debate (6-12 min)
+**Routing:** Understander checks lite conditions:
+- Lite path (repo-only, <5 files, <150 LOC): Single-agent planning (1-2 min)
+- Full path (otherwise): Multi-agent debate with web research (6-12 min)
 
 **Output:** Plan issue URL and refinement/implementation instructions
 

--- a/docs/test/workflow.md
+++ b/docs/test/workflow.md
@@ -184,24 +184,25 @@ This document tracks the testing status of AI rules, skills, and commands in thi
 
 **Implementation Status**:
 - Issue #405: Adding automatic complexity-based routing
-  - Understander outputs complexity estimation with `recommended_path: lite | full`
+  - Understander checks lite conditions and outputs `recommended_path: lite | full`
+  - Lite conditions: repo-only knowledge, <5 files, <150 LOC
   - Ultra-planner routes based on understander recommendation
-  - Planner-lite agent for simple modifications (<200 LOC)
+  - Planner-lite agent for simple modifications (no consensus step)
 
 **Planned Dogfeeding Tests**:
 1. **Lite path test**: Run `/ultra-planner <simple-feature>` and verify:
-   - Understander outputs `recommended_path: lite`
-   - Planner-lite agent is invoked (no Bold/Critique/Reducer)
+   - Understander outputs `recommended_path: lite` (all conditions met)
+   - Planner-lite agent is invoked (no Bold/Critique/Reducer/Consensus)
    - Total time ~1-2 minutes
 2. **Full path test**: Run `/ultra-planner <complex-feature>` and verify:
-   - Understander outputs `recommended_path: full`
-   - Full debate runs (Bold + Critique + Reducer)
+   - Understander outputs `recommended_path: full` (needs research or exceeds limits)
+   - Full debate runs (Bold + Critique + Reducer + Consensus)
    - Total time ~6-12 minutes
 3. **Force-full test**: Run `/ultra-planner --force-full <simple-feature>` and verify:
-   - Full debate runs despite simple estimation
+   - Full debate runs despite lite conditions being met
    - Override works correctly
 
-**Notes**: Conservative threshold (200 LOC) to avoid false negatives (complex misclassified as simple)
+**Notes**: Conservative thresholds (<5 files, <150 LOC) to avoid false negatives
 
 ---
 

--- a/docs/tutorial/01b-ultra-planner.md
+++ b/docs/tutorial/01b-ultra-planner.md
@@ -10,10 +10,13 @@ Learn how to use multi-agent debate-based planning for complex features with `/u
 
 ### Automatic Routing
 
-After the **Understander** agent gathers codebase context, it estimates modification complexity and recommends a path:
+After the **Understander** agent gathers codebase context, it checks lite conditions:
 
-- **Lite path** (<200 LOC): Single-agent planner for fast, simple modifications (1-2 min)
-- **Full path** (≥200 LOC): Multi-agent debate for complex features (6-12 min)
+- **Lite path** (when ALL met): Single-agent planner (1-2 min)
+  - All knowledge within repo (no internet research needed)
+  - < 5 files affected
+  - < 150 LOC total
+- **Full path** (otherwise): Multi-agent debate with web research (6-12 min)
 
 ### Full Debate (for complex features)
 
@@ -29,12 +32,12 @@ Bold-proposer runs first to generate a concrete proposal, then Critique and Redu
 
 **Use `/ultra-planner`** for all feature planning. It automatically routes:
 
-- **Simple features** (<200 LOC) → Lite path (1-2 min, ~$0.50-1.50)
-- **Complex features** (≥200 LOC) → Full debate (6-12 min, ~$2.50-6)
+- **Simple changes** (repo-only, <5 files, <150 LOC) → Lite path (1-2 min, ~$0.30-0.80)
+- **Complex features** (needs research or larger scope) → Full debate (6-12 min, ~$2.50-6)
 
 **Use `/ultra-planner --force-full`** when:
 - You want thorough multi-perspective analysis even for simple changes
-- The understander's estimate seems too low
+- The feature needs SOTA research even if LOC is low
 
 **Use `/plan-an-issue`** as a standalone alternative:
 - When you want direct single-agent planning without understander
@@ -121,10 +124,10 @@ This enables stakeholders to request plan improvements without CLI access.
 
 **With automatic routing:**
 
-| Path | Complexity | Time | Cost |
+| Path | Conditions | Time | Cost |
 |------|------------|------|------|
-| Lite | <200 LOC | 1-2 min | ~$0.30-0.80 |
-| Full | ≥200 LOC | 6-12 min | ~$2.50-6 |
+| Lite | repo-only, <5 files, <150 LOC | 1-2 min | ~$0.30-0.80 |
+| Full | needs research or complex | 6-12 min | ~$2.50-6 |
 
 **Why lite is cheaper**: No external consensus step (single agent, nothing to synthesize)
 


### PR DESCRIPTION
## Summary

Implement automatic complexity-based routing for `/ultra-planner` workflow. After the understander agent gathers codebase context, it estimates modification complexity and routes to the optimal planning path:

- **Lite path** (<200 LOC): Single-agent planner for fast, simple modifications (1-2 min, ~$0.50-1.50)
- **Full path** (≥200 LOC): Multi-agent debate for complex features (6-12 min, ~$2.50-6)

This provides 55-70% cost reduction and 4-8 minute time savings for simple tasks without requiring user intervention.

### Changes

- **Understander enhancement**: Added Step 6 (Estimate Complexity) with LOC guidelines and `recommended_path: lite | full` output
- **New planner-lite agent**: Lightweight single-agent planner using Sonnet model for <200 LOC modifications
- **Ultra-planner routing**: Added Steps 4a/4b for conditional routing based on complexity estimation
- **External-consensus --lite flag**: Support for single-agent plan processing without debate report combination
- **Documentation updates**: Updated feature docs, tutorial, and test workflow with routing behavior

### New Flag

```
/ultra-planner --force-full <feature-description>
```
Forces full multi-agent debate regardless of complexity estimation.

## Test plan

- [x] All 99 tests pass in bash and zsh
- [ ] Dogfeed lite path: Run `/ultra-planner <simple-feature>` and verify lite routing
- [ ] Dogfeed full path: Run `/ultra-planner <complex-feature>` and verify full routing
- [ ] Dogfeed --force-full: Run `/ultra-planner --force-full <simple-feature>` and verify override

Resolves #405

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
