### PR TITLE
[refactor][#630] Add home directory fallback for .agentize.local.yaml

### DIFF
--- a/python/agentize/server/runtime_config.py
+++ b/python/agentize/server/runtime_config.py
@@ -9,6 +9,7 @@ This module handles loading server-specific settings that shouldn't be committed
 Configuration precedence: CLI args > env vars > .agentize.local.yaml > defaults
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +65,22 @@ def load_runtime_config(start_dir: Path | None = None) -> tuple[dict, Path | Non
             # Reached root
             break
         current = parent
+
+    # Fallback 1: Try $AGENTIZE_HOME
+    if config_path is None:
+        agentize_home = os.getenv("AGENTIZE_HOME")
+        if agentize_home:
+            candidate = Path(agentize_home) / ".agentize.local.yaml"
+            if candidate.is_file():
+                config_path = candidate
+
+    # Fallback 2: Try $HOME (user-wide config)
+    if config_path is None:
+        home = os.getenv("HOME")
+        if home:
+            candidate = Path(home) / ".agentize.local.yaml"
+            if candidate.is_file():
+                config_path = candidate
 
     if config_path is None:
         return {}, None


### PR DESCRIPTION
## Summary

Added home directory fallback for `.agentize.local.yaml` configuration in `runtime_config.py` to match the behavior already implemented in `local_config.py`. This enables user-wide configuration (e.g., Telegram credentials) while allowing project-specific overrides.

**Search priority:**
1. Project root (walk up from `start_dir`)
2. `$AGENTIZE_HOME/.agentize.local.yaml`
3. `$HOME/.agentize.local.yaml`

## Changes

- Modified `python/agentize/server/runtime_config.py:12` to add `import os` for environment variable access
- Added `python/agentize/server/runtime_config.py:69-83` with home directory fallback logic after parent directory search
- Added `python/tests/test_runtime_config.py:333-451` with `TestHomeDirectoryFallback` test class containing 4 test cases
- Fixed `python/tests/test_runtime_config.py:16-25` to clear environment variables preventing interference from real home config

## Testing

- Added `TestHomeDirectoryFallback` test class with 4 tests:
  - `test_agentize_home_fallback_when_no_project_config`: Verifies `$AGENTIZE_HOME` used when project has no config
  - `test_home_fallback_when_no_agentize_home`: Verifies `$HOME` used when neither project nor `$AGENTIZE_HOME` has config
  - `test_project_config_takes_priority_over_home`: Verifies project config takes priority over home directories
  - `test_agentize_home_priority_over_home`: Verifies `$AGENTIZE_HOME` takes priority over `$HOME`
- All 22 tests in `test_runtime_config.py` pass
- Code review passed with no critical issues

## Related Issue

Closes #630
