### PR TITLE
[refactor] Unify Claude CLI invocation interface in wt commands

### DIFF
--- a/docs/feat/cli/wt.md
+++ b/docs/feat/cli/wt.md
@@ -184,3 +184,31 @@ $ wt --complete rebase-flags
 ```
 
 This helper is used by the zsh completion system and can be used by other shells in the future.
+
+## Claude CLI Invocation Interface
+
+Commands that invoke Claude CLI (`spawn`, `rebase`) use a unified helper function `wt_invoke_claude()` to ensure consistent flag handling and execution modes.
+
+**Function signature:**
+```bash
+wt_invoke_claude <command> <worktree_path> <yolo> <headless> <log_prefix>
+```
+
+**Parameters:**
+- `command`: Claude CLI command string (e.g., `/issue-to-impl 42`, `/sync-master`)
+- `worktree_path`: Absolute path to worktree where Claude should execute
+- `yolo`: Boolean (`true`/`false`) - passes `--dangerously-skip-permissions` to Claude
+- `headless`: Boolean (`true`/`false`) - uses `--print` flag and background execution
+- `log_prefix`: Prefix for log file name (e.g., `issue-42`, `rebase-123`)
+
+**Behavior:**
+- **Interactive mode** (`headless=false`): Runs Claude in foreground with a `cd` subshell pattern
+- **Headless mode** (`headless=true`): Runs Claude in a detached subshell with `exec`, outputs structured `PID:` and `Log:` format for server integration
+
+**Structured output format** (headless mode only):
+```
+PID: <claude-process-id>
+Log: <log-file-path>
+```
+
+This format enables server daemons to track Claude process liveness and tail output logs.

--- a/src/cli/wt/README.md
+++ b/src/cli/wt/README.md
@@ -8,7 +8,7 @@ Modular implementation of the `wt` git worktree helper. These files are sourced 
 
 | File | Description | Exports |
 |------|-------------|---------|
-| `helpers.sh` | Repository detection and path resolution | `wt_common`, `wt_is_bare_repo`, `wt_get_default_branch`, `wt_configure_origin_tracking`, `wt_resolve_worktree`, `wt_claim_issue_status` |
+| `helpers.sh` | Repository detection and path resolution | `wt_common`, `wt_is_bare_repo`, `wt_get_default_branch`, `wt_configure_origin_tracking`, `wt_resolve_worktree`, `wt_claim_issue_status`, `wt_invoke_claude` |
 | `completion.sh` | Shell-agnostic completion helper | `wt_complete` |
 | `commands.sh` | Command implementations | `cmd_common`, `cmd_init`, `cmd_clone`, `cmd_goto`, `cmd_list`, `cmd_remove`, `cmd_prune`, `cmd_purge`, `cmd_spawn`, `cmd_rebase`, `cmd_help` |
 | `dispatch.sh` | Main dispatcher and entry point | `wt` |


### PR DESCRIPTION
## Summary

- Extract duplicated Claude CLI invocation logic from `cmd_spawn` and `cmd_rebase` into a unified `wt_invoke_claude()` helper function
- Consolidate flag handling (`--dangerously-skip-permissions`, `--print`), yolo warning messages, and headless/interactive mode execution
- Reduce code duplication by ~70 lines while maintaining identical behavior

## Changes

| File | Change |
|------|--------|
| `src/cli/wt/helpers.sh` | Add `wt_invoke_claude()` helper function |
| `src/cli/wt/commands.sh` | Refactor `cmd_spawn` and `cmd_rebase` to use new helper |
| `src/cli/wt/README.md` | Update exports list |
| `docs/feat/cli/wt.md` | Document unified invocation interface |

## Test plan

- [x] Run `test-wt-spawn-headless-nonblocking.sh` - validates PID:/Log: format and non-blocking behavior
- [x] Run `test-wt-rebase.sh` - validates flag parsing for `--headless` and `--yolo`
- [x] Run full test suite (`TEST_SHELLS="bash zsh" make test`) - 68/68 tests pass in both shells

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
