### PR TITLE
[agent.workflow][#583] Extract continuation prompts to external template files

### DIFF
--- a/.claude-plugin/prompts/README.md
+++ b/.claude-plugin/prompts/README.md
@@ -1,0 +1,42 @@
+# Prompts Directory
+
+External template files for workflow continuation prompts. Separating prompt content from code logic improves maintainability and enables easy iteration on prompt text.
+
+## Template Format
+
+Each workflow has a corresponding `.txt` file named after the workflow (e.g., `ultra-planner.txt` for the ultra-planner workflow).
+
+### Variable Syntax
+
+Templates use `{#variable#}` syntax for substitution via Python's `str.replace()`:
+
+| Variable | Description |
+|----------|-------------|
+| `{#session_id#}` | Current Claude Code session ID for `claude -r` resume |
+| `{#fname#}` | Path to handsoff session state JSON file |
+| `{#continuations#}` | Current continuation count |
+| `{#max_continuations#}` | Maximum continuations allowed |
+| `{#pr_no#}` | PR number (used by sync-master workflow) |
+| `{#plan_context#}` | Optional plan context (used by issue-to-impl workflow) |
+
+### Why `{#...#}` Instead of `{...}`?
+
+The `{#variable#}` delimiter avoids conflicts with:
+- Python format strings (`{variable}`)
+- Shell variables (`$variable`, `${variable}`)
+- JSON/jq syntax (`{...}`)
+- Markdown code blocks containing these syntaxes
+
+## Template Files
+
+| File | Workflow | Purpose |
+|------|----------|---------|
+| `ultra-planner.txt` | `/ultra-planner` | Multi-agent debate-based planning |
+| `issue-to-impl.txt` | `/issue-to-impl` | Complete dev cycle from issue to PR |
+| `plan-to-issue.txt` | `/plan-to-issue` | Create GitHub [plan] issues |
+| `setup-viewboard.txt` | `/setup-viewboard` | GitHub Projects v2 board setup |
+| `sync-master.txt` | `/sync-master` | Sync local main/master with upstream |
+
+## Usage
+
+Templates are loaded by `workflow.py::get_continuation_prompt()` and `workflow.py::_ask_claude_for_guidance()`. The public API remains unchanged - callers continue using `get_continuation_prompt(workflow, ...)` without knowing about template files.

--- a/.claude-plugin/prompts/issue-to-impl.txt
+++ b/.claude-plugin/prompts/issue-to-impl.txt
@@ -1,0 +1,27 @@
+This is an auto-continuation prompt for handsoff mode, it is currently {#continuations#}/{#max_continuations#} continuations.
+The ultimate goal of this workflow is to deliver a PR on GitHub that implements the corresponding issue. Did you have this delivered?
+1. If you have completed a milestone but still have more to do, please continue on the next milestone!
+{#plan_context#}1.5. If you are working on documentation updates (Step 5):
+   - Review the "Documentation Planning" section in the issue for diff specifications
+   - Apply any markdown diff previews provided in the plan
+   - Create a dedicated [docs] commit before proceeding to tests
+2. If you have every coding task done, start the following steps to prepare for PR:
+   2.0 Rebase the branch with upstream or origin (priority: upstream/main > upstream/master > origin/main > origin/master).
+   2.1 Run the full test suite following the project's test conventions (see CLAUDE.md).
+   2.2 Use the code-quality-reviewer agent to review the code quality.
+   2.3 If the code review raises concerns, fix the issues and return to 2.1.
+   2.4 If the code review is satisfactory, proceed to open the PR.
+3. Prepare and create the PR. Do not ask user "Should I create the PR?" - just go ahead and create it!
+   - Creating the PR should use the `/open-pr` skill with appropriate titles.
+4. If the PR is successfully created, manually stop further continuations.
+5. If you do not know what to do next, or you reached the max continuations limit without delivering the PR,
+   manually stop further continuations and look at the current branch name to see what issue you are working on.
+   Then, leave a comment on the GitHub Issue for human collaborators to take over.
+   This comment shall include:
+  - What you have done so far
+  - What is blocking you from moving forward
+  - What kind of help you need from human collaborators
+  - The session ID: {#session_id#} so that human can `claude -r {#session_id#}` for a human intervention.
+6. To stop further continuations, run:
+   jq '.state = "done"' {#fname#} > {#fname#}.tmp && mv {#fname#}.tmp {#fname#}
+7. When creating issues or PRs, use `--body-file` instead of `--body`, as body content with "--something" will be misinterpreted as flags.

--- a/.claude-plugin/prompts/plan-to-issue.txt
+++ b/.claude-plugin/prompts/plan-to-issue.txt
@@ -1,0 +1,15 @@
+This is an auto-continuation prompt for handsoff mode, it is currently {#continuations#}/{#max_continuations#} continuations.
+The ultimate goal of this workflow is to create a GitHub [plan] issue from the user-provided plan.
+
+1. If you have not yet created the GitHub issue, please continue working on it!
+   - Parse and format the plan content appropriately
+   - Create the issue with proper labels and formatting
+   - Use `--body-file` instead of `--body` to avoid flag parsing issues
+2. If you have successfully created the GitHub issue, manually stop further continuations.
+3. If you are blocked or reached the max continuations limit without creating the issue:
+   - Stop manually and inform the user what happened
+   - Include what you have done so far
+   - Include what is blocking you
+   - Include the session ID: {#session_id#} so that human can `claude -r {#session_id#}` for intervention.
+4. To stop further continuations, run:
+   jq '.state = "done"' {#fname#} > {#fname#}.tmp && mv {#fname#}.tmp {#fname#}

--- a/.claude-plugin/prompts/setup-viewboard.txt
+++ b/.claude-plugin/prompts/setup-viewboard.txt
@@ -1,0 +1,6 @@
+This is an auto-continuation prompt for handsoff mode, it is currently {#continuations#}/{#max_continuations#} continuations.
+The ultimate goal of this workflow is to set up a GitHub Projects v2 board. Have you completed all steps?
+1. If not, please continue with the remaining setup steps!
+2. If setup is complete, manually stop further continuations.
+3. To stop further continuations, run:
+   jq '.state = "done"' {#fname#} > {#fname#}.tmp && mv {#fname#}.tmp {#fname#}

--- a/.claude-plugin/prompts/sync-master.txt
+++ b/.claude-plugin/prompts/sync-master.txt
@@ -1,0 +1,20 @@
+This is an auto-continuation prompt for handsoff mode, it is currently {#continuations#}/{#max_continuations#} continuations.
+The ultimate goal of this workflow is to sync the local main/master branch with upstream and force-push the PR branch.
+
+1. Check if the rebase has completed successfully:
+   - Run `git status` to verify the working tree state
+   - If rebase conflicts are detected, resolve them and run `git rebase --continue`
+   - If rebase was aborted, re-run the sync-master workflow from the beginning
+2. After successful rebase, verify the PR number is available: {#pr_no#}
+   - If PR number is 'unknown', check the current branch name for the PR association
+3. Force-push the rebased branch to update the PR:
+   - Run `git push -f` to push the rebased changes
+   - Verify the push succeeded without errors
+4. After successful push, manually stop further continuations.
+5. If you encounter unresolvable conflicts or errors:
+   - Stop manually and inform the user what happened
+   - Include what you have done so far
+   - Include what is blocking you
+   - Include the session ID: {#session_id#} so that human can `claude -r {#session_id#}` for intervention.
+6. To stop further continuations, run:
+   jq '.state = "done"' {#fname#} > {#fname#}.tmp && mv {#fname#}.tmp {#fname#}

--- a/.claude-plugin/prompts/ultra-planner.txt
+++ b/.claude-plugin/prompts/ultra-planner.txt
@@ -1,0 +1,15 @@
+This is an auto-continuation prompt for handsoff mode, it is currently {#continuations#}/{#max_continuations#} continuations.
+The ultimate goal of this workflow is to create a comprehensive plan and post it on GitHub Issue. Have you delivered this?
+1. If not, please continue! Try to be as hands-off as possible, avoid asking user design decision questions, and choose the option you recommend most.
+2. If you have already delivered the plan, manually stop further continuations.
+3. If you do not know what to do next, or you reached the max continuations limit without delivering the plan,
+   look at the current branch name to see what issue you are working on. Then stop manually
+   and leave a comment on the GitHub Issue for human collaborators to take over.
+   This comment shall include:
+    - What you have done so far
+    - What is blocking you from moving forward
+    - What kind of help you need from human collaborators
+    - The session ID: {#session_id#} so that human can `claude -r {#session_id#}` for a human intervention.
+4. To stop further continuations, run:
+   jq '.state = "done"' {#fname#} > {#fname#}.tmp && mv {#fname#}.tmp {#fname#}
+5. When creating issues or PRs, use `--body-file` instead of `--body`, as body content with "--something" will be misinterpreted as flags.

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -6,9 +6,10 @@ source "$(dirname "$0")/../common.sh"
 test_info "Workflow module tests"
 
 # Helper to run Python code that imports the workflow module
+# Disable HANDSOFF_SUPERVISOR to test static template behavior
 run_workflow_python() {
     local python_code="$1"
-    PYTHONPATH="$PROJECT_ROOT/.claude-plugin" python3 -c "$python_code"
+    HANDSOFF_SUPERVISOR=0 PYTHONPATH="$PROJECT_ROOT/.claude-plugin" python3 -c "$python_code"
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary

Refactored hardcoded continuation prompts from `workflow.py` into external template files in `.claude-plugin/prompts/` directory. This improves maintainability by separating prompt content from code logic and enables easy iteration on prompt text without modifying Python code.

## Changes

- Created `.claude-plugin/prompts/README.md` documenting template format and `{#variable#}` substitution syntax
- Created `.claude-plugin/prompts/ultra-planner.txt` for ultra-planner workflow continuation prompt
- Created `.claude-plugin/prompts/issue-to-impl.txt` for issue-to-impl workflow continuation prompt
- Created `.claude-plugin/prompts/plan-to-issue.txt` for plan-to-issue workflow continuation prompt
- Created `.claude-plugin/prompts/setup-viewboard.txt` for setup-viewboard workflow continuation prompt
- Created `.claude-plugin/prompts/sync-master.txt` for sync-master workflow continuation prompt
- Modified `.claude-plugin/lib/workflow.py:48-72` to add `_load_prompt_template()` helper function
- Modified `.claude-plugin/lib/workflow.py:143-147` to use template loading in `_ask_claude_for_guidance()`
- Modified `.claude-plugin/lib/workflow.py:282-291` to update `has_continuation_prompt()` to use `_SUPPORTED_WORKFLOWS` set
- Modified `.claude-plugin/lib/workflow.py:319-341` to update `get_continuation_prompt()` to load templates and use `str.replace()` substitution
- Removed ~88 LOC of hardcoded `_CONTINUATION_PROMPTS` dictionary
- Modified `tests/cli/test-workflow-module.sh:8-13` to disable HANDSOFF_SUPERVISOR for consistent test behavior

## Testing

- Ran `make test-fast` with all 45 shell tests passing
- Ran `pytest python/tests` with all 99 Python tests passing
- Modified `tests/cli/test-workflow-module.sh` to test static template behavior by disabling dynamic supervisor
- Manually verified template loading works for all 5 workflow types:
  - ultra-planner: session_id, fname, count/max_count substitution
  - issue-to-impl: plan_context substitution
  - sync-master: pr_no substitution

## Related Issue

Closes #583
