### PR TITLE
[#527][refactor] Fix typo HANDSOFF_SUPERVISER to HANDSOFF_SUPERVISOR

### DIFF
--- a/.claude-plugin/lib/workflow.py
+++ b/.claude-plugin/lib/workflow.py
@@ -137,11 +137,11 @@ The ultimate goal of this workflow is to sync the local main/master branch with 
 
 
 # ============================================================
-# AI Superviser functions (for dynamic continuation prompts)
+# AI Supervisor functions (for dynamic continuation prompts)
 # ============================================================
 
-def _log_superviser_debug(message: dict):
-    """Log superviser activity to hook-debug.log for debugging.
+def _log_supervisor_debug(message: dict):
+    """Log supervisor activity to hook-debug.log for debugging.
 
     Args:
         message: Dictionary with debug information
@@ -198,7 +198,7 @@ def _ask_claude_for_guidance(workflow: str, continuation_count: int,
     Returns:
         Dynamic prompt from Claude, or None to use static template
     """
-    if os.getenv('HANDSOFF_SUPERVISER', '0').lower() not in ['1', 'true', 'on']:
+    if os.getenv('HANDSOFF_SUPERVISOR', '0').lower() not in ['1', 'true', 'on']:
         return None  # Feature disabled
 
     # Read transcript if available for conversation context
@@ -236,8 +236,8 @@ Based on the current workflow progress and conversation context, provide a conci
 Respond with ONLY the continuation instruction (2-3 sentences), no explanations.'''
 
     # Log the request
-    _log_superviser_debug({
-        'event': 'superviser_request',
+    _log_supervisor_debug({
+        'event': 'supervisor_request',
         'workflow': workflow,
         'continuation_count': continuation_count,
         'max_continuations': max_continuations,
@@ -256,8 +256,8 @@ Respond with ONLY the continuation instruction (2-3 sentences), no explanations.
         )
         guidance = result.strip()
         if guidance:
-            _log_superviser_debug({
-                'event': 'superviser_success',
+            _log_supervisor_debug({
+                'event': 'supervisor_success',
                 'workflow': workflow,
                 'guidance': guidance[:500]  # Log first 500 chars
             })
@@ -265,8 +265,8 @@ Respond with ONLY the continuation instruction (2-3 sentences), no explanations.
     except (subprocess.TimeoutExpired, subprocess.CalledProcessError, Exception) as e:
         # Log error for debugging but don't break workflow
         error_msg = str(e)[:200]
-        _log_superviser_debug({
-            'event': 'superviser_error',
+        _log_supervisor_debug({
+            'event': 'supervisor_error',
             'workflow': workflow,
             'error_type': type(e).__name__,
             'error_message': error_msg
@@ -275,7 +275,7 @@ Respond with ONLY the continuation instruction (2-3 sentences), no explanations.
         # Try to log via logger if available
         try:
             from lib.logger import logger
-            logger('superviser', f'Claude guidance failed: {error_msg}')
+            logger('supervisor', f'Claude guidance failed: {error_msg}')
         except Exception:
             pass  # Silently ignore if logger import fails
         return None
@@ -367,7 +367,7 @@ def has_continuation_prompt(workflow):
 def get_continuation_prompt(workflow, session_id, fname, count, max_count, pr_no='unknown', transcript_path=None):
     """Get formatted continuation prompt for a workflow.
 
-    Optionally uses Claude for dynamic guidance if HANDSOFF_SUPERVISER is enabled.
+    Optionally uses Claude for dynamic guidance if HANDSOFF_SUPERVISOR is enabled.
     Falls back to static templates on any error.
 
     Args:

--- a/docs/envvar.md
+++ b/docs/envvar.md
@@ -22,10 +22,10 @@ See [Handsoff Mode](feat/core/handsoff.md) for detailed documentation.
 | `HANDSOFF_MODE` | No | Boolean | `1` | Enable handsoff auto-continuation. Values: `1`, `true`, `on`, `enable`. |
 | `HANDSOFF_MAX_CONTINUATIONS` | No | Integer | `10` | Maximum number of auto-continuations per workflow. |
 | `HANDSOFF_AUTO_PERMISSION` | No | Boolean | `1` | Enable Haiku LLM-based auto-permission decisions. Values: `1`, `true`, `on`, `enable`. |
-| `HANDSOFF_SUPERVISER` | No | Boolean | `0` | Enable Claude-powered dynamic continuation guidance. Values: `1`, `true`, `on`. |
+| `HANDSOFF_SUPERVISOR` | No | Boolean | `0` | Enable Claude-powered dynamic continuation guidance. Values: `1`, `true`, `on`. |
 | `HANDSOFF_DEBUG` | No | Boolean | `0` | Enable detailed debug logging to `.tmp/`. Values: `1`, `true`, `on`, `enable`. |
 
-### HANDSOFF_SUPERVISER
+### HANDSOFF_SUPERVISOR
 
 Control whether workflows use Claude for dynamic continuation guidance.
 
@@ -38,7 +38,7 @@ Control whether workflows use Claude for dynamic continuation guidance.
 **Example**:
 ```bash
 # Enable Claude-powered continuation guidance
-export HANDSOFF_SUPERVISER=1
+export HANDSOFF_SUPERVISOR=1
 
 # Run workflow with dynamic prompts
 /ultra-planner "your feature request here"


### PR DESCRIPTION
## Summary

Fixed the incorrect spelling "SUPERVISER" (with -ER) to the correct spelling "SUPERVISOR" (with -OR) in the handsoff workflow module and its documentation. This is a pure rename refactor with no functional changes.

## Changes

- Modified `.claude-plugin/lib/workflow.py:140` to update comment "AI Supervisor functions"
- Modified `.claude-plugin/lib/workflow.py:143-144` to rename function `_log_superviser_debug` to `_log_supervisor_debug` and update docstring
- Modified `.claude-plugin/lib/workflow.py:201` to update environment variable check from `HANDSOFF_SUPERVISER` to `HANDSOFF_SUPERVISOR`
- Modified `.claude-plugin/lib/workflow.py:239-240` to update function call and event name to `supervisor_request`
- Modified `.claude-plugin/lib/workflow.py:259-260` to update function call and event name to `supervisor_success`
- Modified `.claude-plugin/lib/workflow.py:268-269` to update function call and event name to `supervisor_error`
- Modified `.claude-plugin/lib/workflow.py:278` to update logger tag from `'superviser'` to `'supervisor'`
- Modified `.claude-plugin/lib/workflow.py:370` to update docstring reference to `HANDSOFF_SUPERVISOR`
- Modified `docs/envvar.md:25` to update table entry from `HANDSOFF_SUPERVISER` to `HANDSOFF_SUPERVISOR`
- Modified `docs/envvar.md:28` to update section header to `### HANDSOFF_SUPERVISOR`
- Modified `docs/envvar.md:41` to update example export command

## Testing

- Verified no remaining instances of "SUPERVISER" or "superviser" in the repository using grep
- Ran `python3 -m py_compile .claude-plugin/lib/workflow.py` to confirm Python syntax is valid
- Ran project test suite (`TEST_SHELLS="bash zsh" make test`) - `test-workflow-module` passed
- Pre-existing test failures are unrelated to this change (sandbox tests, credential tests)

## Related Issue

Closes #527
