### PR TITLE
[cli][#686] Added --refine support to lol plan

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -119,10 +119,12 @@ lol usage --week
 Run the multi-agent debate pipeline.
 
 ```bash
-lol plan [--dry-run] [--verbose] [--backend <provider:model>] \
-  [--understander <provider:model>] [--bold <provider:model>] \
-  [--critique <provider:model>] [--reducer <provider:model>] \
+lol plan [--dry-run] [--verbose] [--refine <issue-no> [refinement-instructions]] \
+  [--backend <provider:model>] [--understander <provider:model>] \
+  [--bold <provider:model>] [--critique <provider:model>] \
+  [--reducer <provider:model>] \
   "<feature-description>"
+lol plan --refine <issue-no> [refinement-instructions]
 ```
 
 Runs the full multi-agent debate pipeline for a feature description, producing a consensus implementation plan. This is the preferred entrypoint for the planner pipeline.
@@ -138,8 +140,11 @@ Runs the full multi-agent debate pipeline for a feature description, producing a
 | `--bold` | No | - | Override backend for bold-proposer stage |
 | `--critique` | No | - | Override backend for critique stage |
 | `--reducer` | No | - | Override backend for reducer stage |
+| `--refine <issue-no> [refinement-instructions]` | No | - | Refine an existing plan issue (optional focus) |
 
 By default, `lol plan` creates a GitHub issue when `gh` is available. Use `--dry-run` to skip issue creation and use timestamp-based artifact naming instead.
+
+When `--refine` is set, the issue body is fetched from GitHub and used as the debate context. Optional refinement instructions are appended to the context to guide the agents. Refinement runs write artifacts prefixed with `issue-refine-<N>` and update the existing issue unless `--dry-run` is provided. This mode requires authenticated `gh` access to read the issue body.
 
 #### Example
 
@@ -155,6 +160,12 @@ lol plan --verbose "Add real-time notifications"
 
 # Use a different backend for the understander stage
 lol plan --understander cursor:gpt-5.2-codex "Plan with cursor understander"
+
+# Refine an existing plan issue
+lol plan --refine 42 "Focus on reducing complexity"
+
+# Refine without publishing back to GitHub (still writes issue-refine artifacts)
+lol plan --dry-run --refine 42 "Add more error handling and edge cases"
 ```
 
 See [planner pipeline module](planner.md) for pipeline stage details and artifact naming.

--- a/src/cli/lol.md
+++ b/src/cli/lol.md
@@ -185,17 +185,25 @@ Run the multi-agent debate pipeline via `lol plan`.
 
 **Signature:**
 ```bash
-lol_cmd_plan <feature_desc> <issue_mode> <verbose>
+lol_cmd_plan <feature_desc_or_refine_instructions> <issue_mode> <verbose> \
+  <backend_default> <backend_understander> <backend_bold> <backend_critique> <backend_reducer> \
+  <refine_issue_number>
 ```
 
 **Parameters:**
-- `feature_desc`: Feature description string (required)
-- `issue_mode`: `"true"` to create GitHub issue, `"false"` to skip (required)
+- `feature_desc_or_refine_instructions`: Feature description string, or refinement instructions when refining (required unless `refine_issue_number` is set)
+- `issue_mode`: `"true"` to create/update GitHub issue, `"false"` to skip publish (required)
 - `verbose`: `"true"` for detailed logs, `"false"` for quiet mode (required)
+- `backend_default`: Default backend for all stages (provider:model, optional)
+- `backend_understander`: Override backend for understander stage (optional)
+- `backend_bold`: Override backend for bold-proposer stage (optional)
+- `backend_critique`: Override backend for critique stage (optional)
+- `backend_reducer`: Override backend for reducer stage (optional)
+- `refine_issue_number`: Issue number to refine (optional)
 
 **Operations:**
 1. Lazily load planner modules (sources `planner.sh` if not already loaded)
-2. Call `_planner_run_pipeline` with parsed flags
+2. Call `_planner_run_pipeline` with parsed flags, including optional refine issue number
 
 **Return codes:**
 - `0`: Pipeline completed successfully

--- a/src/cli/lol/commands/plan.sh
+++ b/src/cli/lol/commands/plan.sh
@@ -3,7 +3,7 @@
 # Delegates to planner pipeline for multi-agent debate
 
 # Run the multi-agent debate pipeline
-# Usage: lol_cmd_plan <feature_desc> <issue_mode> <verbose> <backend_default> <backend_understander> <backend_bold> <backend_critique> <backend_reducer>
+# Usage: lol_cmd_plan <feature_desc_or_refine_instructions> <issue_mode> <verbose> <backend_default> <backend_understander> <backend_bold> <backend_critique> <backend_reducer> <refine_issue_number>
 lol_cmd_plan() {
     local feature_desc="$1"
     local issue_mode="$2"
@@ -13,12 +13,13 @@ lol_cmd_plan() {
     local backend_bold="$6"
     local backend_critique="$7"
     local backend_reducer="$8"
+    local refine_issue_number="$9"
 
     # Validate feature description
-    if [ -z "$feature_desc" ]; then
+    if [ -z "$feature_desc" ] && [ -z "$refine_issue_number" ]; then
         echo "Error: Feature description is required." >&2
         echo "" >&2
-        echo "Usage: lol plan [--dry-run] [--verbose] \"<feature-description>\"" >&2
+        echo "Usage: lol plan [--dry-run] [--verbose] [--refine <issue-number> [refinement-instructions]] \"<feature-description>\"" >&2
         return 1
     fi
 
@@ -35,5 +36,5 @@ lol_cmd_plan() {
     # Delegate to planner pipeline
     _planner_run_pipeline "$feature_desc" "$issue_mode" "$verbose" \
         "$backend_default" "$backend_understander" "$backend_bold" \
-        "$backend_critique" "$backend_reducer"
+        "$backend_critique" "$backend_reducer" "$refine_issue_number"
 }

--- a/src/cli/lol/completion.sh
+++ b/src/cli/lol/completion.sh
@@ -44,6 +44,7 @@ lol_complete() {
         plan-flags)
             echo "--dry-run"
             echo "--verbose"
+            echo "--refine"
             ;;
         *)
             # Unknown topic, return empty

--- a/src/cli/lol/dispatch.sh
+++ b/src/cli/lol/dispatch.sh
@@ -101,7 +101,7 @@ lol() {
             echo "  lol project --associate <owner>/<id>"
             echo "  lol project --automation [--write <path>]"
             echo "  lol serve"
-            echo "  lol plan [--dry-run] [--verbose] [--backend <provider:model>] \"<feature-description>\""
+            echo "  lol plan [--dry-run] [--verbose] [--refine <issue-no> [refinement-instructions]] [--backend <provider:model>] \"<feature-description>\""
             echo "  lol usage [--today | --week] [--cache] [--cost]"
             echo "  lol claude-clean [--dry-run]"
             echo ""
@@ -115,6 +115,7 @@ lol() {
             echo "  --title <title>     Project title (project --create)"
             echo "  --dry-run           Skip issue creation (plan) or preview changes (claude-clean)"
             echo "  --verbose           Print detailed stage logs (plan)"
+            echo "  --refine            Refine an existing plan issue (plan)"
             echo "  --backend           Default backend for plan stages (provider:model)"
             echo "  --understander      Override backend for understander stage"
             echo "  --bold              Override backend for bold-proposer stage"
@@ -137,6 +138,7 @@ lol() {
             echo "  lol claude-clean                # Remove stale entries"
             echo "  lol plan \"Add JWT auth\"        # Run planning pipeline"
             echo "  lol plan --dry-run \"Refactor\"  # Plan without creating issue"
+            echo "  lol plan --refine 42 \"Tighten scope\""
             return 1
             ;;
     esac

--- a/src/cli/planner.md
+++ b/src/cli/planner.md
@@ -7,10 +7,12 @@ Internal loader for the planner pipeline module used by `lol plan`. Sources modu
 ## Public Entry Point
 
 ```bash
-lol plan [--dry-run] [--verbose] [--backend <provider:model>] \
-  [--understander <provider:model>] [--bold <provider:model>] \
-  [--critique <provider:model>] [--reducer <provider:model>] \
+lol plan [--dry-run] [--verbose] [--refine <issue-no> [refinement-instructions]] \
+  [--backend <provider:model>] [--understander <provider:model>] \
+  [--bold <provider:model>] [--critique <provider:model>] \
+  [--reducer <provider:model>] \
   "<feature-description>"
+lol plan --refine <issue-no> [refinement-instructions]
 ```
 
 This module exports only internal `_planner_*` helpers; the public entrypoint is `lol plan`.
@@ -31,9 +33,10 @@ Stage-specific flags override `--backend`. Defaults are `claude:sonnet` for unde
 
 | Function | Location | Purpose |
 |----------|----------|---------|
-| `_planner_run_pipeline` | `planner/pipeline.sh` | Orchestrates the multi-agent debate pipeline (optional issue mode) |
+| `_planner_run_pipeline` | `planner/pipeline.sh` | Orchestrates the multi-agent debate pipeline (optional issue mode/refine) |
 | `_planner_render_prompt` | `planner/pipeline.sh` | Concatenates agent prompt + plan-guideline + context into a temp file |
 | `_planner_issue_create` | `planner/github.sh` | Creates placeholder GitHub issue (optional) |
+| `_planner_issue_fetch` | `planner/github.sh` | Fetches existing issue body for refine mode |
 | `_planner_issue_publish` | `planner/github.sh` | Updates issue body and adds `agentize:plan` label |
 
 ## Module Load Order

--- a/src/cli/planner/README.md
+++ b/src/cli/planner/README.md
@@ -15,7 +15,7 @@ planner/github.sh    - GitHub issue creation/update helpers
 ## Load Order
 
 1. `pipeline.sh` - Defines `_planner_run_pipeline()` and `_planner_render_prompt()` helpers
-2. `github.sh` - Defines `_planner_issue_create()` and `_planner_issue_publish()` helpers
+2. `github.sh` - Defines `_planner_issue_create()`, `_planner_issue_fetch()`, and `_planner_issue_publish()` helpers
 
 ## Related Documentation
 

--- a/src/cli/planner/github.md
+++ b/src/cli/planner/github.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Optional GitHub issue helpers for default issue creation; `--dry-run` skips issue creation. Encapsulates all `gh` CLI interactions so the pipeline module only needs to call `_planner_issue_create` and `_planner_issue_publish` without knowing the `gh` API details.
+Optional GitHub issue helpers for default issue creation and refine mode. `--dry-run` skips issue creation/publish. Encapsulates all `gh` CLI interactions so the pipeline module only needs to call `_planner_issue_create`, `_planner_issue_fetch`, and `_planner_issue_publish` without knowing the `gh` API details.
 
 ## Private Helpers
 
@@ -10,8 +10,9 @@ Optional GitHub issue helpers for default issue creation; `--dry-run` skips issu
 |----------|---------|
 | `_planner_gh_available` | Check if `gh` CLI is installed and authenticated |
 | `_planner_issue_create` | Create a placeholder GitHub issue with `[plan] placeholder:` and a truncated feature title |
+| `_planner_issue_fetch` | Fetch issue body (and URL) for refinement runs |
 | `_planner_issue_publish` | Update issue body with consensus plan and add `agentize:plan` label |
 
 ## Design Rationale
 
-All GitHub interactions are isolated in this module to keep the pipeline logic (`pipeline.sh`) independent of GitHub. When `gh` is unavailable or fails, each function returns non-zero and logs a warning, allowing the pipeline to fall back to timestamp-based artifacts without any error propagation.
+All GitHub interactions are isolated in this module to keep the pipeline logic (`pipeline.sh`) independent of GitHub. Creation and publishing log warnings and allow timestamp fallbacks when `gh` is unavailable. Refinement fetches are treated as required inputs so the pipeline can reuse existing issue context.

--- a/src/completion/_lol
+++ b/src/completion/_lol
@@ -84,6 +84,7 @@ _lol_plan() {
     _arguments \
         '--dry-run[Skip GitHub issue creation; use timestamp-based artifacts]' \
         '--verbose[Print detailed stage logs]' \
+        '--refine[Refine an existing plan issue]:issue-number:' \
         ':feature description:'
 }
 

--- a/tests/cli/test-lol-complete-flags.sh
+++ b/tests/cli/test-lol-complete-flags.sh
@@ -46,6 +46,7 @@ plan_output=$(lol --complete plan-flags 2>/dev/null)
 
 echo "$plan_output" | grep -q "^--dry-run$" || test_fail "plan-flags missing: --dry-run"
 echo "$plan_output" | grep -q "^--verbose$" || test_fail "plan-flags missing: --verbose"
+echo "$plan_output" | grep -q "^--refine$" || test_fail "plan-flags missing: --refine"
 
 # Test unknown topic returns empty
 unknown_output=$(lol --complete unknown-topic 2>/dev/null)

--- a/tests/cli/test-lol-help-text.sh
+++ b/tests/cli/test-lol-help-text.sh
@@ -29,4 +29,8 @@ echo "$output" | grep -q "lol usage" || test_fail "Usage text missing 'lol usage
 # Verify usage text includes lol plan command
 echo "$output" | grep -q "lol plan" || test_fail "Usage text missing 'lol plan' command"
 
+# Verify lol plan --help includes --refine
+plan_help=$(lol plan --help 2>&1)
+echo "$plan_help" | grep -q "\-\-refine" || test_fail "lol plan --help missing '--refine' option"
+
 test_pass "lol usage text includes documented commands"


### PR DESCRIPTION
## Summary

Added refine mode to `lol plan` so it can fetch an existing plan issue as context, optionally append refinement focus text, write `issue-refine-<N>` artifacts, and update the issue unless `--dry-run` is set. Updated docs, completion, and tests to keep CLI behavior aligned.

## Changes

- Modified `src/cli/lol/parsers.sh:193-334` to parse `--refine`, collect optional instructions, and allow refine-only invocation.
- Modified `src/cli/lol/commands/plan.sh:6-39` to pass refine issue number into the pipeline and allow empty feature text when refining.
- Modified `src/cli/planner/pipeline.sh:215-459` to fetch issue body in refine mode, append focus text, use `issue-refine-<N>` artifacts, and avoid placeholder creation.
- Added `_planner_issue_fetch` in `src/cli/planner/github.sh:52-79` to retrieve issue body/URL for refinement runs.
- Updated CLI usage and completion in `src/cli/lol/dispatch.sh:104-141`, `src/cli/lol/completion.sh:46-47`, and `src/completion/_lol:86-87`.
- Updated docs in `docs/cli/lol.md:122-168`, `docs/cli/planner.md:8-89`, `src/cli/lol.md:188-206`, `src/cli/planner.md:10-39`, `src/cli/planner/README.md:18`, and `src/cli/planner/github.md:5-18`.
- Expanded tests in `tests/cli/test-lol-help-text.sh:31-34`, `tests/cli/test-lol-complete-flags.sh:48-49`, and `tests/cli/test-lol-plan-issue-mode.sh:37-226`.

## Testing

- `bash tests/cli/test-lol-help-text.sh`
- `bash tests/cli/test-lol-complete-flags.sh`
- `bash tests/cli/test-lol-plan-issue-mode.sh`

## Related Issue

Closes #686
