### PR TITLE
[refactor][#488] Fix permission evaluation ordering with clear rule priority

### DIFF
--- a/docs/feat/core/handsoff.md
+++ b/docs/feat/core/handsoff.md
@@ -312,13 +312,13 @@ Handsoff mode is implemented via three Claude Code hooks (see [.claude/hooks/REA
 
 ### `pre-tool-use.py`
 - **Event:** `PreToolUse` (before tool execution)
-- **Purpose:** Thin wrapper delegating to `python/agentize/permission/` module
-- **Location:** `.claude/hooks/pre-tool-use.py`
+- **Purpose:** Thin wrapper delegating to `.claude-plugin/lib/permission/` module
+- **Location:** `.claude-plugin/hooks/pre-tool-use.py`
 
 **Key logic:**
-- Imports and calls `agentize.permission.determine()` for all permission decisions
-- Rules are sourced from `python/agentize/permission/rules.py` (canonical location)
-- Matches tool usage against deny → ask → allow rules (first match wins)
+- Imports and calls `lib.permission.determine()` for all permission decisions
+- Rules are sourced from `.claude-plugin/lib/permission/rules.py` (canonical location)
+- Evaluation order: Global rules → Workflow auto-allow → Haiku LLM → Telegram (single final escalation)
 - Returns `allow/deny/ask` decision to Claude Code
 - Logs tool usage when `HANDSOFF_DEBUG=1`
 - Falls back to `ask` on any import/execution errors
@@ -326,10 +326,10 @@ Handsoff mode is implemented via three Claude Code hooks (see [.claude/hooks/REA
 **Architecture notes:**
 - The hook is a minimal wrapper (~15 LOC) that delegates to the permission module
 - Permission rules are defined in Python code instead of `.claude/settings.json`
-- Single source of truth: `python/agentize/permission/rules.py`
+- Single source of truth: `.claude-plugin/lib/permission/rules.py`
 - Fail-safe behavior: returns `ask` on any errors
 
-See [.claude/hooks/pre-tool-use.md](../../.claude/hooks/pre-tool-use.md) for interface details.
+See [.claude-plugin/hooks/pre-tool-use.md](../../.claude-plugin/hooks/pre-tool-use.md) for interface details.
 
 ### `user-prompt-submit.py` (Claude Code)
 - **Event:** `UserPromptSubmit` (before prompt is sent to Claude Code)

--- a/docs/feat/permissions/rules.md
+++ b/docs/feat/permissions/rules.md
@@ -1,7 +1,151 @@
 # Rule-Based Permission Management
 
-TODO: Document rule-based permission management.
+Permission rules control tool access through a priority-based evaluation flow.
 
 ## Overview
 
-This document describes how Agentize handles permissions through configurable rules.
+The permission system evaluates tool requests through multiple stages with clear priority ordering. Each stage can return `allow`, `deny`, or `ask`. The key principle is that **global rules always take priority over workflow-specific permissions**.
+
+## Evaluation Order
+
+Permission requests flow through these stages in order:
+
+```
+Tool Request
+    │
+    ▼
+┌─────────────────────────────┐
+│  1. Global Rules            │  ← First match wins (deny/allow/ask)
+│     deny  → DENY (stop)     │
+│     allow → ALLOW (stop)    │
+│     ask   → fall through    │
+└─────────────────────────────┘
+    │ (ask or no match)
+    ▼
+┌─────────────────────────────┐
+│  2. Workflow Auto-Allow     │  ← Workflow-scoped patterns
+│     allow → ALLOW (stop)    │
+│     none  → fall through    │
+└─────────────────────────────┘
+    │ (no match)
+    ▼
+┌─────────────────────────────┐
+│  3. Haiku LLM               │  ← Context-aware evaluation
+│     deny  → DENY (stop)     │
+│     allow → ALLOW (stop)    │
+│     ask   → fall through    │
+└─────────────────────────────┘
+    │ (ask)
+    ▼
+┌─────────────────────────────┐
+│  4. Telegram Escalation     │  ← Single final escalation
+│     deny  → DENY (stop)     │
+│     allow → ALLOW (stop)    │
+│     timeout → ASK (prompt)  │
+└─────────────────────────────┘
+```
+
+## Stage Details
+
+### Stage 1: Global Rules
+
+Global rules are defined in `.claude-plugin/lib/permission/rules.py`. They are evaluated first and take absolute priority.
+
+**Decision behavior:**
+- `deny` → Request is denied immediately. No further evaluation.
+- `allow` → Request is allowed immediately. No further evaluation.
+- `ask` → Falls through to Stage 2 (workflow auto-allow).
+
+**Example rules:**
+```python
+# Deny rules (highest priority)
+('deny', 'Bash', r'^rm\s+-rf'),        # Never allow rm -rf
+('deny', 'Bash', r'^sudo\s+'),          # Never allow sudo
+
+# Allow rules
+('allow', 'Bash', r'^git\s+status'),    # Always allow git status
+('allow', 'Read', r'.*'),               # Allow all file reads
+
+# Ask rules (fall through)
+('ask', 'Bash', r'^gh\s+api'),          # Prompt for gh api calls
+```
+
+### Stage 2: Workflow Auto-Allow
+
+Workflow-specific permissions apply only when a workflow session is active. These patterns allow known-safe operations within the context of a specific workflow.
+
+**Key constraint:** Workflow auto-allow **cannot override global deny rules**. A workflow cannot auto-allow `rm -rf` if global rules deny it.
+
+**Decision behavior:**
+- `allow` → Request is allowed. No further evaluation.
+- No match → Falls through to Stage 3 (Haiku LLM).
+
+**Example:** The `setup-viewboard` workflow auto-allows:
+- `gh auth status` (authentication verification)
+- `gh repo view --json owner` (repository lookup)
+- `gh api graphql` (project configuration)
+- `gh label create --force` (label creation)
+
+These patterns are defined per-workflow and only active during that workflow's session.
+
+### Stage 3: Haiku LLM
+
+When enabled via `HANDSOFF_AUTO_PERMISSION=1`, Haiku evaluates tool requests using conversation context. This provides intelligent permission decisions for operations not covered by explicit rules.
+
+**Decision behavior:**
+- `deny` → Request is denied. No further evaluation.
+- `allow` → Request is allowed. No further evaluation.
+- `ask` → Falls through to Stage 4 (Telegram).
+
+### Stage 4: Telegram Escalation
+
+Telegram approval is the **single final escalation point** for all `ask` outcomes. When enabled via `AGENTIZE_USE_TG=1`, the system sends approval requests to Telegram.
+
+**Decision behavior:**
+- `deny` → Request is denied.
+- `allow` → Request is allowed.
+- Timeout/error → Returns `ask` (prompts local user via Claude Code).
+
+**Important:** Telegram escalation occurs **once at the end**, not at multiple points. This prevents duplicate approval requests and provides a clean escalation path.
+
+See [telegram.md](telegram.md) for configuration details.
+
+## Fall-Through Behavior
+
+The `ask` decision has special fall-through behavior:
+
+1. **Global rule returns `ask`** → Continues to workflow auto-allow, then Haiku, then Telegram
+2. **Workflow auto-allow has no match** → Continues to Haiku, then Telegram
+3. **Haiku returns `ask`** → Continues to Telegram
+4. **Telegram times out** → Returns `ask` (prompts local user)
+
+This ensures that uncertain decisions are progressively escalated through more context-aware stages before finally prompting the user.
+
+## Error Handling
+
+The permission system is fail-safe:
+
+- **Rule evaluation errors** → Falls through to Haiku
+- **Haiku errors** → Falls through to Telegram
+- **Telegram errors** → Returns `ask` (prompts local user)
+
+The system never crashes on errors—it degrades gracefully to user prompts.
+
+## Configuration
+
+### Global Rules
+
+Edit `.claude-plugin/lib/permission/rules.py` to modify global rules. Rules are evaluated in order; first match wins.
+
+### Workflow Auto-Allow
+
+Workflow-specific patterns are defined in `.claude-plugin/lib/permission/determine.py` under workflow-specific pattern lists (e.g., `_SETUP_VIEWBOARD_ALLOW_PATTERNS`).
+
+### Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `HANDSOFF_AUTO_PERMISSION` | Enable Haiku LLM evaluation (`1` to enable) |
+| `AGENTIZE_USE_TG` | Enable Telegram escalation (`1` to enable) |
+
+See [telegram.md](telegram.md) and [handsoff.md](../core/handsoff.md) for full configuration options.

--- a/docs/feat/permissions/telegram.md
+++ b/docs/feat/permissions/telegram.md
@@ -4,7 +4,14 @@ Manual approval workflow via Telegram for hands-off automation.
 
 ## Overview
 
-When rule-based permissions return `ask` (or when Haiku LLM evaluation is uncertain), the permission system can escalate to Telegram for manual approval. This enables secure hands-off operation by letting you approve/deny tool calls from your phone.
+Telegram is the **single final escalation point** in the permission evaluation flow. When all other stages (global rules, workflow auto-allow, Haiku LLM) result in `ask`, the system escalates to Telegram for manual approval. This enables secure hands-off operation by letting you approve/deny tool calls from your phone.
+
+**Position in evaluation order:**
+```
+Global Rules → Workflow Auto-Allow → Haiku LLM → Telegram (final)
+```
+
+Telegram escalation occurs **once at the end**, not at multiple points. This prevents duplicate approval requests and provides a clean escalation path. See [rules.md](rules.md) for the complete evaluation order.
 
 ## Configuration
 

--- a/tests/fixtures/test-pre-tool-use-input.json
+++ b/tests/fixtures/test-pre-tool-use-input.json
@@ -133,5 +133,19 @@
       "command": "gh label create --force agentize:plan"
     },
     "session_id": "test-session-setup-viewboard"
+  },
+  "order_test_global_deny_vs_workflow_allow": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "rm -rf /tmp/test"
+    },
+    "session_id": "test-session-ordering"
+  },
+  "order_test_rule_ask_fallthrough": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "python3 test_script.py"
+    },
+    "session_id": "test-session-ordering"
   }
 }


### PR DESCRIPTION
## Summary

Fixed the permission evaluation order to ensure global rules take priority over workflow-specific permissions, with clear fall-through behavior and unified Telegram escalation. The previous implementation allowed workflow auto-allow to bypass global deny rules, which was a security concern.

## Changes

- Modified `.claude-plugin/lib/permission/determine.py:435-491` to reorder evaluation flow:
  1. Global rules first (deny/allow return, ask falls through)
  2. Workflow auto-allow (allow returns, otherwise continue)
  3. Haiku LLM evaluation (deny/allow return, ask falls through)
  4. Telegram (single final escalation for ask)
- Updated `docs/feat/permissions/rules.md` with explicit evaluation order diagram and stage documentation
- Updated `docs/feat/permissions/telegram.md` to clarify Telegram as the final escalation point
- Fixed `docs/feat/core/handsoff.md` to correct hook location and permission module paths
- Added `tests/cli/test-hook-permission-matching.sh:317-433` with 4 new ordering tests:
  - Test 30: Global deny overrides workflow allow
  - Test 31: Rule 'ask' falls through to workflow auto-allow
  - Test 32: Evaluation order validation via decision source
  - Test 33: Docstring verification for priority order
- Added `tests/fixtures/test-pre-tool-use-input.json` with ordering test fixtures

## Testing

- All 70 existing tests pass with the new implementation
- Added 4 new tests specifically for evaluation order validation:
  - Global deny rules properly override workflow auto-allow (rm -rf denied even with workflow session)
  - Rule 'ask' correctly falls through to workflow auto-allow
  - Decision source correctly reports 'rules' for global deny decisions
  - Docstring verification confirms priority order documentation matches implementation
- Manually verified:
  1. Workflow auto-allow patterns still work when global rules return 'ask'
  2. Global deny rules block dangerous commands regardless of workflow state
  3. Error recovery preserves the correct evaluation order

## Related Issue

Closes #488
