### PR TITLE
[chore][#495] Consolidate permission determination logging into unified permission.txt

### DIFF
--- a/.claude-plugin/hooks/pre-tool-use.md
+++ b/.claude-plugin/hooks/pre-tool-use.md
@@ -116,8 +116,9 @@ This prevents hook failures from blocking Claude Code execution.
 ## Logging Behavior
 
 When `HANDSOFF_DEBUG=1`:
-- Writes tool usage to `$AGENTIZE_HOME/.tmp/hooked-sessions/tool-used.txt` (falls back to worktree-local `.tmp/` if `AGENTIZE_HOME` is unset)
-- Format: `[timestamp] [session_id] [workflow] tool | target`
+- Writes all permission decisions to `$AGENTIZE_HOME/.tmp/hooked-sessions/permission.txt` (falls back to worktree-local `.tmp/` if `AGENTIZE_HOME` is unset)
+- Format: `[timestamp] [session_id] [workflow] [source] [decision] tool | target`
+- Unified log contains all decision sources: rules, haiku, telegram, workflow, error
 - Preserved regardless of permission decision
 
 ## Telegram Approval Integration

--- a/.claude-plugin/lib/README.md
+++ b/.claude-plugin/lib/README.md
@@ -53,7 +53,7 @@ from lib.workflow import detect_workflow, get_continuation_prompt
 
 ### logger.py
 
-Debug logging utilities for hooks. Logs to `.tmp/hook-debug.log` when `HANDSOFF_DEBUG` is enabled.
+Debug logging utilities for hooks. Logs permission decisions to `.tmp/hooked-sessions/permission.txt` with unified format when `HANDSOFF_DEBUG` is enabled.
 
 **Usage:**
 ```python

--- a/.claude-plugin/lib/logger.py
+++ b/.claude-plugin/lib/logger.py
@@ -25,13 +25,13 @@ def logger(sid, msg):
         log_file.write(f"[{time}] [{sid}] {msg}\n")
 
 
-def log_tool_decision(session, context, tool, target, decision):
-    # Log all Haiku decisions and errors to tool-haiku-determined.txt
+def log_tool_decision(session, context, tool, target, decision, workflow='unknown', source='error'):
+    # Log permission decisions to unified permission.txt file
     if os.getenv('HANDSOFF_DEBUG', '0').lower() in ['0', 'false', 'off', 'disable']:
         return
     session_dir = _session_dir()
     os.makedirs(session_dir, exist_ok=True)
     time = datetime.datetime.now().isoformat()
-    log_path = os.path.join(session_dir, 'tool-haiku-determined.txt')
+    log_path = os.path.join(session_dir, 'permission.txt')
     with open(log_path, 'a') as f:
-        f.write(f'[{time}] [{session}] {tool} | {target} => {decision}\n')
+        f.write(f'[{time}] [{session}] [{workflow}] [{source}] [{decision}] {tool} | {target}\n')

--- a/docs/feat/core/handsoff.md
+++ b/docs/feat/core/handsoff.md
@@ -100,7 +100,7 @@ Set in shell environment or `.claude/settings.json`:
 **`HANDSOFF_DEBUG`**
 - **Purpose:** Enable detailed debug logging and tool usage tracking
 - **Values:** `1` (enabled), `0` (disabled, default)
-- **Log file:** `${AGENTIZE_HOME:-.}/.tmp/hooked-sessions/tool-used.txt`
+- **Log file:** `${AGENTIZE_HOME:-.}/.tmp/hooked-sessions/permission.txt` (unified permission log)
 - **Additional output:** Server issue-filter logs (see [server.md](../server.md#issue-filtering-debug-logs))
 - **Example:** `export HANDSOFF_DEBUG=1`
 


### PR DESCRIPTION
## Summary

Consolidated all permission determination logging into a single unified `permission.txt` file with a standardized format. Previously, permission decisions were scattered across three separate files (tool-used.txt, tool-haiku-determined.txt, tool-telegram-determined.txt), making it difficult to analyze the complete permission decision history.

## Changes

- Modified `.claude-plugin/lib/logger.py:28-37` to write unified permission log format to single permission.txt file
- Updated `.claude-plugin/lib/permission/determine.py` to pass workflow and source parameters to all log_tool_decision() calls
- Simplified `_log_debug_info()` function in determine.py to delegate to log_tool_decision()
- Updated `docs/feat/core/handsoff.md:100-105` to reference new unified log file
- Updated `.claude-plugin/hooks/pre-tool-use.md:116-122` to document unified log format
- Updated `.claude-plugin/lib/README.md:54-61` to describe unified logger behavior

## Testing

Verified via syntax check that all Python files compile correctly:
- Checked logger.py for syntax errors
- Checked permission/determine.py for syntax errors
- All files pass Python3 compilation validation

Manual verification performed:
- Reviewed all log_tool_decision() calls to ensure workflow and source parameters are passed consistently
- Verified unified log format matches specification: [timestamp] [session_id] [workflow] [source] [decision] tool | target
- Confirmed all decision sources are captured: rules, haiku, telegram, workflow, error
- Verified old log files (tool-used.txt, tool-haiku-determined.txt, tool-telegram-determined.txt) will no longer be created

## Related Issue

Closes #495
