### PR TITLE
[#502][feat][cli] Add logging output to wt and lol CLI tools

### DIFF
--- a/src/cli/lol.md
+++ b/src/cli/lol.md
@@ -42,6 +42,11 @@ lol <command> [options]
 - `0`: Command executed successfully
 - `1`: Invalid command, command failed, or help displayed
 
+**Logging Behavior:**
+- At startup, logs version information to stderr: `[agentize] <version-tag-or-commit> @ <full-commit-hash>`
+- Version information comes from git tags (via `git describe --tags --always` from `AGENTIZE_HOME`) and commit hash (via `git rev-parse HEAD`)
+- Logging is suppressed for `--complete` mode to avoid polluting completion output
+
 **Commands:**
 - `upgrade`: Upgrade agentize installation
 - `project`: GitHub Projects v2 integration

--- a/src/cli/lol/dispatch.sh
+++ b/src/cli/lol/dispatch.sh
@@ -2,6 +2,24 @@
 # lol CLI main dispatcher
 # Entry point and help text
 
+# Log version information to stderr
+_lol_log_version() {
+    # Get version from git describe or short commit hash (from AGENTIZE_HOME)
+    local version="unknown"
+    if [ -n "$AGENTIZE_HOME" ] && command -v git >/dev/null 2>&1; then
+        # Try to get tag, fall back to short commit hash
+        version=$(git -C "$AGENTIZE_HOME" describe --tags --always 2>/dev/null || echo "unknown")
+    fi
+
+    # Get full commit hash (from AGENTIZE_HOME)
+    local commit="unknown"
+    if [ -n "$AGENTIZE_HOME" ] && command -v git >/dev/null 2>&1; then
+        commit=$(git -C "$AGENTIZE_HOME" rev-parse HEAD 2>/dev/null || echo "unknown")
+    fi
+
+    echo "[agentize] $version @ $commit" >&2
+}
+
 # Main lol function
 lol() {
     # Handle completion helper before AGENTIZE_HOME validation
@@ -37,6 +55,9 @@ lol() {
         echo "  AGENTIZE_HOME may not point to a valid agentize repository"
         return 1
     fi
+
+    # Log version at startup
+    _lol_log_version
 
     # Handle --version flag as alias for version subcommand
     if [ "$1" = "--version" ]; then

--- a/src/cli/wt.md
+++ b/src/cli/wt.md
@@ -37,6 +37,12 @@ wt <command> [options]
 - `0`: Command executed successfully
 - `1`: Invalid command, command failed, or help displayed
 
+**Logging Behavior:**
+- At startup, logs version information to stderr: `[agentize] <version-tag-or-commit> @ <full-commit-hash>`
+- Version information comes from git tags (via `git describe --tags --always`) and commit hash (via `git rev-parse HEAD`)
+- Logging is suppressed for `--complete` mode to avoid polluting completion output
+- When `AGENTIZE_HOME` is not set, logs as "standalone"
+
 **Commands:**
 - `clone <url> [dest]`: Clone repository as bare and initialize worktree environment
 - `common`: Print git common directory (bare repo path)

--- a/src/cli/wt/dispatch.sh
+++ b/src/cli/wt/dispatch.sh
@@ -2,8 +2,41 @@
 # wt CLI main dispatcher
 # Entry point and help routing
 
+# Log version information to stderr
+_wt_log_version() {
+    # Skip logging in --complete mode
+    if [ "$1" = "--complete" ]; then
+        return 0
+    fi
+
+    # Get version from git describe or short commit hash
+    local version="unknown"
+    if command -v git >/dev/null 2>&1; then
+        # Try to get tag, fall back to short commit hash
+        version=$(git describe --tags --always 2>/dev/null || echo "unknown")
+    fi
+
+    # Get full commit hash
+    local commit="unknown"
+    if command -v git >/dev/null 2>&1; then
+        commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+    fi
+
+    # If AGENTIZE_HOME is not set, log as "standalone"
+    if [ -z "$AGENTIZE_HOME" ]; then
+        version="$version-standalone"
+    fi
+
+    echo "[agentize] $version @ $commit" >&2
+}
+
 # Main wt function
 wt() {
+    # Log version at startup (skip for --complete mode)
+    if [ "$1" != "--complete" ]; then
+        _wt_log_version "$1"
+    fi
+
     local command="$1"
     [ $# -gt 0 ] && shift
 

--- a/tests/cli/test-lol-logging.sh
+++ b/tests/cli/test-lol-logging.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Test: lol CLI logging output at startup
+
+source "$(dirname "$0")/../common.sh"
+
+LOL_CLI="$PROJECT_ROOT/src/cli/lol.sh"
+
+test_info "lol CLI logging output at startup"
+
+export AGENTIZE_HOME="$PROJECT_ROOT"
+source "$LOL_CLI"
+
+# Test 1: Verify logging appears in stderr on normal command (--version)
+test_info "Test 1: Verify logging appears in stderr on --version command"
+output=$(lol --version 2>&1 >/dev/null)
+echo "$output" | grep -q "^\[agentize\]" || test_fail "Logging output missing from stderr"
+echo "$output" | grep -q "@" || test_fail "Logging format incorrect - missing commit hash separator"
+test_pass "Test 1: Logging appears in stderr on --version"
+
+# Test 2: Verify logging includes version tag or commit hash
+test_info "Test 2: Verify logging includes version tag or commit hash"
+output=$(lol --version 2>&1 >/dev/null)
+# Extract the part between [agentize] and @
+version_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/\[agentize\] //;s/ @.*//')
+if [ -z "$version_part" ]; then
+  test_fail "Version part is empty"
+fi
+# Should match either a tag (e.g., v1.0.8) or a commit hash (7+ hex chars)
+if ! echo "$version_part" | grep -qE '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,40})$'; then
+  test_fail "Version part format incorrect: $version_part"
+fi
+test_pass "Test 2: Logging includes version tag or commit hash"
+
+# Test 3: Verify logging format includes full commit hash
+test_info "Test 3: Verify logging format includes full commit hash"
+output=$(lol --version 2>&1 >/dev/null)
+# Extract the part after @ (commit hash)
+commit_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/.* @ //')
+if [ -z "$commit_part" ]; then
+  test_fail "Commit hash part is empty"
+fi
+# Should be at least 7 characters (short hash) or 40 (full hash)
+if ! echo "$commit_part" | grep -qE '^[a-f0-9]{7,40}$'; then
+  test_fail "Commit hash format incorrect: $commit_part"
+fi
+test_pass "Test 3: Logging format includes full commit hash"
+
+# Test 4: Verify no logging in --complete mode
+test_info "Test 4: Verify no logging in --complete mode"
+output=$(lol --complete commands 2>&1)
+if echo "$output" | grep -q "^\[agentize\]"; then
+  test_fail "Logging should be suppressed in --complete mode"
+fi
+# But completion data should still appear
+echo "$output" | grep -q "upgrade" || test_fail "Completion data missing when logging suppressed"
+test_pass "Test 4: No logging in --complete mode"
+
+# Test 5: Verify logging includes agentize branding
+test_info "Test 5: Verify logging includes agentize branding"
+output=$(lol --version 2>&1 >/dev/null)
+echo "$output" | grep -q "^\[agentize\]" || test_fail "Missing agentize branding in logging"
+test_pass "Test 5: Logging includes agentize branding"
+
+test_pass "lol CLI logging output verified successfully"

--- a/tests/cli/test-wt-logging.sh
+++ b/tests/cli/test-wt-logging.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Test: wt CLI logging output at startup
+
+source "$(dirname "$0")/../common.sh"
+
+WT_CLI="$PROJECT_ROOT/src/cli/wt.sh"
+
+test_info "wt CLI logging output at startup"
+
+export AGENTIZE_HOME="$PROJECT_ROOT"
+source "$WT_CLI"
+
+# Test 1: Verify logging appears in stderr on normal command
+test_info "Test 1: Verify logging appears in stderr on normal command"
+output=$(wt help 2>&1 >/dev/null)
+echo "$output" | grep -q "^\[agentize\]" || test_fail "Logging output missing from stderr"
+echo "$output" | grep -q "@" || test_fail "Logging format incorrect - missing commit hash separator"
+test_pass "Test 1: Logging appears in stderr"
+
+# Test 2: Verify logging includes version tag or commit hash
+test_info "Test 2: Verify logging includes version tag or commit hash"
+output=$(wt help 2>&1 >/dev/null)
+# Extract the part between [agentize] and @
+version_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/\[agentize\] //;s/ @.*//')
+if [ -z "$version_part" ]; then
+  test_fail "Version part is empty"
+fi
+# Should match either a tag (e.g., v1.0.8) or a commit hash (40 hex chars)
+if ! echo "$version_part" | grep -qE '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,40})$'; then
+  test_fail "Version part format incorrect: $version_part"
+fi
+test_pass "Test 2: Logging includes version tag or commit hash"
+
+# Test 3: Verify logging format includes full commit hash
+test_info "Test 3: Verify logging format includes full commit hash"
+output=$(wt help 2>&1 >/dev/null)
+# Extract the part after @ (commit hash)
+commit_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/.* @ //')
+if [ -z "$commit_part" ]; then
+  test_fail "Commit hash part is empty"
+fi
+# Should be at least 7 characters (short hash) or 40 (full hash)
+if ! echo "$commit_part" | grep -qE '^[a-f0-9]{7,40}$'; then
+  test_fail "Commit hash format incorrect: $commit_part"
+fi
+test_pass "Test 3: Logging format includes full commit hash"
+
+# Test 4: Verify no logging in --complete mode
+test_info "Test 4: Verify no logging in --complete mode"
+output=$(wt --complete commands 2>&1)
+if echo "$output" | grep -q "^\[agentize\]"; then
+  test_fail "Logging should be suppressed in --complete mode"
+fi
+# But completion data should still appear
+echo "$output" | grep -q "^clone$" || test_fail "Completion data missing when logging suppressed"
+test_pass "Test 4: No logging in --complete mode"
+
+# Test 5: Verify logging includes agentize branding
+test_info "Test 5: Verify logging includes agentize branding"
+output=$(wt help 2>&1 >/dev/null)
+echo "$output" | grep -q "^\[agentize\]" || test_fail "Missing agentize branding in logging"
+test_pass "Test 5: Logging includes agentize branding"
+
+test_pass "wt CLI logging output verified successfully"


### PR DESCRIPTION
## Summary

Added logging output to the `wt` and `lol` CLI tools that displays agentize version information and commit hash at startup. This enhances user awareness of which version they're running, helping with debugging and issue reports.

## Changes

- Modified `src/cli/wt/dispatch.sh` to add `_wt_log_version()` function that logs version information to stderr
  - Retrieves version from `git describe --tags --always` or short commit hash
  - Gets full commit hash from `git rev-parse HEAD`
  - Logs as "standalone" when AGENTIZE_HOME is not set
  - Skips logging in `--complete` mode to avoid polluting shell completion data

- Modified `src/cli/lol/dispatch.sh` to add `_lol_log_version()` function
  - Retrieves version and commit from AGENTIZE_HOME using git commands
  - Called after AGENTIZE_HOME validation
  - Skips logging in `--complete` mode

- Updated `src/cli/wt.md` to document logging behavior
  - Format: `[agentize] <version-tag-or-commit> @ <full-commit-hash>`
  - Explains stderr output and --complete suppression

- Updated `src/cli/lol.md` to document logging behavior
  - Describes AGENTIZE_HOME dependency and version retrieval

- Created `tests/cli/test-wt-logging.sh` with 5 comprehensive test cases:
  - Verify logging appears in stderr on normal commands
  - Verify version tag or commit hash format
  - Verify full commit hash format
  - Verify no logging in --complete mode
  - Verify agentize branding

- Created `tests/cli/test-lol-logging.sh` with 5 comprehensive test cases:
  - Same coverage as wt tests adapted for lol CLI

## Testing

- Both new test files pass: `tests/cli/test-wt-logging.sh` and `tests/cli/test-lol-logging.sh`
- Tests verify:
  - Logging output format matches specification
  - Version and commit hash extraction works correctly
  - Logging suppression in --complete mode works
  - Agentize branding is included
- Full test suite run: 72/79 tests pass (7 pre-existing failures unrelated to this change)

## Related Issue

Closes #502
