### PR TITLE
[fix] Add shared library function references to setup-viewboard command

### DIFF
--- a/.claude-plugin/commands/setup-viewboard.md
+++ b/.claude-plugin/commands/setup-viewboard.md
@@ -21,6 +21,15 @@ This command will:
 
 - `$ARGUMENTS` (optional): `--org <org-name>` to specify the organization or user for the project board. Defaults to repository owner.
 
+## Implementation Note
+
+This command is self-contained using shared library functions from `src/cli/lol/project-lib.sh`. The core GitHub Projects v2 operations are provided by:
+
+- `project_create` - Creates a new GitHub Projects v2 board
+- `project_associate` - Associates with an existing project board
+- `project_generate_automation` - Generates the automation workflow file
+- `project_verify_status_options` - Verifies and configures Status field options
+
 ## Workflow Steps
 
 When this command is invoked, follow these steps:


### PR DESCRIPTION
## Summary

- Add "Implementation Note" section to `.claude-plugin/commands/setup-viewboard.md` documenting the shared library functions from `src/cli/lol/project-lib.sh`
- Reference all four core functions: `project_create`, `project_associate`, `project_generate_automation`, `project_verify_status_options`
- Fix `test-setup-viewboard-self-contained` which validates that the command file contains function references instead of `lol project` CLI calls

## Test plan

- [x] Run `tests/e2e/test-setup-viewboard-self-contained.sh` - passes
- [x] Run full test suite with `TEST_SHELLS="bash zsh" make test` - all 67 tests pass in both shells

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
