### PR TITLE
[docs][cli] Clarify CLI vs plugin distribution (oh-my-zsh pattern)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ source $HOME/.agentize/setup.sh
 
 See [docs/cli/install.md](./docs/cli/install.md) for installation options and troubleshooting.
 
+**Upgrade:** Run `lol upgrade` to pull the latest changes.
+
 ### Manual Install
 
 If you prefer manual setup:

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -1,6 +1,11 @@
 # Installing Agentize as a Claude Code Plugin
 
-Agentize can be installed as a Claude Code plugin, which provides all commands, skills, agents, and hooks without requiring a git clone into each project.
+Agentize has two distribution modes:
+
+1. **CLI (`wt`, `lol`)**: Installed via `scripts/install` to `~/.agentize`, sourced in shell, updated via `lol upgrade` (like oh-my-zsh)
+2. **Plugin** (commands/agents/skills/hooks): Installed via Claude Code marketplace or `--plugin-dir`
+
+This page covers plugin installation. For CLI installation, see the [Quick Start](../README.md#quick-start) guide.
 
 ## Installation Methods
 

--- a/scripts/install
+++ b/scripts/install
@@ -85,11 +85,23 @@ echo "Dependencies OK"
 
 # Check if install directory already exists
 if [ -e "$INSTALL_DIR" ]; then
-    echo "Error: Install directory already exists: $INSTALL_DIR" >&2
-    echo "" >&2
-    echo "Please remove the directory or choose a different location with --dir" >&2
-    echo "  rm -rf $INSTALL_DIR" >&2
-    exit 1
+    # Check if it's a valid agentize installation (has setup.sh)
+    if [ -f "$INSTALL_DIR/setup.sh" ]; then
+        echo "Agentize is already installed at: $INSTALL_DIR"
+        echo ""
+        echo "To upgrade your installation, run:"
+        echo "  source $INSTALL_DIR/setup.sh && lol upgrade"
+        echo ""
+        echo "To reinstall, remove the directory first:"
+        echo "  rm -rf $INSTALL_DIR"
+        exit 0
+    else
+        echo "Error: Install directory already exists but is not a valid agentize installation: $INSTALL_DIR" >&2
+        echo "" >&2
+        echo "Please remove the directory or choose a different location with --dir" >&2
+        echo "  rm -rf $INSTALL_DIR" >&2
+        exit 1
+    fi
 fi
 
 # Clone repository


### PR DESCRIPTION
## Summary

- Make install script idempotent: detect existing installations and guide users to upgrade instead of failing
- Document dual distribution story (CLI vs plugin) in plugin-installation.md
- Add upgrade instructions to README.md Quick Start section

Closes #416

## Test plan

- [x] All 64 tests pass in both bash and zsh (`TEST_SHELLS="bash zsh" make test`)
- [x] Code quality review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
