### PR TITLE
[cli][#698] Add git workflow to lol impl for iteration commits and PR creation

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -199,6 +199,10 @@ Before the loop starts, `lol impl` attempts to fetch the issue title/body (and l
 Create `.tmp/report.txt` in the worktree and include `Issue <N> resolved` to finish.
 The first line of `.tmp/report.txt` is used as the PR title.
 
+#### Git workflow
+
+Each iteration stages and commits changes (skipping commits when there are no changes). On completion, the branch is pushed to `upstream` (or `origin`) and the PR targets `master` (or `main`).
+
 #### Example
 
 ```bash


### PR DESCRIPTION
## Summary

Enhanced `lol impl` to stage and commit changes after each `acw` iteration (skipping when no changes exist), detect the appropriate push remote (preferring `upstream` over `origin`) and base branch (preferring `master` over `main`), and push the branch before creating the PR with an explicit `--base` flag.

## Changes

- Modified `src/cli/lol/commands/impl.sh:103-192` to add:
  - Git staging and commit after each iteration with deterministic commit messages
  - Remote detection logic (upstream > origin)
  - Base branch detection logic (master > main)
  - Push before PR creation with explicit `--base` flag
- Updated `docs/cli/lol.md:202-204` to document the new git workflow behavior
- Modified `tests/cli/test-lol-impl-stubbed.sh` to add:
  - Git stub function for testing
  - Test 8: Git commit after iteration when changes exist
  - Test 9: Skip commit when no changes
  - Test 10: Push remote precedence (upstream over origin)
  - Test 11: Base branch selection (master over main)
  - Test 12: Fallback to origin and main when upstream/master unavailable

## Testing

- Added git stub in `tests/cli/test-lol-impl-stubbed.sh` that simulates:
  - Staging changes (`git add -A`)
  - Checking for staged changes (`git diff --cached --quiet`)
  - Committing (`git commit`)
  - Remote detection (`git remote`)
  - Branch verification (`git rev-parse --verify`)
  - Pushing (`git push`)
- Tests verify:
  - Commits are created when changes exist
  - Commits are skipped when no changes
  - `upstream` is preferred over `origin` for pushing
  - `master` is preferred over `main` for PR base branch
  - Fallback behavior when preferred remote/branch unavailable
- All 12 tests pass

## Related Issue

Closes #698
