### PR TITLE
[cli] Add --model option to wt spawn command

### DIFF
--- a/docs/feat/cli/wt.md
+++ b/docs/feat/cli/wt.md
@@ -35,6 +35,7 @@ After running `make setup` and sourcing `setup.sh`, the `wt` command is availabl
   - Before creating the worktree, it rebases onto the latest default branch from the bare repo
   - After creating the worktree, attempts to update the issue's GitHub Projects v2 Status to "In Progress" (best-effort)
   - `--no-agent`: skip automatic Claude invocation after worktree creation
+  - `--model <model>`: specify Claude model to use (opus, sonnet, haiku); uses default if not specified
   - `--yolo`: skip permission prompts by passing `--dangerously-skip-permissions` to Claude
     - **WARNING**: When active, Claude will run with all permission checks bypassed
     - A warning message will be displayed on stderr before Claude invocation
@@ -120,7 +121,7 @@ The `wt` command provides tab-completion support for zsh users. After running `m
 
 **Features:**
 - Subcommand completion (`wt <TAB>` shows: clone, common, init, goto, spawn, list, remove, prune, purge, pathto, rebase, help)
-- Flag completion for `spawn` (`--yolo`, `--no-agent`, `--headless`) — flags can appear before or after `<issue-no>`
+- Flag completion for `spawn` (`--yolo`, `--no-agent`, `--headless`, `--model`) — flags can appear before or after `<issue-no>`
 - Flag completion for `remove` (`--delete-branch`, `-D`, `--force`) — flags can appear before or after `<issue-no>`
 - Flag completion for `rebase` (`--headless`) — flags can appear before or after `<pr-no>`
 - Target completion for `goto` (`main` and `issue-<N>-*` worktrees)
@@ -145,7 +146,7 @@ wt --complete <topic>
 
 **Topics:**
 - `commands` - List available subcommands (clone, common, init, goto, spawn, list, remove, prune, purge, pathto, rebase, help)
-- `spawn-flags` - List flags for `wt spawn` (--yolo, --no-agent, --headless)
+- `spawn-flags` - List flags for `wt spawn` (--yolo, --no-agent, --headless, --model)
 - `remove-flags` - List flags for `wt remove` (--delete-branch, -D, --force)
 - `rebase-flags` - List flags for `wt rebase` (--headless, --yolo)
 - `goto-targets` - List available targets for `wt goto` (main plus issue numbers derived from issue-<N>-* worktrees)
@@ -172,6 +173,7 @@ $ wt --complete spawn-flags
 --yolo
 --no-agent
 --headless
+--model
 
 $ wt --complete goto-targets
 main

--- a/src/cli/wt/commands.sh
+++ b/src/cli/wt/commands.sh
@@ -146,6 +146,7 @@ cmd_spawn() {
     local no_agent=false
     local yolo=false
     local headless=false
+    local model=""
 
     # Parse arguments
     while [ $# -gt 0 ]; do
@@ -161,6 +162,14 @@ cmd_spawn() {
             --headless)
                 headless=true
                 shift
+                ;;
+            --model)
+                if [ $# -lt 2 ]; then
+                    echo "Error: --model requires a value" >&2
+                    return 1
+                fi
+                model="$2"
+                shift 2
                 ;;
             -*)
                 echo "Error: Unknown flag: $1" >&2
@@ -263,7 +272,7 @@ cmd_spawn() {
 
     # Invoke Claude if not disabled
     if [ "$no_agent" = false ] && command -v claude >/dev/null 2>&1; then
-        wt_invoke_claude "/issue-to-impl $issue_no" "$worktree_path" "$yolo" "$headless" "issue-${issue_no}"
+        wt_invoke_claude "/issue-to-impl $issue_no" "$worktree_path" "$yolo" "$headless" "issue-${issue_no}" "$model"
     fi
 
     return 0
@@ -544,6 +553,7 @@ COMMANDS:
 
 OPTIONS (spawn):
   --no-agent          Skip automatic Claude invocation
+  --model <model>     Specify Claude model to use (opus, sonnet, haiku)
   --yolo              Skip permission prompts
   --headless          Run Claude in non-interactive mode (for server daemon)
 

--- a/src/cli/wt/completion.sh
+++ b/src/cli/wt/completion.sh
@@ -26,6 +26,7 @@ wt_complete() {
             echo "--yolo"
             echo "--no-agent"
             echo "--headless"
+            echo "--model"
             ;;
         remove-flags)
             echo "--delete-branch"

--- a/src/completion/_wt
+++ b/src/completion/_wt
@@ -107,7 +107,7 @@ _wt_spawn() {
 
     # Fallback to static flags
     if (( ${#spawn_flags} == 0 )); then
-        spawn_flags=( '--yolo' '--no-agent' '--headless' )
+        spawn_flags=( '--yolo' '--no-agent' '--headless' '--model' )
     fi
 
     # Build option specs from flags
@@ -121,6 +121,9 @@ _wt_spawn() {
                 ;;
             --headless)
                 option_specs+=('--headless[Run Claude in non-interactive mode (for server daemon)]')
+                ;;
+            --model)
+                option_specs+=('--model[Specify Claude model to use]:model:(opus sonnet haiku)')
                 ;;
             *)
                 # Unknown flag, pass through without description


### PR DESCRIPTION
## Summary

- Add `--model <model>` flag to `wt spawn` command to specify Claude model (opus, sonnet, haiku)
- Update shell completion to include `--model` flag with model value suggestions
- Update documentation for the new flag

## Test plan

- [x] Verify `wt --complete spawn-flags` includes `--model`
- [x] Run full test suite (66/67 pass, 1 pre-existing unrelated failure)
- [x] Code quality review passed

Closes #446

🤖 Generated with [Claude Code](https://claude.ai/code)
