### PR TITLE
[feat] Add agentize:pr label to setup-viewboard and auto-add in issue-to-impl

### DIFF
--- a/.claude-plugin/commands/issue-to-impl.md
+++ b/.claude-plugin/commands/issue-to-impl.md
@@ -341,7 +341,17 @@ git diff --cached --name-only  # Verify no .tmp/milestones/ files
 
 Then invoke `commit-msg` skill with `purpose=delivery` and appropriate tags based on the changes.
 
-Command completes successfully after delivery commit is created.
+**Add agentize:pr label to mark completion:**
+
+After the delivery commit is created successfully, add the `agentize:pr` label to the issue:
+
+```bash
+gh issue edit {issue-number} --add-label "agentize:pr"
+```
+
+This marks the issue as having completed implementation and being ready for PR creation.
+
+Command completes successfully after delivery commit is created and label is added.
 
 **Output C: Critical error**
 ```

--- a/.claude-plugin/commands/setup-viewboard.md
+++ b/.claude-plugin/commands/setup-viewboard.md
@@ -204,6 +204,7 @@ gh label create "agentize:plan" --description "Issues with implementation plans"
 gh label create "agentize:refine" --description "Issues queued for refinement" --color "1D76DB" --force
 gh label create "agentize:dev-req" --description "Developer request issues" --color "D93F0B" --force
 gh label create "agentize:bug-report" --description "Bug report issues" --color "B60205" --force
+gh label create "agentize:pr" --description "PR created for implementation" --color "8B6EE8" --force
 ```
 
 Inform the user:
@@ -213,6 +214,7 @@ Created labels:
   - agentize:refine (blue)
   - agentize:dev-req (orange)
   - agentize:bug-report (red)
+  - agentize:pr (purple)
 ```
 
 ### Step 7: Summary
@@ -224,7 +226,7 @@ Setup complete!
 
 Project: <org>/<id>
 Workflow: .github/workflows/add-to-project.yml
-Labels: agentize:plan, agentize:refine, agentize:dev-req, agentize:bug-report
+Labels: agentize:plan, agentize:refine, agentize:dev-req, agentize:bug-report, agentize:pr
 
 See: docs/architecture/project.md for Status field configuration details.
 ```

--- a/docs/commands/setup-viewboard.md
+++ b/docs/commands/setup-viewboard.md
@@ -42,6 +42,7 @@ The command performs the following steps:
    - `agentize:refine` - Issues queued for refinement
    - `agentize:dev-req` - Developer request issues (triage)
    - `agentize:bug-report` - Bug report issues (triage)
+   - `agentize:pr` - PR created for implementation
 
 ## Status Field Options
 

--- a/python/agentize/server/__main__.md
+++ b/python/agentize/server/__main__.md
@@ -157,6 +157,16 @@ Clean up after feat-request planning completion: remove `agentize:feat-request` 
 1. Remove `agentize:feat-request` label via `gh issue edit`
 2. Log cleanup action
 
+### `_add_pr_label(issue_no: int) -> None`
+
+Add `agentize:pr` label when implementation workflow completes.
+
+**Operations:**
+1. Add `agentize:pr` label via `gh issue edit`
+2. Log label addition
+
+**Note:** Only called for implementation workflows, not for refinement or feat-request workflows.
+
 ### `worktree_exists(issue_no: int) -> bool`
 
 Check if a worktree exists for the given issue number.

--- a/python/agentize/server/__main__.py
+++ b/python/agentize/server/__main__.py
@@ -64,6 +64,7 @@ from agentize.server.workers import (
     _check_issue_has_label,
     _cleanup_refinement,
     _cleanup_feat_request,
+    _add_pr_label,
     DEFAULT_WORKERS_DIR,
 )
 

--- a/python/agentize/server/workers.py
+++ b/python/agentize/server/workers.py
@@ -111,6 +111,20 @@ def _cleanup_feat_request(issue_no: int) -> None:
     _log(f"Feat-request cleanup for issue #{issue_no}: removed agentize:feat-request label")
 
 
+def _add_pr_label(issue_no: int) -> None:
+    """Add agentize:pr label when workflow completes.
+
+    Args:
+        issue_no: GitHub issue number
+    """
+    subprocess.run(
+        ['gh', 'issue', 'edit', str(issue_no), '--add-label', 'agentize:pr'],
+        capture_output=True,
+        text=True
+    )
+    _log(f"Added agentize:pr label to issue #{issue_no}")
+
+
 def spawn_refinement(issue_no: int) -> tuple[bool, int | None]:
     """Spawn a refinement session for the given issue.
 
@@ -360,12 +374,19 @@ def cleanup_dead_workers(
                 session_state = _get_session_state_for_issue(issue_no, session_dir)
                 if session_state and session_state.get('state') == 'done':
                     # Check if this was a refinement (has agentize:refine label)
-                    if _check_issue_has_label(issue_no, 'agentize:refine'):
+                    is_refinement = _check_issue_has_label(issue_no, 'agentize:refine')
+                    if is_refinement:
                         _cleanup_refinement(issue_no)
 
                     # Check if this was a feat-request (has agentize:feat-request label)
-                    if _check_issue_has_label(issue_no, 'agentize:feat-request'):
+                    is_feat_request = _check_issue_has_label(issue_no, 'agentize:feat-request')
+                    if is_feat_request:
                         _cleanup_feat_request(issue_no)
+
+                    # Add agentize:pr label only for implementation workflows
+                    # (not refinement or feat-request which don't create PRs)
+                    if not is_refinement and not is_feat_request:
+                        _add_pr_label(issue_no)
 
                     issue_url = f"https://github.com/{repo_slug}/issues/{issue_no}" if repo_slug else None
 


### PR DESCRIPTION
## Summary

- Add `agentize:pr` label creation to `/setup-viewboard` command (purple color)
- Add automatic label application after delivery commit in `/issue-to-impl` workflow
- Add `_add_pr_label` function in `workers.py` for server-side fallback
- Only add label for implementation workflows (not refinement/feat-request)
- Update documentation to reflect new label

This enhancement provides a workflow state indicator showing that an issue has transitioned from planning → implementation → PR creation.

## Test plan

- [x] All 68 tests pass in both bash and zsh
- [x] Code review completed - all documentation gaps addressed
- [ ] Manual verification: Run `/setup-viewboard` and check `agentize:pr` label is created
- [ ] Manual verification: Complete an issue-to-impl workflow and verify label is added

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
