### PR TITLE
Fix zsh completion for lol plan --editor

### DIFF
--- a/src/completion/_lol
+++ b/src/completion/_lol
@@ -86,7 +86,7 @@ _lol() {
 
 # Completion for 'lol plan' subcommand
 _lol_plan() {
-    _arguments \
+    _arguments -s \
         '--dry-run[Skip GitHub issue creation; use timestamp-based artifacts]' \
         '--verbose[Print detailed stage logs]' \
         '--editor[Open $EDITOR to compose feature description]' \

--- a/src/completion/_lol.md
+++ b/src/completion/_lol.md
@@ -44,3 +44,5 @@ for the known flags so the completion UI remains informative.
   helper fails.
 - Descriptions are sourced from the CLI documentation to minimize drift and keep
   the UX consistent with the published interface.
+- `_lol_plan()` uses `_arguments -s` to enable smart option matching so unique
+  flag prefixes (like `--ed`) complete immediately without requiring a second tab.

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -62,6 +62,16 @@ Run CLI tests under multiple shells:
 TEST_SHELLS="bash zsh" bash tests/cli/test-wt-complete-commands.sh
 ```
 
+## Manual Completion Check (Zsh)
+
+These checks are interactive and cannot be automated in CI.
+
+1. Source the completion file: `source src/completion/_lol`
+2. Verify unique prefix completion: type `lol plan --ed<TAB>`
+   - Expected: completes to `--editor` on the first tab press
+3. Verify ambiguous prefix behavior: type `lol plan --<TAB>`
+   - Expected: shows all available options
+
 ## Test Patterns
 
 CLI tests follow the standard test structure:


### PR DESCRIPTION
Fix zsh completion for lol plan --editor

## Summary
- enable smart option matching for lol plan completion via _arguments -s
- document smart matching rationale in completion design notes
- add manual Zsh completion check for unique prefixes

## Testing
- not run (manual completion check documented in tests/cli/README.md)

Issue 711 resolved
Closes #711