### PR TITLE
Add --silent flag to acw for provider stderr suppression

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,11 @@
+# CLI Docs
+
+## Purpose
+
+Design and usage documentation for Agentize command-line interfaces.
+
+## Organization
+
+- `acw.md` - Agent CLI Wrapper interface and usage
+- `lol.md` - Agentize CLI commands and behavior
+- `planner.md` - Planner CLI interface

--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -12,7 +12,7 @@ acw --help
 
 ## Description
 
-`acw` provides a consistent interface for invoking different AI CLI tools (claude, codex, opencode, cursor/agent) with file-based input/output. This enables scripts to use a uniform interface regardless of the underlying AI provider.
+`acw` provides a consistent interface for invoking different AI CLI tools (claude, codex, opencode, cursor/agent) with file-based input/output. This enables scripts to use a uniform interface regardless of the underlying AI provider and control provider stderr behavior with a single flag.
 
 ## Arguments
 
@@ -22,7 +22,13 @@ acw --help
 | `model-name` | Yes | Model identifier passed to the provider |
 | `input-file` | Yes | Path to file containing the prompt |
 | `output-file` | Yes | Path where response will be written |
-| `cli-options` | No | Additional options passed to the provider CLI |
+| `cli-options` | No | Additional options passed to the provider CLI (acw consumes `--silent`) |
+
+## Common CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--silent` | Suppress provider stderr output while keeping acw validation errors visible |
 
 ## Supported Providers
 
@@ -57,6 +63,9 @@ acw codex gpt-4o prompt.txt response.txt
 
 # Pass additional options to the provider
 acw claude claude-sonnet-4-20250514 prompt.txt response.txt --max-tokens 4096
+
+# Suppress provider stderr output
+acw claude claude-sonnet-4-20250514 prompt.txt response.txt --silent
 ```
 
 ### Script Integration
@@ -89,7 +98,7 @@ Use `acw --complete <topic>` to get completion values programmatically:
 | Topic | Description |
 |-------|-------------|
 | `providers` | List of supported providers (claude, codex, opencode, cursor) |
-| `cli-options` | Common CLI options (e.g., --help, --model, --max-tokens, --yolo) |
+| `cli-options` | Common CLI options (e.g., --help, --model, --max-tokens, --yolo, --silent) |
 
 ### Setup
 
@@ -104,6 +113,7 @@ autoload -Uz compinit && compinit
 
 - The output directory is created automatically if it doesn't exist
 - Provider-specific options are passed through unchanged, except `--yolo` is normalized to Claude's `--dangerously-skip-permissions`
+- `--silent` suppresses provider stderr output while preserving acw validation errors
 - The wrapper returns the provider's exit code on successful execution
 - Best-effort providers (opencode, cursor) may have limited functionality
 - Only `acw` is the public function; all helper functions (provider invocation, completion, validation) are internal (prefixed with `_acw_`) and won't appear in tab completion

--- a/src/cli/acw.md
+++ b/src/cli/acw.md
@@ -33,6 +33,8 @@ acw <cli-name> <model-name> <input-file> <output-file> [options...]
 
 Validates arguments, dispatches to provider function, returns provider exit code.
 
+Options include `--silent`, which suppresses provider stderr output while keeping acw validation errors visible. The flag is consumed by `acw` and not forwarded to providers.
+
 This is the **only public function** exported by `acw.sh`. All other functions are internal (prefixed with `_acw_`).
 
 ### Private Functions

--- a/src/cli/acw/completion.md
+++ b/src/cli/acw/completion.md
@@ -1,0 +1,25 @@
+# completion.sh
+
+Shell completion helper for `acw`. Provides newline-delimited tokens for provider names and common CLI options.
+
+## External Interface
+
+### acw --complete <topic>
+
+Returns completion candidates for the given topic without requiring provider configuration.
+
+**Parameters**:
+- `topic`: Completion category (`providers` or `cli-options`).
+
+**Output**:
+- Newline-delimited tokens to stdout.
+
+## Internal Helpers
+
+### _acw_complete()
+
+Maps completion topics to stable lists:
+- `providers`: `claude`, `codex`, `opencode`, `cursor`.
+- `cli-options`: `--help`, `--model`, `--max-tokens`, `--yolo`, `--silent`.
+
+Returns an empty list for unknown topics to keep completion behavior resilient.

--- a/src/cli/acw/completion.sh
+++ b/src/cli/acw/completion.sh
@@ -19,6 +19,7 @@ _acw_complete() {
             echo "--model"
             echo "--max-tokens"
             echo "--yolo"
+            echo "--silent"
             ;;
         *)
             # Unknown topic, return empty (graceful degradation)

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -1,0 +1,28 @@
+# dispatch.sh
+
+Dispatch layer for the `acw` CLI, including help output, validation, and provider routing.
+
+## External Interface
+
+### acw()
+
+Entry point for the Agent CLI Wrapper.
+
+**Parameters**:
+- `$1`: Provider name or top-level flag (`--help`, `--complete`).
+- `$2`: Model identifier for the provider.
+- `$3`: Input file path.
+- `$4`: Output file path.
+- `$@`: Provider options.
+
+**Behavior**:
+- Emits usage text for `--help` and returns completion values for `--complete`.
+- Validates required arguments, provider name, and input/output paths before dispatch.
+- Consumes `--silent` from the option list to suppress provider stderr output while keeping acw validation errors visible.
+- Forwards remaining options to the provider invocation and returns the provider exit code.
+
+## Internal Helpers
+
+### _acw_usage()
+
+Prints a stable usage banner describing arguments, options, and exit codes.

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -21,6 +21,7 @@ Arguments:
 
 Options:
   --help        Show this help message
+  --silent      Suppress provider stderr output
   [options...]  Additional options passed to the provider CLI
 
 Providers:
@@ -107,19 +108,51 @@ acw() {
     # Shift past the four required arguments
     shift 4
 
+    # Parse acw-specific options and filter provider args
+    local silent_mode=0
+    local filtered_args=()
+    local arg
+
+    for arg in "$@"; do
+        if [ "$arg" = "--silent" ]; then
+            silent_mode=1
+        else
+            filtered_args+=( "$arg" )
+        fi
+    done
+
+    set -- "${filtered_args[@]}"
+
     # Dispatch to provider function
-    case "$cli_name" in
-        claude)
-            _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@"
-            ;;
-        codex)
-            _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@"
-            ;;
-        opencode)
-            _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@"
-            ;;
-        cursor)
-            _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@"
-            ;;
-    esac
+    if [ "$silent_mode" -eq 1 ]; then
+        case "$cli_name" in
+            claude)
+                _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@" 2>/dev/null
+                ;;
+            codex)
+                _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@" 2>/dev/null
+                ;;
+            opencode)
+                _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@" 2>/dev/null
+                ;;
+            cursor)
+                _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@" 2>/dev/null
+                ;;
+        esac
+    else
+        case "$cli_name" in
+            claude)
+                _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@"
+                ;;
+            codex)
+                _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@"
+                ;;
+            opencode)
+                _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@"
+                ;;
+            cursor)
+                _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@"
+                ;;
+        esac
+    fi
 }

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -18,6 +18,13 @@ Tests for the `wt` (worktree) command:
 - `test-wt-purge.sh` - Tests cleanup of stale worktrees
 - `test-wt-zsh-completion-crash.sh` - Tests zsh completion stability
 
+### Agent CLI Wrapper Tests (`test-acw-*`)
+
+Tests for the `acw` command:
+
+- `test-acw-silent-flag.sh` - Validates `--silent` stderr suppression and option filtering
+- `test-acw-yolo-translation.sh` - Tests `--yolo` translation for Claude provider
+
 ### Agentize CLI Tests (`test-lol-*`, `test-agentize-*`)
 
 Tests for the `lol` (agentize) command:

--- a/tests/cli/test-acw-silent-flag.md
+++ b/tests/cli/test-acw-silent-flag.md
@@ -1,0 +1,32 @@
+# test-acw-silent-flag.sh
+
+## Purpose
+
+Validate `acw --silent` behavior for provider stderr suppression and option filtering while preserving acw validation errors.
+
+## Test Cases
+
+### provider_stderr_visible_without_silent
+**Purpose**: Ensure provider stderr passes through when `--silent` is not used.
+**Setup**: Stub `claude` CLI emits stderr and stdout.
+**Expected**: stderr contains provider output and response file is written.
+
+### provider_stderr_suppressed_with_silent
+**Purpose**: Ensure provider stderr is suppressed when `--silent` is present.
+**Setup**: Stub `claude` CLI emits stderr and stdout.
+**Expected**: stderr is empty and response file is written.
+
+### silent_not_forwarded_to_provider
+**Purpose**: Ensure `--silent` is not passed to provider arguments.
+**Setup**: Stub `claude` logs arguments to a file.
+**Expected**: Arguments contain provider options but not `--silent`.
+
+### validation_errors_visible_with_silent
+**Purpose**: Ensure acw validation errors remain visible with `--silent`.
+**Setup**: Invoke `acw --silent` with missing required args.
+**Expected**: stderr includes the validation error and exit code is non-zero.
+
+### completion_includes_silent
+**Purpose**: Ensure completion includes `--silent` in `cli-options`.
+**Setup**: Invoke `acw --complete cli-options`.
+**Expected**: Output includes `--silent`.

--- a/tests/cli/test-acw-silent-flag.sh
+++ b/tests/cli/test-acw-silent-flag.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test: acw --silent suppresses provider stderr without hiding acw errors
+
+source "$(dirname "$0")/../common.sh"
+
+ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
+
+test_info "Testing acw --silent behavior"
+
+# Create temp directory for test artifacts
+TMP_DIR=$(make_temp_dir "acw-silent-$$")
+trap 'cleanup_dir "$TMP_DIR"' EXIT
+
+# Create a simple input file
+echo "Test prompt" > "$TMP_DIR/input.txt"
+
+# Create a stub claude command that logs args and writes stderr
+cat > "$TMP_DIR/claude" << 'STUB'
+#!/usr/bin/env bash
+echo "provider-stderr" >&2
+echo "$@" > "$ARGS_LOG_FILE"
+echo "stub response"
+STUB
+chmod +x "$TMP_DIR/claude"
+
+# Prepend stub directory to PATH so the stub is found first
+export PATH="$TMP_DIR:$PATH"
+
+# Source the acw module
+source "$ACW_CLI"
+
+# Case 1: provider stderr visible without --silent
+export ARGS_LOG_FILE="$TMP_DIR/args-default.log"
+acw claude test-model "$TMP_DIR/input.txt" "$TMP_DIR/output-default.txt" --max-tokens 111 2> "$TMP_DIR/stderr-default.txt"
+
+if ! grep -q "provider-stderr" "$TMP_DIR/stderr-default.txt"; then
+    test_fail "Expected provider stderr without --silent"
+fi
+
+if ! grep -q "stub response" "$TMP_DIR/output-default.txt"; then
+    test_fail "Expected response content without --silent"
+fi
+
+# Case 2: provider stderr suppressed with --silent
+export ARGS_LOG_FILE="$TMP_DIR/args-silent.log"
+acw claude test-model "$TMP_DIR/input.txt" "$TMP_DIR/output-silent.txt" --silent --max-tokens 222 2> "$TMP_DIR/stderr-silent.txt"
+
+if [ -s "$TMP_DIR/stderr-silent.txt" ]; then
+    test_fail "Expected provider stderr to be suppressed with --silent"
+fi
+
+if ! grep -q "stub response" "$TMP_DIR/output-silent.txt"; then
+    test_fail "Expected response content with --silent"
+fi
+
+if grep -q -- "--silent" "$TMP_DIR/args-silent.log"; then
+    test_fail "--silent was forwarded to the provider"
+fi
+
+if ! grep -q -- "--max-tokens" "$TMP_DIR/args-silent.log"; then
+    test_fail "Expected provider options to be forwarded"
+fi
+
+# Case 3: validation errors remain visible with --silent
+set +e
+acw --silent 2> "$TMP_DIR/stderr-validate.txt"
+status=$?
+set -e
+
+if [ $status -eq 0 ]; then
+    test_fail "Expected validation failure for missing args"
+fi
+
+if ! grep -q "Missing model-name argument" "$TMP_DIR/stderr-validate.txt"; then
+    test_fail "Expected validation error output with --silent"
+fi
+
+# Case 4: completion includes --silent
+completion=$(acw --complete cli-options)
+if ! echo "$completion" | grep -q -- "--silent"; then
+    test_fail "Expected --silent in cli-options completion"
+fi
+
+test_pass "acw --silent suppresses provider stderr and preserves acw errors"


### PR DESCRIPTION
Add --silent flag to acw for provider stderr suppression

## Summary
- handle --silent in acw dispatch and completion
- document silent behavior in CLI and module docs
- add CLI tests for stderr suppression, option filtering, and completion

## Testing
- bash tests/cli/test-acw-silent-flag.sh

Issue 715 resolved
Closes #715