### PR TITLE
[agent.command][#579] Cache issue plan locally for stop hook drift detection

### DIFF
--- a/.claude-plugin/commands/issue-to-impl.md
+++ b/.claude-plugin/commands/issue-to-impl.md
@@ -180,6 +180,16 @@ gh issue view {issue-number} --json body --jq '.body'
 - LOC estimates
 - Test strategy details
 
+**Cache the plan locally:**
+
+After extracting the "Proposed Solution" section, write it to a local cache file for drift awareness during handsoff continuation:
+
+```
+${AGENTIZE_HOME:-.}/.tmp/plan-of-issue-{N}.md
+```
+
+This cached plan is read by the stop hook and included in continuation prompts to help the agent maintain context across sessions.
+
 **Error handling:**
 - No "Proposed Solution" section found:
   ```

--- a/docs/feat/core/handsoff.md
+++ b/docs/feat/core/handsoff.md
@@ -179,11 +179,16 @@ The ultimate goal of this workflow is to create a comprehensive plan and post it
 
 **Goal:** Deliver a PR on GitHub that implements the corresponding issue.
 
+**Plan caching:** During Step 4 (Read Implementation Plan), the workflow caches the extracted "Proposed Solution" section to `.tmp/plan-of-issue-{N}.md`. This cached plan is included in continuation prompts to provide drift awareness and easier resumption during autonomous workflows.
+
 **Auto-continuation prompt (injected by Stop hook):**
 ```
 This is an auto-continuation prompt for handsoff mode, it is currently {N}/{MAX} continuations.
 The ultimate goal of this workflow is to deliver a PR on GitHub that implements the corresponding issue. Did you have this delivered?
 1. If you have completed a milestone but still have more to do, please continue on the next milestone!
+1.5. Review the cached plan (if available):
+   - Plan file: {plan_path}
+   {plan_excerpt}
 2. If you have every coding task done, start the following steps to prepare for PR:
    2.0 Rebase the branch with upstream or origin (priority: upstream/main > upstream/master > origin/main > origin/master).
    2.1 Run the full test suite following the project's test conventions (see CLAUDE.md).

--- a/docs/feat/core/issue-to-impl.md
+++ b/docs/feat/core/issue-to-impl.md
@@ -41,3 +41,16 @@ This separation provides:
 - Ability to revert documentation independently from code
 - Explicit tracking of documentation completeness
 
+## Plan Caching
+
+During Step 4 (Read Implementation Plan), the workflow extracts the "Proposed Solution" section from the GitHub issue and caches it locally:
+
+**Cache location:** `${AGENTIZE_HOME:-.}/.tmp/plan-of-issue-{N}.md`
+
+This cached plan enables:
+- Drift awareness during handsoff continuation prompts
+- Easier resumption when sessions are interrupted
+- Context preservation across multiple continuation cycles
+
+The stop hook reads this cached plan (when available) and includes it in the `/issue-to-impl` continuation prompt. If the plan cache is missing, the continuation prompt gracefully degrades without the plan context.
+

--- a/docs/tutorial/02-issue-to-impl.md
+++ b/docs/tutorial/02-issue-to-impl.md
@@ -49,16 +49,21 @@ When you run `/issue-to-impl`:
 - Creates/updates documentation files
 - Adds README files as needed
 
-**4. Test Cases (from plan)**
+**4. Plan Caching**
+- Extracts "Proposed Solution" from issue body
+- Caches to `.tmp/plan-of-issue-{N}.md` for drift awareness
+- Plan is included in continuation prompts for easier resumption
+
+**5. Test Cases (from plan)**
 - Creates test files
 - Implements test cases from Test Strategy
 
-**5. Milestone 1 Commit**
+**6. Milestone 1 Commit**
 - Commits docs + tests
 - Status: 0/N tests passing (expected)
 - Uses `--no-verify` (tests not implemented yet)
 
-**6. Implementation Loop**
+**7. Implementation Loop**
 - Implements code in chunks (~100-200 LOC)
 - Runs tests after each chunk
 - Tracks total LOC with `git diff --stat`

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -164,6 +164,35 @@ print('EMPTY' if prompt == '' else 'NOT_EMPTY')
 [ "$RESULT" = "EMPTY" ] || test_fail "Expected empty string for unknown workflow, got '$RESULT'"
 
 # ============================================================
+# Test plan context in continuation prompt
+# ============================================================
+
+test_info "Test 27a: get_continuation_prompt() for issue-to-impl includes plan_path when provided"
+RESULT=$(run_workflow_python "
+from lib.workflow import get_continuation_prompt
+prompt = get_continuation_prompt('issue-to-impl', 'test-session', '/tmp/test.json', 1, 10, plan_path='/tmp/plan-of-issue-42.md')
+print('PLAN_PATH_OK' if '/tmp/plan-of-issue-42.md' in prompt else 'PLAN_PATH_MISSING')
+")
+[ "$RESULT" = "PLAN_PATH_OK" ] || test_fail "Expected plan_path in issue-to-impl prompt, got '$RESULT'"
+
+test_info "Test 27b: get_continuation_prompt() for issue-to-impl includes plan_excerpt when provided"
+RESULT=$(run_workflow_python "
+from lib.workflow import get_continuation_prompt
+prompt = get_continuation_prompt('issue-to-impl', 'test-session', '/tmp/test.json', 1, 10, plan_path='/tmp/plan.md', plan_excerpt='Step 1: Add feature X')
+print('PLAN_EXCERPT_OK' if 'Step 1: Add feature X' in prompt else 'PLAN_EXCERPT_MISSING')
+")
+[ "$RESULT" = "PLAN_EXCERPT_OK" ] || test_fail "Expected plan_excerpt in issue-to-impl prompt, got '$RESULT'"
+
+test_info "Test 27c: get_continuation_prompt() for issue-to-impl works without plan context"
+RESULT=$(run_workflow_python "
+from lib.workflow import get_continuation_prompt
+prompt = get_continuation_prompt('issue-to-impl', 'test-session', '/tmp/test.json', 1, 10)
+# Should still have the base prompt without plan context
+print('NO_PLAN_OK' if 'milestone' in prompt.lower() and 'Plan file:' not in prompt else 'NO_PLAN_FAIL')
+")
+[ "$RESULT" = "NO_PLAN_OK" ] || test_fail "Expected prompt without plan context to still work, got '$RESULT'"
+
+# ============================================================
 # Test workflow constants
 # ============================================================
 


### PR DESCRIPTION
## Summary

Enable the `/issue-to-impl` workflow to cache the GitHub issue's implementation plan locally so that the stop hook can include it in continuation prompts. This provides drift awareness and easier resumption during autonomous handsoff workflows.

## Changes

- Modified `.claude-plugin/commands/issue-to-impl.md` to specify plan caching in Step 4
- Updated `.claude-plugin/hooks/stop.py:64-101` to read cached plan and pass to workflow prompt
- Extended `.claude-plugin/lib/workflow.py:357-403` with `plan_path` and `plan_excerpt` parameters for `get_continuation_prompt()`
- Added `{plan_context}` placeholder in ISSUE_TO_IMPL continuation prompt template
- Updated `docs/feat/core/handsoff.md` with plan caching documentation in `/issue-to-impl` section
- Added Plan Caching section to `docs/feat/core/issue-to-impl.md`
- Updated `docs/tutorial/02-issue-to-impl.md` with plan caching step in "What Happens Automatically"
- Added 3 test cases in `tests/cli/test-workflow-module.sh` for plan context inclusion

## Testing

- Added test cases in `tests/cli/test-workflow-module.sh`:
  - Test 27a: Verifies `plan_path` is included in prompt when provided
  - Test 27b: Verifies `plan_excerpt` is included in prompt when provided
  - Test 27c: Verifies prompt works without plan context (graceful degradation)
- All 45 bash tests pass
- All 99 Python tests pass
- Ran full `make test-fast` successfully

## Related Issue

Closes #579
