### PR TITLE
Remove Bash permission from mega-proposal-critique agent

### DIFF
--- a/.claude-plugin/agents/mega-proposal-critique.md
+++ b/.claude-plugin/agents/mega-proposal-critique.md
@@ -1,7 +1,7 @@
 ---
 name: mega-proposal-critique
 description: Validate assumptions and analyze technical feasibility of BOTH proposals (bold + paranoia)
-tools: WebSearch, WebFetch, Grep, Glob, Read, Bash
+tools: WebSearch, WebFetch, Grep, Glob, Read
 model: opus
 ---
 


### PR DESCRIPTION
## Summary
- Remove unnecessary Bash tool permission from the mega-proposal-critique agent
- The critique agent only needs read-only access (WebSearch, WebFetch, Grep, Glob, Read) to analyze proposals
- Bash execution is not required for validation and risk assessment tasks

## Test plan
- [ ] Verify mega-proposal-critique agent still functions correctly without Bash
- [ ] Run mega-planner workflow to confirm critique phase works

🤖 Generated with [Claude Code](https://claude.com/claude-code)