### PR TITLE
[cli]: Complete lol usage command in zsh completion

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -92,6 +92,8 @@ Parses JSONL files from `~/.claude/projects/**/*.jsonl` to extract and aggregate
 |--------|----------|---------|-------------|
 | `--today` | No | Yes | Show usage by hour for the last 24 hours |
 | `--week` | No | - | Show usage by day for the last 7 days |
+| `--cache` | No | - | Include cache token statistics (cache_read, cache_write columns) |
+| `--cost` | No | - | Show cost estimate based on model pricing |
 
 #### Example
 

--- a/src/completion/_lol
+++ b/src/completion/_lol
@@ -21,6 +21,7 @@ _lol() {
             'claude-clean:Remove stale Claude config entries'
             'upgrade:Upgrade agentize installation'
             'project:Manage GitHub Projects v2 integration'
+            'usage:Report Claude Code token usage statistics'
             'version:Display version information'
         )
     else


### PR DESCRIPTION
## Summary

- Add `--cache` and `--cost` flags documentation to `lol usage` command in `docs/cli/lol.md`
- Add `usage` command to static fallback list in `src/completion/_lol` for zsh completion

## Test plan

- [x] All 65 tests pass in both bash and zsh shells
- [x] Existing tests already cover the functionality:
  - Dynamic completion test (`tests/cli/test-lol-complete-commands.sh`)
  - Functional tests (`tests/cli/test-lol-usage.sh`)
  - Completion file structure test (`tests/lint/test-lol-zsh-completion-file.sh`)

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
