### PR TITLE
[#587][refactor] Rename _ask_claude_for_guidance to _ask_supervisor_for_guidance

### DIFF
--- a/.claude-plugin/lib/workflow.py
+++ b/.claude-plugin/lib/workflow.py
@@ -172,8 +172,8 @@ def _log_supervisor_debug(message: dict):
         pass  # Silently ignore logging errors
 
 
-def _ask_claude_for_guidance(workflow: str, continuation_count: int,
-                             max_continuations: int, transcript_path: str = None) -> Optional[str]:
+def _ask_supervisor_for_guidance(workflow: str, continuation_count: int,
+                                 max_continuations: int, transcript_path: str = None) -> Optional[str]:
     """Ask AI provider for context-aware continuation guidance.
 
     Uses acw (Agent CLI Wrapper) to invoke the configured AI provider.
@@ -220,7 +220,7 @@ def _ask_claude_for_guidance(workflow: str, continuation_count: int,
     except FileNotFoundError:
         return None  # No template for this workflow
 
-    # Build context prompt for Claude with full workflow template
+    # Build context prompt for supervisor with full workflow template
     prompt = f'''You are a workflow supervisor for an AI agent system.
 You are evaluating an exisint `host session` to see:
 1. If it is sticking to the original purpose of the workflow.
@@ -455,8 +455,8 @@ def get_continuation_prompt(workflow, session_id, fname, count, max_count, pr_no
     Returns:
         Formatted continuation prompt string, or empty string if workflow not found
     """
-    # Try to get dynamic guidance from Claude if enabled
-    guidance = _ask_claude_for_guidance(workflow, count, max_count, transcript_path)
+    # Try to get dynamic guidance from supervisor if enabled
+    guidance = _ask_supervisor_for_guidance(workflow, count, max_count, transcript_path)
     if guidance:
         return guidance
 

--- a/.claude-plugin/prompts/README.md
+++ b/.claude-plugin/prompts/README.md
@@ -39,4 +39,4 @@ The `{#variable#}` delimiter avoids conflicts with:
 
 ## Usage
 
-Templates are loaded by `workflow.py::get_continuation_prompt()` and `workflow.py::_ask_claude_for_guidance()`. The public API remains unchanged - callers continue using `get_continuation_prompt(workflow, ...)` without knowing about template files.
+Templates are loaded by `workflow.py::get_continuation_prompt()` and `workflow.py::_ask_supervisor_for_guidance()`. The public API remains unchanged - callers continue using `get_continuation_prompt(workflow, ...)` without knowing about template files.

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -231,8 +231,8 @@ RESULT=$(run_workflow_python "from lib.workflow import SYNC_MASTER; print(SYNC_M
 
 test_info "Test 33: HANDSOFF_SUPERVISOR=none disables supervisor (returns None)"
 RESULT=$(run_workflow_python_env "HANDSOFF_SUPERVISOR=none" "
-from lib.workflow import _ask_claude_for_guidance
-result = _ask_claude_for_guidance('ultra-planner', 1, 10)
+from lib.workflow import _ask_supervisor_for_guidance
+result = _ask_supervisor_for_guidance('ultra-planner', 1, 10)
 print('DISABLED' if result is None else 'ENABLED')
 ")
 [ "$RESULT" = "DISABLED" ] || test_fail "Expected supervisor disabled with 'none', got '$RESULT'"


### PR DESCRIPTION
## Summary

- Rename `_ask_claude_for_guidance` to `_ask_supervisor_for_guidance` to reflect provider-agnostic nature
- Update internal comment and documentation references
- Update test imports to use new function name

This rename aligns with the existing naming convention used by related functions:
- `_get_supervisor_provider()`
- `_get_supervisor_model()`
- `_get_supervisor_flags()`
- `_log_supervisor_debug()`

## Test plan

- [x] `tests/cli/test-workflow-module.sh` - all 41 tests pass
- [x] `make test-fast` - all 45 shell tests + 99 Python tests pass

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
