### PR TITLE
[#585][agent.workflow] Modularize supervisor invocation via acw

### DIFF
--- a/.claude-plugin/lib/workflow.py
+++ b/.claude-plugin/lib/workflow.py
@@ -82,10 +82,10 @@ _VALID_PROVIDERS = {'claude', 'codex', 'cursor', 'opencode'}
 
 # Default models per provider
 _DEFAULT_MODELS = {
-    'claude': 'sonnet',
+    'claude': 'opus',
     'codex': 'gpt-5.2-codex',
-    'cursor': 'claude-3.5-sonnet',
-    'opencode': 'sonnet'
+    'cursor': 'gpt-5.2-codex-xhigh',
+    'opencode': 'openai/gpt-5.2-codex'
 }
 
 # Legacy boolean mappings for backward compatibility

--- a/docs/envvar.md
+++ b/docs/envvar.md
@@ -47,10 +47,10 @@ Control which AI provider is used for dynamic continuation guidance.
 **Provider Defaults**:
 | Provider | Default Model |
 |----------|---------------|
-| `claude` | `sonnet` |
+| `claude` | `opus` |
 | `codex` | `gpt-5.2-codex` |
-| `cursor` | `claude-3.5-sonnet` |
-| `opencode` | `sonnet` |
+| `cursor` | `gpt-5.2-codex-xhigh` |
+| `opencode` | `openai/gpt-5.2-codex` |
 
 **Examples**:
 ```bash

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -270,7 +270,7 @@ from lib.workflow import _get_supervisor_model
 model = _get_supervisor_model('claude')
 print(model)
 ")
-[ "$RESULT" = "sonnet" ] || test_fail "Expected default 'sonnet', got '$RESULT'"
+[ "$RESULT" = "opus" ] || test_fail "Expected default 'opus', got '$RESULT'"
 
 test_info "Test 38: HANDSOFF_SUPERVISOR_FLAGS is read correctly"
 RESULT=$(HANDSOFF_SUPERVISOR=claude HANDSOFF_SUPERVISOR_FLAGS="--timeout 1800" PYTHONPATH="$PROJECT_ROOT/.claude-plugin" python3 -c "


### PR DESCRIPTION
## Summary

Replaced the hardcoded `subprocess.check_output(['claude', '-p'], ...)` in `workflow.py::_ask_claude_for_guidance()` with a call to `acw` (Agent CLI Wrapper), making the supervisor provider configurable. This is a breaking change that transitions `HANDSOFF_SUPERVISOR` from a boolean (`0`/`1`) to a provider name enum (`none`/`claude`/`codex`/`cursor`/`opencode`).

## Changes

- Modified `.claude-plugin/lib/workflow.py:75-145` to add supervisor configuration section:
  - Added `_VALID_PROVIDERS`, `_DEFAULT_MODELS`, `_LEGACY_DISABLE`, `_LEGACY_ENABLE` constants
  - Added `_get_supervisor_provider()` function for provider selection with backward compatibility
  - Added `_get_supervisor_model()` function for model name resolution
  - Added `_get_supervisor_flags()` function for extra flags
- Modified `.claude-plugin/lib/workflow.py:175-354` to refactor `_ask_claude_for_guidance()`:
  - Replaced direct subprocess call with acw invocation using temp files for I/O
  - Added provider-specific logging in debug output
- Updated `docs/envvar.md:25-79` to document new environment variables:
  - `HANDSOFF_SUPERVISOR`: Changed from Boolean to String (provider enum)
  - `HANDSOFF_SUPERVISOR_MODEL`: New variable for model selection
  - `HANDSOFF_SUPERVISOR_FLAGS`: New variable for extra acw flags
- Updated `tests/cli/test-workflow-module.sh:8-20` to add helper for custom env vars
- Added `tests/cli/test-workflow-module.sh:227-305` with 9 new tests (Tests 33-41):
  - Tests for provider selection (none/claude/codex)
  - Tests for model and flags configuration
  - Tests for backward compatibility with legacy 0/1 values

## Testing

- All 41 workflow module tests pass (tests/cli/test-workflow-module.sh)
- Full test suite passes: 45 bash tests, 99 pytest tests
- New tests verify:
  - `HANDSOFF_SUPERVISOR=none` disables supervisor
  - `HANDSOFF_SUPERVISOR=claude` enables claude provider
  - `HANDSOFF_SUPERVISOR=codex` enables codex provider
  - `HANDSOFF_SUPERVISOR_MODEL` overrides default model
  - `HANDSOFF_SUPERVISOR_FLAGS` passes extra flags to acw
  - Legacy `HANDSOFF_SUPERVISOR=0` maps to disabled
  - Legacy `HANDSOFF_SUPERVISOR=1` maps to claude provider

## Related Issue

Closes #585
