### PR TITLE
[#623][refactor] Replace custom YAML parser with PyYAML library

### DIFF
--- a/.claude-plugin/lib/local_config.md
+++ b/.claude-plugin/lib/local_config.md
@@ -110,21 +110,7 @@ workflows:
 
 **No environment overrides:** YAML is the sole configuration source, providing a single, predictable place to manage settings.
 
-**Minimal parser:** Uses the same minimal YAML parser as `runtime_config.py` to avoid external dependencies.
-
-## Parser Limitations
-
-The minimal YAML parser supports:
-- Nested dicts (key-value pairs with indentation)
-- Simple scalar values (strings, integers)
-- Arrays of scalars: `- "value"` or `- value`
-- Arrays of dicts: `- key: value`
-
-Not supported:
-- YAML anchors and aliases
-- Flow-style syntax (`[a, b]` or `{a: b}`)
-- Multi-line literals (`|` or `>`)
-- Complex nested arrays
+**PyYAML library:** Uses `yaml.safe_load()` for full YAML 1.2 compliance, providing robust parsing with support for all standard YAML features.
 
 ## Internal Usage
 

--- a/.claude-plugin/lib/local_config.py
+++ b/.claude-plugin/lib/local_config.py
@@ -15,6 +15,8 @@ import os
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+import yaml
+
 # Module-level cache for loaded config
 _cached_config: Optional[dict] = None
 _cached_path: Optional[Path] = None
@@ -94,14 +96,7 @@ def load_local_config(start_dir: Optional[Path] = None) -> tuple[dict, Optional[
 
 
 def _parse_yaml_file(path: Path) -> dict:
-    """Parse a simple YAML file into a nested dict.
-
-    Supports basic YAML structure with nested dicts and arrays.
-    Arrays are supported as:
-      - "- value"  (scalar items)
-      - "- key: value" (dict items with subsequent indented key-values)
-
-    Does not support anchors, flow-style syntax, or multi-line literals.
+    """Parse YAML file using PyYAML's safe_load.
 
     Args:
         path: Path to the YAML file
@@ -109,169 +104,8 @@ def _parse_yaml_file(path: Path) -> dict:
     Returns:
         Parsed configuration as nested dict
     """
-    lines: list[tuple[int, str]] = []
-
     with open(path, "r") as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip())
-            lines.append((indent, stripped))
-
-    return _parse_lines(lines, 0, len(lines), -1)
-
-
-def _parse_lines(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> dict:
-    """Parse a range of lines into a dict, handling nested structures."""
-    result: dict[str, Any] = {}
-    i = start
-
-    while i < end:
-        indent, stripped = lines[i]
-
-        # Skip lines that are less indented than our scope
-        if indent <= parent_indent and i > start:
-            break
-
-        if stripped.startswith("- "):
-            # This shouldn't happen at dict level - skip
-            i += 1
-            continue
-
-        if ":" not in stripped:
-            i += 1
-            continue
-
-        key, _, value = stripped.partition(":")
-        key = key.strip()
-        value = value.strip()
-
-        # Remove quotes from value if present
-        if value and value[0] in ('"', "'") and value[-1] == value[0]:
-            value = value[1:-1]
-
-        if value:
-            # Simple key: value
-            try:
-                result[key] = int(value)
-            except ValueError:
-                result[key] = value
-            i += 1
-        else:
-            # Key with no value - check what follows
-            i += 1
-            if i < end:
-                next_indent, next_stripped = lines[i]
-                if next_indent > indent:
-                    if next_stripped.startswith("- "):
-                        # It's a list
-                        result[key], i = _parse_list(lines, i, end, indent)
-                    else:
-                        # It's a nested dict
-                        child_end = _find_block_end(lines, i, end, indent)
-                        result[key] = _parse_lines(lines, i, child_end, indent)
-                        i = child_end
-                else:
-                    # Empty value
-                    result[key] = {}
-            else:
-                result[key] = {}
-
-    return result
-
-
-def _parse_list(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> tuple[list, int]:
-    """Parse a list starting at the given position."""
-    result: list[Any] = []
-    i = start
-
-    while i < end:
-        indent, stripped = lines[i]
-
-        # Stop if we've de-indented past the list level
-        if indent <= parent_indent:
-            break
-
-        if not stripped.startswith("- "):
-            # Not a list item - might be continuation of previous dict item
-            i += 1
-            continue
-
-        item_content = stripped[2:].strip()
-
-        # First check if the entire item is a quoted string (may contain colons)
-        if item_content and item_content[0] in ('"', "'") and item_content[-1] == item_content[0]:
-            # Scalar item: quoted string
-            item_value = item_content[1:-1]
-            result.append(item_value)
-            i += 1
-        elif ":" in item_content:
-            # Dict item: "- key: value"
-            key, _, value = item_content.partition(":")
-            key = key.strip()
-            value = value.strip()
-
-            # Remove quotes if present
-            if value and value[0] in ('"', "'") and value[-1] == value[0]:
-                value = value[1:-1]
-
-            item_dict: dict[str, Any] = {}
-            if value:
-                try:
-                    item_dict[key] = int(value)
-                except ValueError:
-                    item_dict[key] = value
-            else:
-                item_dict[key] = {}
-
-            i += 1
-
-            # Check for additional keys at deeper indentation
-            while i < end:
-                next_indent, next_stripped = lines[i]
-                if next_indent <= indent:
-                    break
-                if next_stripped.startswith("- "):
-                    break
-                if ":" in next_stripped:
-                    k, _, v = next_stripped.partition(":")
-                    k = k.strip()
-                    v = v.strip()
-                    if v and v[0] in ('"', "'") and v[-1] == v[0]:
-                        v = v[1:-1]
-                    if v:
-                        try:
-                            item_dict[k] = int(v)
-                        except ValueError:
-                            item_dict[k] = v
-                    else:
-                        item_dict[k] = {}
-                i += 1
-
-            result.append(item_dict)
-        else:
-            # Scalar item: unquoted value
-            item_value: Any = item_content
-            try:
-                item_value = int(item_value)
-            except ValueError:
-                pass
-            result.append(item_value)
-            i += 1
-
-    return result, i
-
-
-def _find_block_end(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> int:
-    """Find where a block ends (where indentation returns to parent level)."""
-    i = start
-    while i < end:
-        indent, _ = lines[i]
-        if indent <= parent_indent:
-            break
-        i += 1
-    return i
+        return yaml.safe_load(f) or {}
 
 
 def _get_nested_value(config: dict, path: str) -> Any:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - Used by: `/setup-viewboard`, `/open-issue`, `/open-pr`, GitHub workflow automation
 - **Python 3.10+** - Required for permission automation module, otherwise you can have infinite `yes` to prompt!
   - Use Python `venv` or `anaconda` to manage a good Python release!
+  - Requires **PyYAML** (`pip install pyyaml`) for YAML configuration parsing
 
 ### Recommended Libraries
 

--- a/python/agentize/server/runtime_config.md
+++ b/python/agentize/server/runtime_config.md
@@ -49,9 +49,7 @@ Extract workflow -> model mapping from config.
 
 ### `_parse_yaml_file(path: Path) -> dict`
 
-Parse a simple YAML file into a nested dict. Supports basic YAML structure with nested dicts. Does not support arrays, anchors, or complex YAML features.
-
-This minimal parser avoids external dependencies, consistent with the project's approach for `.agentize.yaml` parsing.
+Parse a YAML file into a nested dict using PyYAML's `yaml.safe_load()`. Provides full YAML 1.2 compliance with support for all standard YAML features.
 
 ## Configuration Schema
 
@@ -110,11 +108,12 @@ This enables user-wide configuration (e.g., Telegram credentials) while allowing
 
 ## Parser Capabilities
 
-The minimal YAML parser supports:
-- Nested dicts (key-value pairs with indentation)
-- Simple scalar values (strings, integers)
-- Arrays of scalars: `- "value"` or `- value`
-- Arrays of dicts: `- key: value`
+The PyYAML library provides full YAML 1.2 support including:
+- Nested dicts and arrays
+- All scalar types (strings, integers, booleans, floats)
+- Multi-line literals (`|` and `>`)
+- Anchors and aliases
+- Flow-style syntax (`[a, b]` and `{a: b}`)
 
 The `permissions` top-level key is allowed for user-configurable permission rules:
 ```yaml

--- a/python/agentize/server/runtime_config.py
+++ b/python/agentize/server/runtime_config.py
@@ -12,6 +12,8 @@ Configuration precedence: CLI args > env vars > .agentize.local.yaml > defaults
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 # Valid top-level keys in .agentize.local.yaml
 # Extended to include handsoff and metadata keys for unified local configuration
 VALID_TOP_LEVEL_KEYS = {
@@ -81,14 +83,7 @@ def load_runtime_config(start_dir: Path | None = None) -> tuple[dict, Path | Non
 
 
 def _parse_yaml_file(path: Path) -> dict:
-    """Parse a simple YAML file into a nested dict.
-
-    Supports basic YAML structure with nested dicts and arrays.
-    Arrays are supported as:
-      - "- value"  (scalar items)
-      - "- key: value" (dict items with subsequent indented key-values)
-
-    Does not support anchors, flow-style syntax, or multi-line literals.
+    """Parse YAML file using PyYAML's safe_load.
 
     Args:
         path: Path to the YAML file
@@ -96,169 +91,8 @@ def _parse_yaml_file(path: Path) -> dict:
     Returns:
         Parsed configuration as nested dict
     """
-    lines: list[tuple[int, str]] = []
-
     with open(path, "r") as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip())
-            lines.append((indent, stripped))
-
-    return _parse_lines(lines, 0, len(lines), -1)
-
-
-def _parse_lines(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> dict:
-    """Parse a range of lines into a dict, handling nested structures."""
-    result: dict[str, Any] = {}
-    i = start
-
-    while i < end:
-        indent, stripped = lines[i]
-
-        # Skip lines that are less indented than our scope
-        if indent <= parent_indent and i > start:
-            break
-
-        if stripped.startswith("- "):
-            # This shouldn't happen at dict level - skip
-            i += 1
-            continue
-
-        if ":" not in stripped:
-            i += 1
-            continue
-
-        key, _, value = stripped.partition(":")
-        key = key.strip()
-        value = value.strip()
-
-        # Remove quotes from value if present
-        if value and value[0] in ('"', "'") and value[-1] == value[0]:
-            value = value[1:-1]
-
-        if value:
-            # Simple key: value
-            try:
-                result[key] = int(value)
-            except ValueError:
-                result[key] = value
-            i += 1
-        else:
-            # Key with no value - check what follows
-            i += 1
-            if i < end:
-                next_indent, next_stripped = lines[i]
-                if next_indent > indent:
-                    if next_stripped.startswith("- "):
-                        # It's a list
-                        result[key], i = _parse_list(lines, i, end, indent)
-                    else:
-                        # It's a nested dict
-                        child_end = _find_block_end(lines, i, end, indent)
-                        result[key] = _parse_lines(lines, i, child_end, indent)
-                        i = child_end
-                else:
-                    # Empty value
-                    result[key] = {}
-            else:
-                result[key] = {}
-
-    return result
-
-
-def _parse_list(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> tuple[list, int]:
-    """Parse a list starting at the given position."""
-    result: list[Any] = []
-    i = start
-
-    while i < end:
-        indent, stripped = lines[i]
-
-        # Stop if we've de-indented past the list level
-        if indent <= parent_indent:
-            break
-
-        if not stripped.startswith("- "):
-            # Not a list item - might be continuation of previous dict item
-            i += 1
-            continue
-
-        item_content = stripped[2:].strip()
-
-        # First check if the entire item is a quoted string (may contain colons)
-        if item_content and item_content[0] in ('"', "'") and item_content[-1] == item_content[0]:
-            # Scalar item: quoted string
-            item_value = item_content[1:-1]
-            result.append(item_value)
-            i += 1
-        elif ":" in item_content:
-            # Dict item: "- key: value"
-            key, _, value = item_content.partition(":")
-            key = key.strip()
-            value = value.strip()
-
-            # Remove quotes if present
-            if value and value[0] in ('"', "'") and value[-1] == value[0]:
-                value = value[1:-1]
-
-            item_dict: dict[str, Any] = {}
-            if value:
-                try:
-                    item_dict[key] = int(value)
-                except ValueError:
-                    item_dict[key] = value
-            else:
-                item_dict[key] = {}
-
-            i += 1
-
-            # Check for additional keys at deeper indentation
-            while i < end:
-                next_indent, next_stripped = lines[i]
-                if next_indent <= indent:
-                    break
-                if next_stripped.startswith("- "):
-                    break
-                if ":" in next_stripped:
-                    k, _, v = next_stripped.partition(":")
-                    k = k.strip()
-                    v = v.strip()
-                    if v and v[0] in ('"', "'") and v[-1] == v[0]:
-                        v = v[1:-1]
-                    if v:
-                        try:
-                            item_dict[k] = int(v)
-                        except ValueError:
-                            item_dict[k] = v
-                    else:
-                        item_dict[k] = {}
-                i += 1
-
-            result.append(item_dict)
-        else:
-            # Scalar item: unquoted value
-            item_value: Any = item_content
-            try:
-                item_value = int(item_value)
-            except ValueError:
-                pass
-            result.append(item_value)
-            i += 1
-
-    return result, i
-
-
-def _find_block_end(lines: list[tuple[int, str]], start: int, end: int, parent_indent: int) -> int:
-    """Find where a block ends (where indentation returns to parent level)."""
-    i = start
-    while i < end:
-        indent, _ = lines[i]
-        if indent <= parent_indent:
-            break
-        i += 1
-    return i
+        return yaml.safe_load(f) or {}
 
 
 def resolve_precedence(

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,2 +1,3 @@
 # Development dependencies for agentize Python modules
 pytest>=7.0.0
+pyyaml>=6.0

--- a/python/tests/test_local_config.py
+++ b/python/tests/test_local_config.py
@@ -59,7 +59,7 @@ handsoff:
         config, path = load_local_config(tmp_path)
 
         assert path is not None
-        assert config.get("handsoff", {}).get("enabled") == "true"
+        assert config.get("handsoff", {}).get("enabled") is True
         assert config.get("handsoff", {}).get("max_continuations") == 15
         assert config.get("handsoff", {}).get("supervisor", {}).get("provider") == "claude"
 
@@ -80,7 +80,7 @@ telegram:
         config, path = load_local_config(tmp_path)
 
         assert path is not None
-        assert config.get("telegram", {}).get("enabled") == "true"
+        assert config.get("telegram", {}).get("enabled") is True
         assert config.get("telegram", {}).get("token") == "123456:ABC-DEF"
         assert config.get("telegram", {}).get("allowed_user_ids") == "123,456,789"
 
@@ -101,7 +101,7 @@ handsoff:
         config, path = load_local_config(nested_dir)
 
         assert path is not None
-        assert config.get("handsoff", {}).get("enabled") == "true"
+        assert config.get("handsoff", {}).get("enabled") is True
 
 
 class TestGetNestedValue:
@@ -281,9 +281,9 @@ permissions:
         config_content = """
 permissions:
   allow:
-    - pattern: "^cat .*\\.md$"
+    - pattern: '^cat .*\\.md$'
       tool: Read
-    - pattern: "^npm run build"
+    - pattern: '^npm run build'
       tool: Bash
 """
         config_file = tmp_path / ".agentize.local.yaml"
@@ -306,11 +306,11 @@ permissions:
         config_content = """
 permissions:
   allow:
-    - "^npm run build"
-    - pattern: "^cat .*\\.md$"
+    - '^npm run build'
+    - pattern: '^cat .*\\.md$'
       tool: Read
   deny:
-    - "^rm -rf"
+    - '^rm -rf'
 """
         config_file = tmp_path / ".agentize.local.yaml"
         config_file.write_text(config_content)

--- a/python/tests/test_runtime_config.py
+++ b/python/tests/test_runtime_config.py
@@ -29,7 +29,7 @@ server:
 
 telegram:
   token: "test-token"
-  chat_id: "12345"
+  chat_id: 12345
 
 workflows:
   impl:
@@ -201,10 +201,10 @@ handsoff:
         config, path = load_runtime_config(tmp_path)
 
         assert path is not None
-        assert config.get("handsoff", {}).get("enabled") == "true"
+        assert config.get("handsoff", {}).get("enabled") is True
         assert config.get("handsoff", {}).get("max_continuations") == 20
-        assert config.get("handsoff", {}).get("auto_permission") == "true"
-        assert config.get("handsoff", {}).get("debug") == "false"
+        assert config.get("handsoff", {}).get("auto_permission") is True
+        assert config.get("handsoff", {}).get("debug") is False
         assert config.get("handsoff", {}).get("supervisor", {}).get("provider") == "claude"
         assert config.get("handsoff", {}).get("supervisor", {}).get("model") == "opus"
         assert config.get("handsoff", {}).get("supervisor", {}).get("flags") == "--timeout 1800"
@@ -215,7 +215,7 @@ handsoff:
 telegram:
   enabled: true
   token: "test-token"
-  chat_id: "-1001234567890"
+  chat_id: -1001234567890
   timeout_sec: 120
   poll_interval_sec: 10
   allowed_user_ids: "123,456,789"
@@ -226,7 +226,7 @@ telegram:
         config, path = load_runtime_config(tmp_path)
 
         assert path is not None
-        assert config.get("telegram", {}).get("enabled") == "true"
+        assert config.get("telegram", {}).get("enabled") is True
         assert config.get("telegram", {}).get("token") == "test-token"
         # Note: YAML parser converts numeric strings to int (negative numbers work)
         assert config.get("telegram", {}).get("chat_id") == -1001234567890
@@ -287,11 +287,11 @@ pre_commit:
         config_content = """
 permissions:
   allow:
-    - "^npm run build"
-    - pattern: "^cat .*\\.md$"
+    - '^npm run build'
+    - pattern: '^cat .*\\.md$'
       tool: Read
   deny:
-    - "^rm -rf"
+    - '^rm -rf'
 """
         config_file = tmp_path / ".agentize.local.yaml"
         config_file.write_text(config_content)
@@ -310,9 +310,9 @@ permissions:
         config_content = """
 permissions:
   allow:
-    - "^npm run build"
-    - "^make test"
-    - pattern: "^cat .*\\.md$"
+    - '^npm run build'
+    - '^make test'
+    - pattern: '^cat .*\\.md$'
       tool: Read
 """
         config_file = tmp_path / ".agentize.local.yaml"


### PR DESCRIPTION
## Summary

- Replace ~525 lines of custom minimal YAML parser code with PyYAML's `yaml.safe_load()`
- Add `pyyaml>=6.0` as a new dependency in `requirements-dev.txt`
- Update module documentation to reflect PyYAML usage and full YAML 1.2 compliance
- Update test expectations for PyYAML's native boolean coercion (`true` → `True`)

## Changes

| File | Change |
|------|--------|
| `python/requirements-dev.txt` | Added `pyyaml>=6.0` dependency |
| `README.md` | Document PyYAML as required for Python 3.10+ |
| `.claude-plugin/lib/local_config.py` | Replace ~180 lines custom parser with `yaml.safe_load()` |
| `python/agentize/server/runtime_config.py` | Replace ~180 lines custom parser with `yaml.safe_load()` |
| `.claude-plugin/lib/permission/rules.py` | Replace ~165 lines custom parser with `yaml.safe_load()` |
| `*.md` documentation | Update parser descriptions and capabilities |
| `python/tests/*.py` | Update test assertions and YAML escaping |

## Net Impact

- Removed ~500 lines of duplicated custom parser code
- Full YAML 1.2 compliance (anchors, aliases, multi-line literals, flow-style)
- Improved maintainability and robustness

## Test Plan

- [x] All 209 pytest tests pass
- [x] All 44 shell tests pass
- [x] `make test-fast` passes

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)