### PR TITLE
[feat][agent.workflow]: Include original user prompt in bold-proposer report

### DIFF
--- a/.claude-plugin/agents/bold-proposer.md
+++ b/.claude-plugin/agents/bold-proposer.md
@@ -47,6 +47,8 @@ Focus on:
 
 ### Step 3: Propose Bold Solution
 
+**IMPORTANT**: Before generating your proposal, capture the original feature request exactly as provided in your prompt. This will be included verbatim in your report output under "Original User Request".
+
 Generate a comprehensive proposal with:
 
 #### A. Core Innovation
@@ -98,6 +100,12 @@ Your proposal should be structured as:
 ## Innovation Summary
 
 [1-2 sentence summary of the bold approach]
+
+## Original User Request
+
+[Verbatim copy of the original feature description provided to this agent]
+
+This section preserves the user's exact requirements so that critique and reducer agents can verify alignment with the original intent.
 
 ## Research Findings
 

--- a/.claude-plugin/skills/external-consensus/external-review-prompt.md
+++ b/.claude-plugin/skills/external-consensus/external-review-prompt.md
@@ -10,6 +10,7 @@ Three specialized agents have analyzed the following requirement:
 
 Each agent provided a different perspective:
 1. **Bold Proposer**: Innovative, SOTA-driven approach, which searched from internet for cutting-edge techniques.
+   - The bold proposal includes the "Original User Request" section with the verbatim feature description.
 2. **Critique Agent**: Feasibility analysis and risk assessment for the aggressive solution from the **Bold Proposer**.
 3. **Reducer Agent**: Simplified, "less is more" approach focusing on the core functionality from a minimalistic standpoint, by simplifying the **Bold Proposer**'s design.
 


### PR DESCRIPTION
## Summary

- Add "Original User Request" section to bold-proposer output template
- Preserve verbatim user requirements for downstream critique and reducer agents
- Update external-consensus documentation to reflect the new section

This ensures minor user requirements aren't lost when agents analyze Bold's interpretation of the request.

## Changes

| File | Change |
|------|--------|
| `.claude-plugin/agents/bold-proposer.md` | Add instruction in Step 3 to capture original request; Add "Original User Request" section to output template |
| `.claude-plugin/skills/external-consensus/external-review-prompt.md` | Document that Bold's proposal includes the original request |

## Test Plan

- [x] All 65 tests pass in both bash and zsh
- [ ] Manual verification: Run `/ultra-planner` with a test feature description
- [ ] Check `.tmp/issue-{N}-bold-proposal.md` contains "Original User Request" section
- [ ] Verify the verbatim user request is preserved accurately

## Related Issue

Closes #418

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
