### PR TITLE
[feat][cli][#505] Auto-allow session state modifications for workflow completion signaling

### DIFF
--- a/docs/feat/permissions/rules.md
+++ b/docs/feat/permissions/rules.md
@@ -80,11 +80,18 @@ Workflow-specific permissions apply only when a workflow session is active. Thes
 - `allow` → Request is allowed. No further evaluation.
 - No match → Falls through to Stage 3 (Haiku LLM).
 
-**Example:** The `setup-viewboard` workflow auto-allows:
+**Example workflows:**
+
+**setup-viewboard:** Auto-allows GitHub configuration operations:
 - `gh auth status` (authentication verification)
 - `gh repo view --json owner` (repository lookup)
 - `gh api graphql` (project configuration)
 - `gh label create --force` (label creation)
+
+**Any workflow:** Auto-allows session state modifications:
+- `jq '.state = "done"' ~/.agentize/.tmp/hooked-sessions/{session-id}.json > ... && mv ...` (workflow completion signaling)
+
+This allows workflows to update their session state files to signal completion without requiring permission prompts. The pattern requires literal `.tmp/hooked-sessions/` path and alphanumeric session IDs, preventing path traversal attacks.
 
 These patterns are defined per-workflow and only active during that workflow's session.
 

--- a/tests/fixtures/test-pre-tool-use-input.json
+++ b/tests/fixtures/test-pre-tool-use-input.json
@@ -147,5 +147,54 @@
       "command": "python3 test_script.py"
     },
     "session_id": "test-session-ordering"
+  },
+  "session_state_update_done": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"done\"' /tmp/.tmp/hooked-sessions/test-session-123.json > /tmp/.tmp/hooked-sessions/test-session-123.json.tmp && mv /tmp/.tmp/hooked-sessions/test-session-123.json.tmp /tmp/.tmp/hooked-sessions/test-session-123.json"
+    },
+    "session_id": "test-session-123"
+  },
+  "session_state_update_completed": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"completed\"' /home/user/.agentize/.tmp/hooked-sessions/session-abc.json > /home/user/.agentize/.tmp/hooked-sessions/session-abc.json.tmp && mv /home/user/.agentize/.tmp/hooked-sessions/session-abc.json.tmp /home/user/.agentize/.tmp/hooked-sessions/session-abc.json"
+    },
+    "session_id": "session-abc"
+  },
+  "session_state_update_error": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"error\"' .tmp/hooked-sessions/workflow-xyz.json > .tmp/hooked-sessions/workflow-xyz.json.tmp && mv .tmp/hooked-sessions/workflow-xyz.json.tmp .tmp/hooked-sessions/workflow-xyz.json"
+    },
+    "session_id": "workflow-xyz"
+  },
+  "session_state_update_failed": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"failed\"' /tmp/.tmp/hooked-sessions/test-session.json > /tmp/.tmp/hooked-sessions/test-session.json.tmp && mv /tmp/.tmp/hooked-sessions/test-session.json.tmp /tmp/.tmp/hooked-sessions/test-session.json"
+    },
+    "session_id": "test-session"
+  },
+  "session_state_with_quotes": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"done\"' /tmp/.tmp/hooked-sessions/test-1.json > /tmp/.tmp/hooked-sessions/test-1.json.tmp && mv /tmp/.tmp/hooked-sessions/test-1.json.tmp /tmp/.tmp/hooked-sessions/test-1.json"
+    },
+    "session_id": "test-1"
+  },
+  "session_state_invalid_path": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"done\"' /tmp/hooked-sessions/test.json > /tmp/hooked-sessions/test.json.tmp && mv /tmp/hooked-sessions/test.json.tmp /tmp/hooked-sessions/test.json"
+    },
+    "session_id": "test-session"
+  },
+  "session_state_path_traversal": {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "jq '.state = \"done\"' /tmp/.tmp/hooked-sessions/../../../etc/passwd.json > /tmp/.tmp/hooked-sessions/../../../etc/passwd.json.tmp && mv /tmp/.tmp/hooked-sessions/../../../etc/passwd.json.tmp /tmp/.tmp/hooked-sessions/../../../etc/passwd.json"
+    },
+    "session_id": "test-session"
   }
 }


### PR DESCRIPTION
## Summary

Extended the workflow-scoped permission system to auto-allow session state file modifications without requiring explicit permission prompts. This enables workflows (like issue-to-impl, plan-to-issue, ultra-planner) to update their session state files to signal completion and control auto-continuation behavior.

Previously, commands like `jq '.state = "done"' .tmp/hooked-sessions/{id}.json > ... && mv ...` were blocked by the permission system. Now these operations are automatically allowed for all active workflows.

## Changes

- Modified `.claude-plugin/lib/permission/determine.py:567-597` to add session state modification patterns
  - Added `_SESSION_STATE_ALLOW_PATTERNS` regex to match jq state update commands
  - Pattern validates literal `.tmp/hooked-sessions/` path and alphanumeric session IDs
  - Supports state values: "done", "completed", "error", "failed"
  - Integrated into `_check_workflow_auto_allow()` to check patterns for all workflows
- Updated `docs/feat/permissions/rules.md:83-96` to document the session state exception
  - Explains that any workflow can update session state to signal completion
  - Notes security constraints (path validation prevents traversal attacks)
- Enhanced `tests/cli/test-hook-permission-matching.sh:433-527` with 7 new tests (Tests 34-40)
  - Session state updates to "done", "completed", "error", "failed" are auto-allowed
  - Different path formats are supported
  - Invalid paths and path traversal attempts are rejected
- Added test fixtures in `tests/fixtures/test-pre-tool-use-input.json:151-199` for all scenarios

## Testing

All 40 permission matching tests passed, including 7 new tests specifically for session state modifications:

- **Test 34:** Session state update to "done" → auto-allow ✓
- **Test 35:** Session state update to "completed" → auto-allow ✓
- **Test 36:** Session state update to "error" → auto-allow ✓
- **Test 37:** Session state update to "failed" → auto-allow ✓
- **Test 38:** Session state update with relative path → auto-allow ✓
- **Test 39:** Session state update with invalid path (missing .tmp) → ask (not auto-allowed) ✓
- **Test 40:** Session state with path traversal attempt → ask (not auto-allowed) ✓

Ran test suite:
```bash
bash tests/cli/test-hook-permission-matching.sh
# Result: ✓ Test passed: PreToolUse hook permission matching works correctly (40/40 tests)
```

## Security Considerations

The implementation includes robust security validations:
- **Path validation:** Pattern requires literal `.tmp/hooked-sessions/` prefix, preventing directory traversal
- **Session ID validation:** Only alphanumeric characters, underscores, and hyphens allowed
- **Command structure validation:** Requires proper jq syntax, redirection, and mv command
- **State value whitelist:** Only allows specific state values (done, completed, error, failed)

## Related Issue

Closes #505
