### PR TITLE
[#592][refactor] Consolidate _get_agentize_home() into session_utils.py

### DIFF
--- a/.claude-plugin/lib/README.md
+++ b/.claude-plugin/lib/README.md
@@ -48,7 +48,7 @@ Tool permission evaluation for the PreToolUse hook. Provides rule-based matching
 
 Unified workflow definitions for handsoff mode. Centralizes workflow detection, issue extraction, and continuation prompts.
 
-**Self-contained design:** This module includes its own `_get_agentize_home()` and `_run_acw()` helpers to invoke the `acw` shell function without importing from `agentize.shell` or depending on `setup.sh`. This maintains plugin standalone capability.
+**Self-contained design:** This module uses `get_agentize_home()` from `session_utils.py` for AGENTIZE_HOME resolution and includes its own `_run_acw()` helper to invoke the `acw` shell function without importing from `agentize.shell` or depending on `setup.sh`. This maintains plugin standalone capability.
 
 **Usage:**
 ```python

--- a/.claude-plugin/lib/logger.py
+++ b/.claude-plugin/lib/logger.py
@@ -1,12 +1,12 @@
 import os
 import datetime
 
-from lib.session_utils import session_dir
+from lib.session_utils import session_dir, get_agentize_home
 
 
 def _tmp_dir():
-    """Get tmp directory path using AGENTIZE_HOME fallback."""
-    base = os.getenv('AGENTIZE_HOME', '.')
+    """Get tmp directory path using get_agentize_home()."""
+    base = get_agentize_home()
     return os.path.join(base, '.tmp')
 
 

--- a/.claude-plugin/lib/session_utils.md
+++ b/.claude-plugin/lib/session_utils.md
@@ -4,6 +4,28 @@ Shared utilities for session directory resolution, handsoff mode checks, and iss
 
 ## External Interface
 
+### `get_agentize_home() -> str`
+
+Get the AGENTIZE_HOME path for agentize repository root resolution.
+
+**Returns:** String path to the agentize repository root
+
+**Behavior:**
+- First checks `AGENTIZE_HOME` environment variable
+- If not set, derives from module location (`.claude-plugin/lib/session_utils.py` → `../../`)
+- Uses `os.path.realpath()` to resolve symlinks (e.g., `.cursor/hooks/lib` → `.claude-plugin/lib`)
+- Does not validate the path - caller should handle errors if expected files are missing
+
+**Usage:**
+
+```python
+from lib.session_utils import get_agentize_home
+
+# Get agentize repository root
+agentize_home = get_agentize_home()
+# Returns: "{AGENTIZE_HOME}" or derived repo root path
+```
+
 ### `session_dir(makedirs: bool = False) -> str`
 
 Get the session directory path using `AGENTIZE_HOME` fallback.
@@ -87,7 +109,8 @@ index_path = write_issue_index(session_id, issue_no, workflow, sess_dir=custom_d
 - `.claude-plugin/hooks/user-prompt-submit.py`: Session tracking, handsoff check, issue index
 - `.claude-plugin/hooks/stop.py`: Session cleanup, handsoff check
 - `.claude-plugin/hooks/post-bash-issue-create.py`: Issue number persistence, issue index
-- `.claude-plugin/lib/logger.py`: Log file path resolution
+- `.claude-plugin/lib/logger.py`: Log file path resolution (uses `get_agentize_home()`)
+- `.claude-plugin/lib/workflow.py`: acw invocation (uses `get_agentize_home()`)
 - `.claude-plugin/lib/permission/determine.py`: Permission decision logging
 - `.cursor/hooks/before-prompt-submit.py`: Cursor hook session tracking
 - `.cursor/hooks/stop.py`: Cursor hook session cleanup

--- a/tests/cli/test-cursor-hook-before-prompt-submit.sh
+++ b/tests/cli/test-cursor-hook-before-prompt-submit.sh
@@ -53,17 +53,22 @@ STATE_FILE_2="$CENTRAL_HOME/.tmp/hooked-sessions/$SESSION_ID_2.json"
 ISSUE_NO_2=$(jq -r '.issue_no' "$STATE_FILE_2")
 [ "$ISSUE_NO_2" = "42" ] || test_fail "Expected issue_no=42, got '$ISSUE_NO_2'"
 
-# Test 3: Without AGENTIZE_HOME, session file created in local .tmp/
-test_info "Test 3: AGENTIZE_HOME unset → local session file"
+# Test 3: Without AGENTIZE_HOME, session file created at repo root (derived from module location)
+test_info "Test 3: AGENTIZE_HOME unset → session file at repo root (derived from session_utils.py)"
 SESSION_ID_3="test-session-local-3"
 run_hook "/issue-to-impl 99" "$SESSION_ID_3" ""
 
-STATE_FILE_3="$LOCAL_HOME/.tmp/hooked-sessions/$SESSION_ID_3.json"
-[ -f "$STATE_FILE_3" ] || test_fail "Session file not created at local path: $STATE_FILE_3"
+# When AGENTIZE_HOME is unset, get_agentize_home() derives from session_utils.py location
+# which resolves to the repo root, not the current working directory
+STATE_FILE_3="$PROJECT_ROOT/.tmp/hooked-sessions/$SESSION_ID_3.json"
+[ -f "$STATE_FILE_3" ] || test_fail "Session file not created at repo root path: $STATE_FILE_3"
 
 # Verify issue_no is extracted
 ISSUE_NO_3=$(jq -r '.issue_no' "$STATE_FILE_3")
 [ "$ISSUE_NO_3" = "99" ] || test_fail "Expected issue_no=99, got '$ISSUE_NO_3'"
+
+# Clean up the session file from repo root
+rm -f "$STATE_FILE_3"
 
 # Test 4: /ultra-planner with --refine <issue> extracts issue_no
 test_info "Test 4: /ultra-planner --refine 123 → issue_no=123"

--- a/tests/cli/test-handsoff-session-path.sh
+++ b/tests/cli/test-handsoff-session-path.sh
@@ -44,17 +44,22 @@ STATE_FILE_1="$CENTRAL_HOME/.tmp/hooked-sessions/$SESSION_ID_1.json"
 ISSUE_NO_1=$(jq -r '.issue_no' "$STATE_FILE_1")
 [ "$ISSUE_NO_1" = "42" ] || test_fail "Expected issue_no=42, got '$ISSUE_NO_1'"
 
-# Test 2: Without AGENTIZE_HOME, session file created in local .tmp/
-test_info "Test 2: AGENTIZE_HOME unset → local session file"
+# Test 2: Without AGENTIZE_HOME, session file created at repo root (derived from module location)
+test_info "Test 2: AGENTIZE_HOME unset → session file at repo root (derived from session_utils.py)"
 SESSION_ID_2="test-session-local-2"
 run_hook "/issue-to-impl 99" "$SESSION_ID_2" ""
 
-STATE_FILE_2="$LOCAL_HOME/.tmp/hooked-sessions/$SESSION_ID_2.json"
-[ -f "$STATE_FILE_2" ] || test_fail "Session file not created at local path: $STATE_FILE_2"
+# When AGENTIZE_HOME is unset, get_agentize_home() derives from session_utils.py location
+# which resolves to the repo root, not the current working directory
+STATE_FILE_2="$PROJECT_ROOT/.tmp/hooked-sessions/$SESSION_ID_2.json"
+[ -f "$STATE_FILE_2" ] || test_fail "Session file not created at repo root path: $STATE_FILE_2"
 
 # Verify issue_no is extracted
 ISSUE_NO_2=$(jq -r '.issue_no' "$STATE_FILE_2")
 [ "$ISSUE_NO_2" = "99" ] || test_fail "Expected issue_no=99, got '$ISSUE_NO_2'"
+
+# Clean up the session file from repo root
+rm -f "$STATE_FILE_2"
 
 # Test 3: /ultra-planner with --refine <issue> extracts issue_no
 test_info "Test 3: /ultra-planner --refine 123 → issue_no=123"

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -289,33 +289,33 @@ print('EMPTY' if flags == '' else flags)
 [ "$RESULT" = "EMPTY" ] || test_fail "Expected empty string, got '$RESULT'"
 
 # ============================================================
-# Test _get_agentize_home() and _run_acw() helpers
+# Test get_agentize_home() (session_utils) and _run_acw() helpers
 # ============================================================
 
-test_info "Test 40: _get_agentize_home() reads from AGENTIZE_HOME env var"
+test_info "Test 40: get_agentize_home() reads from AGENTIZE_HOME env var"
 RESULT=$(run_workflow_python_env "AGENTIZE_HOME=/custom/path" "
-from lib.workflow import _get_agentize_home
-home = _get_agentize_home()
+from lib.session_utils import get_agentize_home
+home = get_agentize_home()
 print(home)
 ")
 [ "$RESULT" = "/custom/path" ] || test_fail "Expected '/custom/path', got '$RESULT'"
 
-test_info "Test 41: _get_agentize_home() derives from workflow.py location when env var not set"
+test_info "Test 41: get_agentize_home() derives from session_utils.py location when env var not set"
 RESULT=$(run_workflow_python_env "AGENTIZE_HOME=" "
-from lib.workflow import _get_agentize_home
+from lib.session_utils import get_agentize_home
 import os
-home = _get_agentize_home()
+home = get_agentize_home()
 # Should derive to repo root where Makefile exists
 makefile = os.path.join(home, 'Makefile')
 print('VALID' if os.path.isfile(makefile) else 'INVALID')
 ")
 [ "$RESULT" = "VALID" ] || test_fail "Expected derived path to be valid repo root, got '$RESULT'"
 
-test_info "Test 42: _get_agentize_home() returns correct repo root structure"
+test_info "Test 42: get_agentize_home() returns correct repo root structure"
 RESULT=$(run_workflow_python_env "AGENTIZE_HOME=" "
-from lib.workflow import _get_agentize_home
+from lib.session_utils import get_agentize_home
 import os
-home = _get_agentize_home()
+home = get_agentize_home()
 # Verify expected files exist
 acw_sh = os.path.join(home, 'src', 'cli', 'acw.sh')
 print('ACW_OK' if os.path.isfile(acw_sh) else 'ACW_MISSING')


### PR DESCRIPTION
## Summary

Consolidated duplicate AGENTIZE_HOME path resolution logic by moving the `_get_agentize_home()` function from `workflow.py` into `session_utils.py` as a public `get_agentize_home()` function. This eliminates code duplication while maintaining workflow.py's self-contained design principle (since session_utils.py is part of the plugin lib).

The new implementation also handles symlink resolution correctly using `os.path.realpath()`, which fixes path derivation when imported via the `.cursor/hooks/lib` symlink.

## Changes

- Added `get_agentize_home()` to `.claude-plugin/lib/session_utils.py:12-35` with symlink-aware path resolution
- Updated `session_dir()` in `.claude-plugin/lib/session_utils.py:89` to use `get_agentize_home()` instead of direct `os.getenv()`
- Removed `_get_agentize_home()` from `.claude-plugin/lib/workflow.py:145-168`
- Updated `.claude-plugin/lib/workflow.py:29` to import `get_agentize_home` from session_utils
- Updated `.claude-plugin/lib/logger.py:4,9` to use `get_agentize_home()` in `_tmp_dir()`
- Updated `.claude-plugin/lib/session_utils.md` to document `get_agentize_home()` interface
- Updated `.claude-plugin/lib/README.md:51` to reflect workflow.py's dependency on session_utils

## Testing

- Updated `tests/cli/test-workflow-module.sh:295-323` (Tests 40-42) to import from session_utils
- Updated `tests/cli/test-handsoff-session-path.sh:47-62` (Test 2) for new path derivation behavior
- Updated `tests/cli/test-cursor-hook-before-prompt-submit.sh:56-71` (Test 3) for new behavior
- All 45 bash tests pass (`make test-fast`)
- All 99 Python tests pass

## Related Issue

Closes #592
