### PR TITLE
[bugfix] Fix agentize:pr label to only apply to PRs, not issues

### DIFF
--- a/.claude-plugin/commands/issue-to-impl.md
+++ b/.claude-plugin/commands/issue-to-impl.md
@@ -341,17 +341,7 @@ git diff --cached --name-only  # Verify no .tmp/milestones/ files
 
 Then invoke `commit-msg` skill with `purpose=delivery` and appropriate tags based on the changes.
 
-**Add agentize:pr label to mark completion:**
-
-After the delivery commit is created successfully, add the `agentize:pr` label to the issue:
-
-```bash
-gh issue edit {issue-number} --add-label "agentize:pr"
-```
-
-This marks the issue as having completed implementation and being ready for PR creation.
-
-Command completes successfully after delivery commit is created and label is added.
+Command completes successfully after delivery commit is created.
 
 **Output C: Critical error**
 ```

--- a/python/agentize/server/__main__.md
+++ b/python/agentize/server/__main__.md
@@ -157,16 +157,6 @@ Clean up after feat-request planning completion: remove `agentize:feat-request` 
 1. Remove `agentize:feat-request` label via `gh issue edit`
 2. Log cleanup action
 
-### `_add_pr_label(issue_no: int) -> None`
-
-Add `agentize:pr` label when implementation workflow completes.
-
-**Operations:**
-1. Add `agentize:pr` label via `gh issue edit`
-2. Log label addition
-
-**Note:** Only called for implementation workflows, not for refinement or feat-request workflows.
-
 ### `worktree_exists(issue_no: int) -> bool`
 
 Check if a worktree exists for the given issue number.

--- a/python/agentize/server/__main__.py
+++ b/python/agentize/server/__main__.py
@@ -64,7 +64,6 @@ from agentize.server.workers import (
     _check_issue_has_label,
     _cleanup_refinement,
     _cleanup_feat_request,
-    _add_pr_label,
     DEFAULT_WORKERS_DIR,
 )
 

--- a/python/agentize/server/workers.py
+++ b/python/agentize/server/workers.py
@@ -126,20 +126,6 @@ def _cleanup_feat_request(issue_no: int) -> None:
     _log(f"Feat-request cleanup for issue #{issue_no}: removed agentize:feat-request label")
 
 
-def _add_pr_label(issue_no: int) -> None:
-    """Add agentize:pr label when workflow completes.
-
-    Args:
-        issue_no: GitHub issue number
-    """
-    subprocess.run(
-        ['gh', 'issue', 'edit', str(issue_no), '--add-label', 'agentize:pr'],
-        capture_output=True,
-        text=True
-    )
-    _log(f"Added agentize:pr label to issue #{issue_no}")
-
-
 def spawn_refinement(issue_no: int) -> tuple[bool, int | None]:
     """Spawn a refinement session for the given issue.
 
@@ -397,11 +383,6 @@ def cleanup_dead_workers(
                     is_feat_request = _check_issue_has_label(issue_no, 'agentize:feat-request')
                     if is_feat_request:
                         _cleanup_feat_request(issue_no)
-
-                    # Add agentize:pr label only for implementation workflows
-                    # (not refinement or feat-request which don't create PRs)
-                    if not is_refinement and not is_feat_request:
-                        _add_pr_label(issue_no)
 
                     issue_url = f"https://github.com/{repo_slug}/issues/{issue_no}" if repo_slug else None
 


### PR DESCRIPTION
## Summary

- Remove `_add_pr_label()` function from `workers.py` that incorrectly added `agentize:pr` label to issues
- Remove the call to `_add_pr_label()` in the worker completion flow
- Remove `_add_pr_label` from module exports and documentation
- Remove incorrect instruction in `issue-to-impl.md` to add the label to issues

The `agentize:pr` label is used by the auto-rebase workflow (`discover_candidate_prs`) to find PRs that need rebasing. This label should only exist on pull requests, not issues. The `/open-pr` skill already correctly adds this label to PRs via `gh pr create --label "agentize:pr"`.

## Test plan

- [x] All 68 tests pass in both bash and zsh
- [x] Verified Python imports work correctly after removing the function
- [x] Code quality review passed

Fixes #468

🤖 Generated with [Claude Code](https://claude.ai/code)
