### PR TITLE
[feat] Add sync-master workflow to handsoff mode hooks

### DIFF
--- a/.claude-plugin/hooks/stop.py
+++ b/.claude-plugin/hooks/stop.py
@@ -120,6 +120,29 @@ The ultimate goal of this workflow is to create a GitHub [plan] issue from the u
    - Include the session ID: {session_id} so that human can `claude -r {session_id}` for intervention.
 4. To stop further continuations, run:
    jq '.state = "done"' {fname} > {fname}.tmp && mv {fname}.tmp {fname}'''
+        elif workflow == 'sync-master':
+            pr_no = state.get('pr_no', 'unknown')
+            prompt = f'''
+This is an auto-continuation prompt for handsoff mode, it is currently {continuation_count}/{max_continuations} continuations.
+The ultimate goal of this workflow is to sync the local main/master branch with upstream and force-push the PR branch.
+
+1. Check if the rebase has completed successfully:
+   - Run `git status` to verify the working tree state
+   - If rebase conflicts are detected, resolve them and run `git rebase --continue`
+   - If rebase was aborted, re-run the sync-master workflow from the beginning
+2. After successful rebase, verify the PR number is available: {pr_no}
+   - If PR number is 'unknown', check the current branch name for the PR association
+3. Force-push the rebased branch to update the PR:
+   - Run `git push -f` to push the rebased changes
+   - Verify the push succeeded without errors
+4. After successful push, manually stop further continuations.
+5. If you encounter unresolvable conflicts or errors:
+   - Stop manually and inform the user what happened
+   - Include what you have done so far
+   - Include what is blocking you
+   - Include the session ID: {session_id} so that human can `claude -r {session_id}` for intervention.
+6. To stop further continuations, run:
+   jq '.state = "done"' {fname} > {fname}.tmp && mv {fname}.tmp {fname}'''
 
         if prompt:
             with open(fname, 'w') as f:

--- a/.claude-plugin/hooks/user-prompt-submit.py
+++ b/.claude-plugin/hooks/user-prompt-submit.py
@@ -46,6 +46,21 @@ def _extract_issue_no(prompt):
     return None
 
 
+def _extract_pr_no(prompt):
+    """Extract PR number from /sync-master command arguments.
+
+    Pattern:
+    - /sync-master <number>
+
+    Returns:
+        int or None if no PR number found
+    """
+    match = re.match(r'^/sync-master\s+(\d+)', prompt)
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def main():
 
     handsoff = os.getenv('HANDSOFF_MODE', '0')
@@ -91,6 +106,13 @@ def main():
     if prompt.startswith('/setup-viewboard'):
         state['workflow'] = 'setup-viewboard'
         state['state'] = 'initial'
+
+    if prompt.startswith('/sync-master'):
+        state['workflow'] = 'sync-master'
+        state['state'] = 'initial'
+        pr_no = _extract_pr_no(prompt)
+        if pr_no is not None:
+            state['pr_no'] = pr_no
 
     if state:
         # Extract optional issue number from command arguments

--- a/.cursor/hooks/before-prompt-submit.py
+++ b/.cursor/hooks/before-prompt-submit.py
@@ -51,6 +51,21 @@ def _extract_issue_no(prompt):
     return None
 
 
+def _extract_pr_no(prompt):
+    """Extract PR number from /sync-master command arguments.
+
+    Pattern:
+    - /sync-master <number>
+
+    Returns:
+        int or None if no PR number found
+    """
+    match = re.match(r'^/sync-master\s+(\d+)', prompt)
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def main():
     # Read hook input from stdin first
     hook_input = json.load(sys.stdin)
@@ -96,6 +111,13 @@ def main():
     if prompt.startswith('/setup-viewboard'):
         state['workflow'] = 'setup-viewboard'
         state['state'] = 'initial'
+
+    if prompt.startswith('/sync-master'):
+        state['workflow'] = 'sync-master'
+        state['state'] = 'initial'
+        pr_no = _extract_pr_no(prompt)
+        if pr_no is not None:
+            state['pr_no'] = pr_no
 
     if state:
         # Extract optional issue number from command arguments

--- a/.cursor/hooks/stop.py
+++ b/.cursor/hooks/stop.py
@@ -139,6 +139,28 @@ The ultimate goal of this workflow is to deliver a PR on GitHub that implements 
 6. To stop further continuations, run:
    jq '.state = "done"' {fname} > {fname}.tmp && mv {fname}.tmp {fname}
 7. When creating issues or PRs, use `--body-file` instead of `--body`, as body content with "--something" will be misinterpreted as flags.'''
+        elif workflow == 'sync-master':
+            pr_no = state.get('pr_no', 'unknown')
+            prompt = f'''This is an auto-continuation prompt for handsoff mode, it is currently {continuation_count + 1}/{max_continuations} continuations.
+The ultimate goal of this workflow is to sync the local main/master branch with upstream and force-push the PR branch.
+
+1. Check if the rebase has completed successfully:
+   - Run `git status` to verify the working tree state
+   - If rebase conflicts are detected, resolve them and run `git rebase --continue`
+   - If rebase was aborted, re-run the sync-master workflow from the beginning
+2. After successful rebase, verify the PR number is available: {pr_no}
+   - If PR number is 'unknown', check the current branch name for the PR association
+3. Force-push the rebased branch to update the PR:
+   - Run `git push -f` to push the rebased changes
+   - Verify the push succeeded without errors
+4. After successful push, manually stop further continuations.
+5. If you encounter unresolvable conflicts or errors:
+   - Stop manually and inform the user what happened
+   - Include what you have done so far
+   - Include what is blocking you
+   - Include the session ID: {session_id} so that human can `claude -r {session_id}` for intervention.
+6. To stop further continuations, run:
+   jq '.state = "done"' {fname} > {fname}.tmp && mv {fname}.tmp {fname}'''
 
         if prompt:
             with open(fname, 'w') as f:


### PR DESCRIPTION
## Summary

- Add sync-master workflow tracking to user-prompt-submit hooks for workflow state initialization
- Add sync-master continuation prompts to stop hooks for hands-off PR rebase completion
- Mirror changes in both Claude Code (`.claude-plugin/hooks/`) and Cursor (`.cursor/hooks/`) hooks

## Changes

| File | Purpose |
|------|---------|
| `.claude-plugin/hooks/user-prompt-submit.py` | Add `_extract_pr_no()` helper and sync-master workflow detection |
| `.claude-plugin/hooks/stop.py` | Add sync-master continuation prompt for rebase → push -f guidance |
| `.cursor/hooks/before-prompt-submit.py` | Mirror sync-master workflow detection for Cursor |
| `.cursor/hooks/stop.py` | Mirror sync-master continuation prompt for Cursor |

## Test plan

- [x] All 68 tests pass in both bash and zsh (`TEST_SHELLS="bash zsh" make test`)
- [x] Code quality review completed
- [ ] Manual verification: Run `wt rebase <pr-no>` with `HANDSOFF_MODE=1` to verify workflow tracking

## Notes

The continuation prompt guides Claude through:
1. Verifying rebase completion and resolving any conflicts
2. Confirming PR number availability
3. Executing `git push -f` to update the PR
4. Stopping continuations after successful push

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
