### PR TITLE
[cli][#526] Add ACW autocompletion and make helper functions private

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -6,6 +6,8 @@ Unified file-based interface for invoking multiple AI CLI tools.
 
 ```bash
 acw <cli-name> <model-name> <input-file> <output-file> [cli-options...]
+acw --complete <topic>
+acw --help
 ```
 
 ## Description
@@ -76,12 +78,35 @@ fi
 |----------|-------------|
 | `AGENTIZE_HOME` | Required. Path to agentize installation. |
 
+## Shell Completion
+
+`acw` supports shell autocompletion for zsh. The completion is provided by `src/completion/_acw`.
+
+### Completion Topics
+
+Use `acw --complete <topic>` to get completion values programmatically:
+
+| Topic | Description |
+|-------|-------------|
+| `providers` | List of supported providers (claude, codex, opencode, cursor) |
+| `cli-options` | Common CLI options |
+
+### Setup
+
+For zsh, add the completion directory to your `fpath`:
+
+```bash
+fpath=($AGENTIZE_HOME/src/completion $fpath)
+autoload -Uz compinit && compinit
+```
+
 ## Notes
 
 - The output directory is created automatically if it doesn't exist
 - Provider-specific options are passed through unchanged
 - The wrapper returns the provider's exit code on successful execution
 - Best-effort providers (opencode, cursor) may have limited functionality
+- Helper functions are internal (prefixed with `_acw_`) and won't appear in tab completion
 
 ## See Also
 

--- a/src/cli/acw.md
+++ b/src/cli/acw.md
@@ -9,17 +9,19 @@ Thin loader for the Agent CLI Wrapper module, providing a unified file-based int
 ```
 acw.sh          # Entry point (this file) - thin loader
 acw/
-  helpers.sh    # Validation and utility functions
+  helpers.sh    # Validation and utility functions (private)
   providers.sh  # Provider-specific invocation functions
+  completion.sh # Completion helper for shell integration
   dispatch.sh   # Main dispatcher, help text, argument parsing
   README.md     # Module map and architecture
 ```
 
 ## Load Order
 
-1. `helpers.sh` - Provides validation helpers (`acw_validate_args`, `acw_check_cli`)
+1. `helpers.sh` - Provides validation helpers (`_acw_validate_args`, `_acw_check_cli`, etc.)
 2. `providers.sh` - Provides provider functions (`acw_invoke_claude`, etc.)
-3. `dispatch.sh` - Provides main entry point (`acw`)
+3. `completion.sh` - Provides completion helper (`acw_complete`)
+4. `dispatch.sh` - Provides main entry point (`acw`)
 
 ## Exported Functions
 
@@ -42,15 +44,24 @@ acw_invoke_cursor <model> <input> <output> [options...]
 
 Each provider function handles CLI-specific invocation patterns.
 
-### Helper Functions
+### Completion Function
 
 ```bash
-acw_validate_args <cli> <model> <input> <output>
-# Returns: 0 if valid, non-zero with error message otherwise
-
-acw_check_cli <cli-name>
-# Returns: 0 if CLI binary exists, 4 otherwise
+acw_complete <topic>
+# Returns: newline-separated list of completions for the topic
+# Topics: providers, cli-options
 ```
+
+### Private Helper Functions
+
+Helper functions are prefixed with `_acw_` to prevent tab-completion pollution:
+
+- `_acw_validate_args` - Validates required arguments
+- `_acw_check_cli` - Checks if provider CLI binary exists
+- `_acw_ensure_output_dir` - Creates output directory if needed
+- `_acw_check_input_file` - Verifies input file exists and is readable
+
+These are internal functions not intended for direct use.
 
 ## Design Rationale
 

--- a/src/cli/acw.sh
+++ b/src/cli/acw.sh
@@ -26,4 +26,5 @@ _ACW_DIR="$(_acw_script_dir)"
 # Source all modules in dependency order
 source "$_ACW_DIR/acw/helpers.sh"
 source "$_ACW_DIR/acw/providers.sh"
+source "$_ACW_DIR/acw/completion.sh"
 source "$_ACW_DIR/acw/dispatch.sh"

--- a/src/cli/acw/README.md
+++ b/src/cli/acw/README.md
@@ -8,34 +8,39 @@ Modular implementation of the Agent CLI Wrapper (`acw`) command.
 
 | File | Dependencies | Exports |
 |------|--------------|---------|
-| `helpers.sh` | None | `acw_validate_args`, `acw_check_cli`, `acw_ensure_output_dir`, `acw_check_input_file` |
+| `helpers.sh` | None | `_acw_validate_args`, `_acw_check_cli`, `_acw_ensure_output_dir`, `_acw_check_input_file` (private) |
 | `providers.sh` | `helpers.sh` | `acw_invoke_claude`, `acw_invoke_codex`, `acw_invoke_opencode`, `acw_invoke_cursor` |
-| `dispatch.sh` | `helpers.sh`, `providers.sh` | `acw` |
+| `completion.sh` | None | `acw_complete` |
+| `dispatch.sh` | `helpers.sh`, `providers.sh`, `completion.sh` | `acw` |
 
 ## Load Order
 
 The parent `acw.sh` sources modules in this order:
 
-1. `helpers.sh` - No dependencies
+1. `helpers.sh` - No dependencies (private helper functions)
 2. `providers.sh` - Uses helper functions
-3. `dispatch.sh` - Uses helpers and providers
+3. `completion.sh` - No dependencies (completion support)
+4. `dispatch.sh` - Uses helpers, providers, and completion
 
 ## Architecture
 
 ```
 acw.sh (thin loader)
     |
-    +-- helpers.sh
-    |     +-- acw_validate_args()
-    |     +-- acw_check_cli()
-    |     +-- acw_ensure_output_dir()
-    |     +-- acw_check_input_file()
+    +-- helpers.sh (private)
+    |     +-- _acw_validate_args()
+    |     +-- _acw_check_cli()
+    |     +-- _acw_ensure_output_dir()
+    |     +-- _acw_check_input_file()
     |
     +-- providers.sh
     |     +-- acw_invoke_claude()
     |     +-- acw_invoke_codex()
     |     +-- acw_invoke_opencode()
     |     +-- acw_invoke_cursor()
+    |
+    +-- completion.sh
+    |     +-- acw_complete()
     |
     +-- dispatch.sh
           +-- acw()  [main entry point]

--- a/src/cli/acw/completion.sh
+++ b/src/cli/acw/completion.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# acw CLI completion helper
+# Returns newline-delimited lists for shell completion systems
+
+# Usage: acw_complete <topic>
+# Topics: providers, cli-options
+acw_complete() {
+    local topic="$1"
+
+    case "$topic" in
+        providers)
+            echo "claude"
+            echo "codex"
+            echo "opencode"
+            echo "cursor"
+            ;;
+        cli-options)
+            echo "--help"
+            echo "--model"
+            echo "--max-tokens"
+            ;;
+        *)
+            # Unknown topic, return empty (graceful degradation)
+            return 0
+            ;;
+    esac
+}

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -52,6 +52,12 @@ acw() {
         return 0
     fi
 
+    # Handle --complete flag for shell completion
+    if [ "$1" = "--complete" ]; then
+        acw_complete "$2"
+        return 0
+    fi
+
     # Parse arguments
     local cli_name="$1"
     local model_name="$2"
@@ -65,7 +71,7 @@ acw() {
     fi
 
     # Validate required arguments
-    if ! acw_validate_args "$cli_name" "$model_name" "$input_file" "$output_file"; then
+    if ! _acw_validate_args "$cli_name" "$model_name" "$input_file" "$output_file"; then
         echo "" >&2
         echo "Usage: acw <cli-name> <model-name> <input-file> <output-file> [options...]" >&2
         return 1
@@ -84,17 +90,17 @@ acw() {
     esac
 
     # Check if input file exists
-    if ! acw_check_input_file "$input_file"; then
+    if ! _acw_check_input_file "$input_file"; then
         return 3
     fi
 
     # Ensure output directory exists
-    if ! acw_ensure_output_dir "$output_file"; then
+    if ! _acw_ensure_output_dir "$output_file"; then
         return 1
     fi
 
     # Check if CLI binary exists
-    if ! acw_check_cli "$cli_name"; then
+    if ! _acw_check_cli "$cli_name"; then
         return 4
     fi
 

--- a/src/cli/acw/helpers.sh
+++ b/src/cli/acw/helpers.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# acw helper functions
+# acw helper functions (private)
 # Validation and utility functions for the Agent CLI Wrapper
+# All functions prefixed with _acw_ to prevent tab-completion pollution
 
 # Validate required arguments
-# Usage: acw_validate_args <cli> <model> <input> <output>
+# Usage: _acw_validate_args <cli> <model> <input> <output>
 # Returns: 0 if valid, 1 if missing args
-acw_validate_args() {
+_acw_validate_args() {
     local cli="$1"
     local model="$2"
     local input="$3"
@@ -35,9 +36,9 @@ acw_validate_args() {
 }
 
 # Check if provider CLI binary exists
-# Usage: acw_check_cli <cli-name>
+# Usage: _acw_check_cli <cli-name>
 # Returns: 0 if exists, 4 if not found
-acw_check_cli() {
+_acw_check_cli() {
     local cli_name="$1"
     local binary=""
 
@@ -69,9 +70,9 @@ acw_check_cli() {
 }
 
 # Ensure output directory exists
-# Usage: acw_ensure_output_dir <output-file>
+# Usage: _acw_ensure_output_dir <output-file>
 # Returns: 0 on success, non-zero on failure
-acw_ensure_output_dir() {
+_acw_ensure_output_dir() {
     local output="$1"
     local dir
 
@@ -88,9 +89,9 @@ acw_ensure_output_dir() {
 }
 
 # Check if input file exists and is readable
-# Usage: acw_check_input_file <input-file>
+# Usage: _acw_check_input_file <input-file>
 # Returns: 0 if exists and readable, 3 otherwise
-acw_check_input_file() {
+_acw_check_input_file() {
     local input="$1"
 
     if [ ! -f "$input" ]; then

--- a/src/completion/README.md
+++ b/src/completion/README.md
@@ -15,6 +15,7 @@ Completion scripts follow the naming pattern `_<command>` for zsh completions:
 
 - `_wt` - Completion for the `wt` (worktree) command
 - `_lol` - Completion for the `lol` (SDK CLI) command
+- `_acw` - Completion for the `acw` (Agent CLI Wrapper) command
 
 ## How Completions Are Loaded
 

--- a/src/completion/_acw
+++ b/src/completion/_acw
@@ -1,0 +1,57 @@
+#compdef acw
+
+# Zsh completion for acw (Agent CLI Wrapper)
+# This completion file provides interactive command-line hints for acw arguments and flags
+
+_acw() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    # Try to use acw --complete if available, fallback to static lists
+    local -a providers
+    if (( $+commands[acw] )); then
+        # Dynamically fetch providers from acw --complete
+        providers=( ${(f)"$(acw --complete providers 2>/dev/null)"} )
+    fi
+
+    # Fallback to static provider list if dynamic fetch failed
+    if (( ${#providers} == 0 )); then
+        providers=(
+            'claude:Anthropic Claude CLI (full support)'
+            'codex:OpenAI Codex CLI (full support)'
+            'opencode:Opencode CLI (best-effort)'
+            'cursor:Cursor Agent CLI (best-effort)'
+        )
+    else
+        # Add descriptions to dynamically fetched providers
+        local -a providers_with_desc
+        for provider in $providers; do
+            case $provider in
+                claude) providers_with_desc+=('claude:Anthropic Claude CLI (full support)') ;;
+                codex) providers_with_desc+=('codex:OpenAI Codex CLI (full support)') ;;
+                opencode) providers_with_desc+=('opencode:Opencode CLI (best-effort)') ;;
+                cursor) providers_with_desc+=('cursor:Cursor Agent CLI (best-effort)') ;;
+                *) providers_with_desc+=("$provider") ;;
+            esac
+        done
+        providers=( $providers_with_desc )
+    fi
+
+    _arguments -C \
+        '--help[Show help message]' \
+        '-h[Show help message]' \
+        '--complete[Shell completion helper]:topic:(providers cli-options)' \
+        '1:provider:->provider' \
+        '2:model:' \
+        '3:input-file:_files' \
+        '4:output-file:_files' \
+        '*:additional options:'
+
+    case $state in
+        provider)
+            _describe -t providers 'acw providers' providers
+            ;;
+    esac
+}
+
+_acw "$@"

--- a/tests/cli/test-acw-command-functions-loaded.sh
+++ b/tests/cli/test-acw-command-functions-loaded.sh
@@ -1,33 +1,63 @@
 #!/usr/bin/env bash
-# Test: All acw_* functions are available after sourcing acw.sh
+# Test: Only public acw_* functions are exposed after sourcing acw.sh
+# Private helper functions should be prefixed with _acw_ and not appear in public API
 
 source "$(dirname "$0")/../common.sh"
 
 ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
 
-test_info "All acw_* functions are available after sourcing acw.sh"
+test_info "Testing acw public API - only public functions should be exposed"
 
 export AGENTIZE_HOME="$PROJECT_ROOT"
 source "$ACW_CLI"
 
-# List of expected functions
-EXPECTED_FUNCTIONS=(
+# List of expected PUBLIC functions (acw_ prefix without underscore)
+EXPECTED_PUBLIC_FUNCTIONS=(
     "acw"
     "acw_invoke_claude"
     "acw_invoke_codex"
     "acw_invoke_opencode"
     "acw_invoke_cursor"
-    "acw_validate_args"
-    "acw_check_cli"
-    "acw_ensure_output_dir"
+    "acw_complete"
 )
 
-# Check each function is defined (shell-agnostic approach)
-for func in "${EXPECTED_FUNCTIONS[@]}"; do
-    # Use 'type' output which works in both bash and zsh
+# List of PRIVATE functions that should exist but be prefixed with _acw_
+EXPECTED_PRIVATE_FUNCTIONS=(
+    "_acw_validate_args"
+    "_acw_check_cli"
+    "_acw_ensure_output_dir"
+    "_acw_check_input_file"
+)
+
+# Check each public function is defined
+test_info "Checking public functions exist"
+for func in "${EXPECTED_PUBLIC_FUNCTIONS[@]}"; do
     if ! type "$func" 2>/dev/null | grep -q "function"; then
-        test_fail "Function '$func' is not defined after sourcing acw.sh"
+        test_fail "Public function '$func' is not defined after sourcing acw.sh"
     fi
 done
 
-test_pass "All ${#EXPECTED_FUNCTIONS[@]} acw_* functions are available"
+# Check each private function is defined (with underscore prefix)
+test_info "Checking private functions exist with _acw_ prefix"
+for func in "${EXPECTED_PRIVATE_FUNCTIONS[@]}"; do
+    if ! type "$func" 2>/dev/null | grep -q "function"; then
+        test_fail "Private function '$func' is not defined after sourcing acw.sh"
+    fi
+done
+
+# Verify old public helpers are NOT available (should be renamed to _acw_)
+test_info "Checking old acw_* helper names are removed"
+OLD_HELPER_NAMES=(
+    "acw_validate_args"
+    "acw_check_cli"
+    "acw_ensure_output_dir"
+    "acw_check_input_file"
+)
+
+for func in "${OLD_HELPER_NAMES[@]}"; do
+    if type "$func" 2>/dev/null | grep -q "function"; then
+        test_fail "Old helper '$func' should be renamed to '_$func' but still exists"
+    fi
+done
+
+test_pass "Public API has ${#EXPECTED_PUBLIC_FUNCTIONS[@]} functions, ${#EXPECTED_PRIVATE_FUNCTIONS[@]} private helpers correctly prefixed"

--- a/tests/cli/test-acw-completion.sh
+++ b/tests/cli/test-acw-completion.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Test: acw completion functionality
+# Verifies acw --complete returns expected values for each topic
+
+source "$(dirname "$0")/../common.sh"
+
+ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
+
+test_info "Testing acw completion functionality"
+
+export AGENTIZE_HOME="$PROJECT_ROOT"
+source "$ACW_CLI"
+
+# Test 1: acw --complete providers returns all providers
+test_info "Checking --complete providers"
+providers_output=$(acw --complete providers)
+
+for provider in claude codex opencode cursor; do
+    if ! echo "$providers_output" | grep -q "^${provider}$"; then
+        test_fail "Provider '$provider' not found in --complete providers output"
+    fi
+done
+
+# Test 2: acw --complete cli-options returns common flags
+test_info "Checking --complete cli-options"
+options_output=$(acw --complete cli-options)
+
+for option in "--help" "--model"; do
+    if ! echo "$options_output" | grep -q "^${option}$"; then
+        test_fail "Option '$option' not found in --complete cli-options output"
+    fi
+done
+
+# Test 3: acw --complete with unknown topic returns empty (graceful degradation)
+test_info "Checking --complete with unknown topic"
+unknown_output=$(acw --complete unknown-topic 2>/dev/null)
+
+if [ -n "$unknown_output" ]; then
+    test_fail "Expected empty output for unknown completion topic, got: $unknown_output"
+fi
+
+# Test 4: acw_complete function is available
+test_info "Checking acw_complete function exists"
+if ! type acw_complete 2>/dev/null | grep -q "function"; then
+    test_fail "acw_complete function is not defined"
+fi
+
+test_pass "All completion tests passed"


### PR DESCRIPTION
## Summary

Added shell autocompletion support for the ACW (Agent CLI Wrapper) command and made internal helper functions private to prevent tab-completion pollution. Users can now tab-complete provider names and CLI options when using acw.

## Changes

- Modified `src/cli/acw/helpers.sh` to rename 4 helper functions from `acw_*` to `_acw_*` prefix (private)
- Updated `src/cli/acw/dispatch.sh` to use new private function names and add `--complete` flag handler
- Created `src/cli/acw/completion.sh` with `acw_complete()` function for shell completion
- Updated `src/cli/acw.sh` to source the new completion module
- Created `src/completion/_acw` zsh completion file following the `_wt` and `_lol` patterns
- Updated `src/cli/acw/README.md` with new module map, architecture diagram, and completion module
- Updated `src/cli/acw.md` with corrected load order and documented private helpers
- Updated `docs/cli/acw.md` with shell completion section and `--complete` flag documentation
- Updated `src/completion/README.md` to list the new `_acw` completion file
- Updated `tests/cli/test-acw-command-functions-loaded.sh` to verify 6 public and 4 private functions
- Created `tests/cli/test-acw-completion.sh` to test completion functionality

## Testing

- Added `tests/cli/test-acw-completion.sh` to verify:
  - `acw --complete providers` returns all 4 providers (claude, codex, opencode, cursor)
  - `acw --complete cli-options` returns common flags
  - Unknown completion topics return empty (graceful degradation)
  - `acw_complete` function is available
- Updated `tests/cli/test-acw-command-functions-loaded.sh` to verify:
  - Public API exposes exactly 6 functions: `acw`, `acw_invoke_*` (4), `acw_complete`
  - Private helpers (`_acw_*`) are defined correctly
  - Old `acw_*` helper names are removed
- All ACW tests pass in both bash and zsh

## Related Issue

Closes #526
