### PR TITLE
Add lol use-branch and clarify upgrade branch switching

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -24,15 +24,30 @@ The Python entrypoint sources `setup.sh` and delegates to the shell implementati
 Upgrade the agentize installation.
 
 ```bash
-lol upgrade
+lol upgrade [--keep-branch]
 ```
 
+By default, `lol upgrade` switches to the default branch before pulling updates.
+Use `--keep-branch` to stay on the current branch and pull from its upstream.
+
 The upgrade process has three phases:
-1. **Pull updates**: Runs `git pull --rebase` to fetch latest changes
+1. **Pull updates**: Switches to the default branch (unless `--keep-branch`) and runs `git pull --rebase`
 2. **Rebuild environment**: Runs `make setup` to regenerate `setup.sh` with any build process changes
 3. **Update Claude plugin** (optional): If `claude` CLI is available, updates the local marketplace and plugin registration. This step is non-fatal; failures do not block the upgrade.
 
 This mirrors the installation process in `scripts/install`, ensuring updates to the build configuration and plugin are applied.
+
+### lol use-branch
+
+Switch to a remote development branch and rebuild the local environment.
+
+```bash
+lol use-branch <remote>/<branch>
+lol use-branch <branch>  # defaults to origin
+```
+
+This command fetches the remote branch, checks it out locally (creating a tracking
+branch if needed), runs `make setup`, and prints shell reload instructions.
 
 ### lol project
 

--- a/src/cli/lol/README.md
+++ b/src/cli/lol/README.md
@@ -14,13 +14,14 @@ Modular implementation of the `lol` SDK CLI. These files are sourced by `lol.sh`
 | `commands.sh` | Thin loader that sources `commands/*.sh` | All `_lol_cmd_*` functions (private) |
 | `commands/` | Per-command implementation files | See below |
 | `dispatch.sh` | Main dispatcher and help text | `lol` |
-| `parsers.sh` | Argument parsing for each command | `_lol_parse_project`, `_lol_parse_serve`, `_lol_parse_usage`, `_lol_parse_claude_clean`, `_lol_parse_plan`, `_lol_parse_impl` |
+| `parsers.sh` | Argument parsing for each command | `_lol_parse_project`, `_lol_parse_serve`, `_lol_parse_usage`, `_lol_parse_claude_clean`, `_lol_parse_plan`, `_lol_parse_impl`, `_lol_parse_use_branch`, `_lol_parse_upgrade` |
 
 ### commands/ Directory
 
 | File | Exports |
 |------|---------|
 | `upgrade.sh` | `_lol_cmd_upgrade` |
+| `use-branch.sh` | `_lol_cmd_use_branch` |
 | `version.sh` | `_lol_cmd_version` |
 | `project.sh` | `_lol_cmd_project` |
 | `serve.sh` | `_lol_cmd_serve` |

--- a/src/cli/lol/commands.md
+++ b/src/cli/lol/commands.md
@@ -1,0 +1,18 @@
+# commands.sh
+
+Loader for per-command `lol` implementations stored under `commands/`.
+
+## External Interface
+
+None. This module is sourced by `lol.sh` to register `_lol_cmd_*` functions.
+
+## Internal Helpers
+
+### _lol_commands_dir()
+Resolves the directory containing the `lol` CLI modules for both bash and zsh,
+so command files are sourced from the correct location regardless of the shell
+invocation context.
+
+### _LOL_COMMANDS_DIR
+Module-level path set by `_lol_commands_dir()`. Used to source individual
+command implementations in a stable order.

--- a/src/cli/lol/commands.sh
+++ b/src/cli/lol/commands.sh
@@ -15,6 +15,7 @@ _lol_commands_dir() {
 _LOL_COMMANDS_DIR="$(_lol_commands_dir)"
 
 source "$_LOL_COMMANDS_DIR/commands/upgrade.sh"
+source "$_LOL_COMMANDS_DIR/commands/use-branch.sh"
 source "$_LOL_COMMANDS_DIR/commands/version.sh"
 source "$_LOL_COMMANDS_DIR/commands/project.sh"
 source "$_LOL_COMMANDS_DIR/commands/serve.sh"

--- a/src/cli/lol/commands/README.md
+++ b/src/cli/lol/commands/README.md
@@ -9,6 +9,7 @@ Per-command implementation files for the `lol` CLI. Each file exports exactly on
 | File | Function | Description |
 |------|----------|-------------|
 | `upgrade.sh` | `_lol_cmd_upgrade` | Upgrade agentize installation via git |
+| `use-branch.sh` | `_lol_cmd_use_branch` | Switch to a remote development branch |
 | `version.sh` | `_lol_cmd_version` | Display version information |
 | `project.sh` | `_lol_cmd_project` | GitHub Projects v2 integration |
 | `serve.sh` | `_lol_cmd_serve` | Run polling server for automation |

--- a/src/cli/lol/commands/upgrade.md
+++ b/src/cli/lol/commands/upgrade.md
@@ -4,13 +4,14 @@ Implements `lol upgrade` for refreshing the agentize installation.
 
 ## External Interface
 
-### lol upgrade
+### lol upgrade [--keep-branch]
 
 Pulls the latest changes, rebuilds `setup.sh`, and refreshes optional tooling.
 
 **Behavior**:
 - Requires a clean git worktree.
-- Runs `git pull --rebase` against the default branch.
+- Switches to the default branch before pulling unless `--keep-branch` is used.
+- With `--keep-branch`, pulls the current branch's upstream instead of switching.
 - Runs `make setup` to regenerate environment scripts.
 - Attempts to update the Claude plugin when available.
 

--- a/src/cli/lol/commands/use-branch.md
+++ b/src/cli/lol/commands/use-branch.md
@@ -1,0 +1,25 @@
+# use-branch.sh
+
+Implements `lol use-branch` for switching the SDK worktree to a remote
+development branch and rebuilding the environment.
+
+## External Interface
+
+### lol use-branch <remote>/<branch>
+Fetches the remote branch, checks out (or creates) a local tracking branch,
+runs `make setup`, and prints shell reload instructions.
+
+### lol use-branch <branch>
+Defaults the remote to `origin` and applies the same workflow as above.
+
+**Exit codes**:
+- 0 on success.
+- 1 on validation failures (missing args, dirty worktree, unknown remote/branch,
+  or setup failures).
+
+## Internal Helpers
+
+### _lol_cmd_use_branch()
+Private entrypoint that validates the git worktree, ensures a clean state,
+fetches the requested branch, checks it out with upstream tracking, runs
+`make setup`, and emits reload guidance.

--- a/src/cli/lol/commands/use-branch.sh
+++ b/src/cli/lol/commands/use-branch.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# _lol_cmd_use_branch: Switch to a remote development branch
+# Runs in subshell to preserve set -e semantics
+_lol_cmd_use_branch() (
+    set -e
+
+    local remote="$1"
+    local branch="$2"
+
+    if [ -z "$remote" ] || [ -z "$branch" ]; then
+        echo "Error: Missing branch reference."
+        echo "Usage: lol use-branch <remote>/<branch>"
+        echo "       lol use-branch <branch>"
+        exit 1
+    fi
+
+    # Validate AGENTIZE_HOME is a valid git worktree
+    if ! git -C "$AGENTIZE_HOME" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "Error: AGENTIZE_HOME is not a valid git worktree."
+        echo "  Current value: $AGENTIZE_HOME"
+        exit 1
+    fi
+
+    # Check for uncommitted changes (dirty-tree guard)
+    if [ -n "$(git -C "$AGENTIZE_HOME" status --porcelain)" ]; then
+        echo "Warning: Uncommitted changes detected in AGENTIZE_HOME."
+        echo ""
+        echo "Please commit or stash your changes before switching branches:"
+        echo "  git add ."
+        echo "  git commit -m \"...\""
+        echo "OR"
+        echo "  git stash"
+        exit 1
+    fi
+
+    # Validate remote exists
+    if ! git -C "$AGENTIZE_HOME" remote get-url "$remote" >/dev/null 2>&1; then
+        echo "Error: Remote '$remote' is not configured in AGENTIZE_HOME."
+        echo ""
+        echo "Available remotes:"
+        git -C "$AGENTIZE_HOME" remote -v | awk '{print "  " $1}' | sort -u
+        exit 1
+    fi
+
+    echo "Switching agentize branch..."
+    echo "  AGENTIZE_HOME: $AGENTIZE_HOME"
+    echo "  Remote branch: $remote/$branch"
+    echo ""
+
+    echo "Fetching $remote/$branch..."
+    if ! git -C "$AGENTIZE_HOME" fetch "$remote" "$branch"; then
+        echo ""
+        echo "Error: Failed to fetch $remote/$branch."
+        exit 1
+    fi
+
+    if ! git -C "$AGENTIZE_HOME" show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
+        echo ""
+        echo "Error: Remote branch '$remote/$branch' not found."
+        exit 1
+    fi
+
+    if git -C "$AGENTIZE_HOME" show-ref --verify --quiet "refs/heads/$branch"; then
+        echo "Checking out existing branch '$branch'..."
+        git -C "$AGENTIZE_HOME" checkout "$branch"
+    else
+        echo "Creating tracking branch '$branch' from $remote/$branch..."
+        git -C "$AGENTIZE_HOME" checkout -b "$branch" --track "$remote/$branch"
+    fi
+
+    if ! git -C "$AGENTIZE_HOME" rev-parse --abbrev-ref --symbolic-full-name "@{u}" >/dev/null 2>&1; then
+        echo "Setting upstream for '$branch' to $remote/$branch..."
+        git -C "$AGENTIZE_HOME" branch --set-upstream-to "$remote/$branch" "$branch"
+    fi
+
+    echo ""
+    echo "Running make setup to rebuild environment configuration..."
+    if ! make -C "$AGENTIZE_HOME" setup; then
+        echo ""
+        echo "Error: make setup failed after branch switch"
+        exit 1
+    fi
+
+    echo ""
+    echo "Branch switch complete."
+    echo ""
+    echo "To apply changes, reload your shell:"
+    echo "  exec \$SHELL                # Clean shell restart (recommended)"
+    echo "OR"
+    echo "  source \"\$AGENTIZE_HOME/setup.sh\"  # In-place reload"
+)

--- a/src/cli/lol/completion.md
+++ b/src/cli/lol/completion.md
@@ -12,7 +12,8 @@ entrypoint routes `--complete` to the internal helper without requiring a full
 agentize environment.
 
 **Parameters**:
-- `topic`: Completion category (e.g., `commands`, `project-modes`, `plan-flags`).
+- `topic`: Completion category (e.g., `commands`, `project-modes`, `plan-flags`,
+  `upgrade-flags`).
 
 **Output**:
 - Newline-delimited tokens to stdout.

--- a/src/cli/lol/completion.sh
+++ b/src/cli/lol/completion.sh
@@ -10,6 +10,7 @@ _lol_complete() {
     case "$topic" in
         commands)
             echo "upgrade"
+            echo "use-branch"
             echo "version"
             echo "project"
             echo "usage"
@@ -17,6 +18,9 @@ _lol_complete() {
             echo "claude-clean"
             echo "plan"
             echo "impl"
+            ;;
+        upgrade-flags)
+            echo "--keep-branch"
             ;;
         project-modes)
             echo "--create"

--- a/src/cli/lol/dispatch.md
+++ b/src/cli/lol/dispatch.md
@@ -6,7 +6,8 @@ Dispatch layer for the `lol` CLI, including help output and version logging.
 
 ### lol()
 
-Routes subcommands to their parsers and handles top-level flags.
+Routes subcommands (including `use-branch`) to their parsers and handles
+top-level flags.
 
 **Parameters**:
 - `$1`: Subcommand or flag (`upgrade`, `project`, `plan`, `usage`, `--version`, `--complete`, etc.).

--- a/src/cli/lol/dispatch.sh
+++ b/src/cli/lol/dispatch.sh
@@ -71,6 +71,9 @@ lol() {
         upgrade)
             _lol_parse_upgrade "$@"
             ;;
+        use-branch)
+            _lol_parse_use_branch "$@"
+            ;;
         project)
             _lol_parse_project "$@"
             ;;
@@ -98,7 +101,9 @@ lol() {
             echo "lol: AI-powered SDK CLI"
             echo ""
             echo "Usage:"
-            echo "  lol upgrade"
+            echo "  lol upgrade [--keep-branch]"
+            echo "  lol use-branch <remote>/<branch>"
+            echo "  lol use-branch <branch>"
             echo "  lol --version"
             echo "  lol project --create [--org <owner>] [--title <title>]"
             echo "  lol project --associate <owner>/<id>"
@@ -111,6 +116,7 @@ lol() {
             echo ""
             echo "Flags:"
             echo "  --version           Display version information"
+            echo "  --keep-branch       Keep current branch for upgrade (pulls upstream)"
             echo "  --create            Create new GitHub Projects v2 board (project)"
             echo "  --associate <owner>/<id>  Associate existing project board (project)"
             echo "  --automation        Generate automation workflow template (project)"
@@ -135,6 +141,8 @@ lol() {
             echo ""
             echo "Examples:"
             echo "  lol upgrade                     # Upgrade agentize installation"
+            echo "  lol upgrade --keep-branch       # Upgrade without switching branches"
+            echo "  lol use-branch dev/feature      # Switch to a remote development branch"
             echo "  lol --version                   # Display version information"
             echo "  lol project --create --org my-org --title \"My Project\""
             echo "  lol project --associate my-org/3"

--- a/src/cli/lol/parsers.md
+++ b/src/cli/lol/parsers.md
@@ -10,7 +10,11 @@ None. Parsers are private and invoked by `lol()`.
 ## Internal Helpers
 
 ### _lol_parse_upgrade()
-Validates that no extra arguments are provided, then calls `_lol_cmd_upgrade`.
+Accepts optional `--keep-branch` and passes the flag to `_lol_cmd_upgrade`.
+
+### _lol_parse_use_branch()
+Parses `<remote>/<branch>` or `<branch>` (defaulting the remote to `origin`) and
+calls `_lol_cmd_use_branch`.
 
 ### _lol_parse_project()
 Parses `--create`, `--associate`, and `--automation` modes plus optional flags,

--- a/src/completion/_lol
+++ b/src/completion/_lol
@@ -2,7 +2,7 @@
 
 # Zsh completion for lol (AI-powered SDK CLI)
 # Provides interactive command-line hints for lol subcommands and flags
-# Supports: upgrade, version, project, usage, serve, claude-clean, plan, impl
+# Supports: upgrade, use-branch, version, project, usage, serve, claude-clean, plan, impl
 
 _lol() {
     local curcontext="$curcontext" state line
@@ -19,6 +19,7 @@ _lol() {
     if (( ${#commands} == 0 )); then
         commands=(
             'upgrade:Upgrade agentize installation'
+            'use-branch:Switch to a remote development branch'
             'version:Display version information'
             'project:Manage GitHub Projects v2 integration'
             'usage:Report Claude Code token usage statistics'
@@ -33,6 +34,7 @@ _lol() {
         for cmd in $commands; do
             case $cmd in
                 upgrade) commands_with_desc+=('upgrade:Upgrade agentize installation') ;;
+                use-branch) commands_with_desc+=('use-branch:Switch to a remote development branch') ;;
                 version) commands_with_desc+=('version:Display version information') ;;
                 project) commands_with_desc+=('project:Manage GitHub Projects v2 integration') ;;
                 usage) commands_with_desc+=('usage:Report Claude Code token usage statistics') ;;
@@ -66,6 +68,9 @@ _lol() {
                     ;;
                 upgrade)
                     _lol_upgrade
+                    ;;
+                use-branch)
+                    _lol_use_branch
                     ;;
                 project)
                     _lol_project
@@ -124,8 +129,27 @@ _lol_impl() {
 
 # Completion for 'lol upgrade' subcommand
 _lol_upgrade() {
-    # No flags or arguments for upgrade command
-    return 0
+    local -a upgrade_flags upgrade_flags_with_desc
+
+    # Try dynamic fetch first
+    if (( $+commands[lol] )); then
+        upgrade_flags=( ${(f)"$(lol --complete upgrade-flags 2>/dev/null)"} )
+    fi
+
+    # Fallback to static flags
+    if (( ${#upgrade_flags} == 0 )); then
+        upgrade_flags=( '--keep-branch' )
+    fi
+
+    for flag in $upgrade_flags; do
+        case $flag in
+            --keep-branch) upgrade_flags_with_desc+=( '--keep-branch[Keep current branch and pull its upstream]' ) ;;
+            *) upgrade_flags_with_desc+=( "$flag" ) ;;
+        esac
+    done
+
+    _arguments \
+        ${upgrade_flags_with_desc[@]}
 }
 
 # Completion for 'lol version' subcommand
@@ -210,6 +234,12 @@ _lol_claude_clean() {
 _lol_serve() {
     # No CLI flags - show message about YAML configuration
     _message "Configure server.period and server.num_workers in .agentize.local.yaml"
+}
+
+# Completion for 'lol use-branch' subcommand
+_lol_use_branch() {
+    _arguments \
+        ':remote/branch:'
 }
 
 _lol "$@"

--- a/src/completion/_lol.md
+++ b/src/completion/_lol.md
@@ -25,7 +25,9 @@ Each handler provides completion for a specific `lol` subcommand:
 - `_lol_project()` completes project modes and flags.
 - `_lol_usage()` completes usage-reporting flags.
 - `_lol_claude_clean()` completes cleanup flags.
-- `_lol_upgrade()`, `_lol_version()`, `_lol_serve()` are no-flag handlers.
+- `_lol_upgrade()` completes upgrade flags.
+- `_lol_use_branch()` completes the remote/branch argument.
+- `_lol_version()` and `_lol_serve()` are no-flag handlers.
 
 ## Internal Helpers
 

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -27,6 +27,8 @@ Tests for the `lol` (agentize) command:
 - `test-lol-help-text.sh` - Validates help text formatting and content
 - `test-lol-version.sh` - Tests version command output
 - `test-lol-claude-clean.sh` - Tests `lol claude-clean` command for cleaning stale entries
+- `test-lol-upgrade.sh` - Tests `lol upgrade` branch selection and setup workflow
+- `test-lol-use-branch.sh` - Tests `lol use-branch` remote branch switching
 - `test-lol-command-functions-loaded.sh` - Smoke test for `_lol_cmd_*` availability and absence of `lol_cmd_*`
 - `test-lol-project-*.sh` - Tests for `lol project` command
 - `test-agentize-cli-*-agentize-home.sh` - Tests for AGENTIZE_HOME validation

--- a/tests/cli/test-lol-command-functions-loaded.md
+++ b/tests/cli/test-lol-command-functions-loaded.md
@@ -1,0 +1,9 @@
+# test-lol-command-functions-loaded.sh
+
+Ensures private `_lol_cmd_*` functions are registered after sourcing `lol.sh` and
+public `lol_cmd_*` helpers remain unavailable.
+
+## Coverage
+
+- `_lol_cmd_use_branch` and other command handlers are defined.
+- Public `lol_cmd_*` aliases are not exported.

--- a/tests/cli/test-lol-command-functions-loaded.sh
+++ b/tests/cli/test-lol-command-functions-loaded.sh
@@ -13,6 +13,7 @@ source "$LOL_CLI"
 # List of expected command functions
 EXPECTED_FUNCTIONS=(
     "_lol_cmd_upgrade"
+    "_lol_cmd_use_branch"
     "_lol_cmd_version"
     "_lol_cmd_project"
     "_lol_cmd_serve"
@@ -34,6 +35,7 @@ done
 
 DISALLOWED_FUNCTIONS=(
     "lol_cmd_upgrade"
+    "lol_cmd_use_branch"
     "lol_cmd_version"
     "lol_cmd_project"
     "lol_cmd_serve"

--- a/tests/cli/test-lol-complete-commands.md
+++ b/tests/cli/test-lol-complete-commands.md
@@ -1,0 +1,9 @@
+# test-lol-complete-commands.sh
+
+Verifies `lol --complete commands` returns the documented subcommand list.
+
+## Coverage
+
+- Core command names appear in newline-delimited output.
+- `use-branch` is included in the completion list.
+- Removed commands are excluded.

--- a/tests/cli/test-lol-complete-commands.sh
+++ b/tests/cli/test-lol-complete-commands.sh
@@ -16,6 +16,7 @@ output=$(lol --complete commands 2>/dev/null)
 # Verify documented commands are present
 # Check each command individually (shell-neutral approach)
 echo "$output" | grep -q "^upgrade$" || test_fail "Missing command: upgrade"
+echo "$output" | grep -q "^use-branch$" || test_fail "Missing command: use-branch"
 echo "$output" | grep -q "^version$" || test_fail "Missing command: version"
 echo "$output" | grep -q "^project$" || test_fail "Missing command: project"
 echo "$output" | grep -q "^usage$" || test_fail "Missing command: usage"

--- a/tests/cli/test-lol-complete-flags.md
+++ b/tests/cli/test-lol-complete-flags.md
@@ -1,0 +1,9 @@
+# test-lol-complete-flags.sh
+
+Validates `lol --complete <topic>` returns the expected flag sets.
+
+## Coverage
+
+- Existing flag topics return the documented flags.
+- `upgrade-flags` includes `--keep-branch`.
+- Unknown or removed topics return empty output.

--- a/tests/cli/test-lol-complete-flags.sh
+++ b/tests/cli/test-lol-complete-flags.sh
@@ -56,6 +56,11 @@ echo "$impl_output" | grep -q "^--backend$" || test_fail "impl-flags missing: --
 echo "$impl_output" | grep -q "^--max-iterations$" || test_fail "impl-flags missing: --max-iterations"
 echo "$impl_output" | grep -q "^--yolo$" || test_fail "impl-flags missing: --yolo"
 
+# Test upgrade-flags
+upgrade_output=$(lol --complete upgrade-flags 2>/dev/null)
+
+echo "$upgrade_output" | grep -q "^--keep-branch$" || test_fail "upgrade-flags missing: --keep-branch"
+
 # Test unknown topic returns empty
 unknown_output=$(lol --complete unknown-topic 2>/dev/null)
 if [ -n "$unknown_output" ]; then

--- a/tests/cli/test-lol-help-text.md
+++ b/tests/cli/test-lol-help-text.md
@@ -1,0 +1,9 @@
+# test-lol-help-text.sh
+
+Checks that `lol` help output includes the documented commands and flags.
+
+## Coverage
+
+- Usage text lists `lol use-branch` and `lol upgrade`.
+- `--keep-branch` appears in the help text.
+- `lol plan --help` exposes required planner flags.

--- a/tests/cli/test-lol-help-text.sh
+++ b/tests/cli/test-lol-help-text.sh
@@ -17,6 +17,9 @@ output=$(lol 2>&1 || true)
 # Verify usage text includes lol upgrade command
 echo "$output" | grep -q "lol upgrade" || test_fail "Usage text missing 'lol upgrade' command"
 
+# Verify usage text includes lol use-branch command
+echo "$output" | grep -q "lol use-branch" || test_fail "Usage text missing 'lol use-branch' command"
+
 # Verify usage text includes --version flag
 echo "$output" | grep -q "\-\-version" || test_fail "Usage text missing '--version' flag"
 
@@ -35,5 +38,8 @@ echo "$output" | grep -q "lol impl" || test_fail "Usage text missing 'lol impl' 
 # Verify lol plan --help includes --refine
 plan_help=$(lol plan --help 2>&1)
 echo "$plan_help" | grep -q "\-\-refine" || test_fail "lol plan --help missing '--refine' option"
+
+# Verify usage text includes --keep-branch flag
+echo "$output" | grep -q "\-\-keep-branch" || test_fail "Usage text missing '--keep-branch' flag"
 
 test_pass "lol usage text includes documented commands"

--- a/tests/cli/test-lol-upgrade.md
+++ b/tests/cli/test-lol-upgrade.md
@@ -1,0 +1,10 @@
+# test-lol-upgrade.sh
+
+Validates `lol upgrade` behavior for branch selection and setup workflow.
+
+## Coverage
+
+- Default behavior switches to the default branch before pulling updates.
+- `--keep-branch` keeps the current branch and pulls its upstream.
+- `make setup` runs after successful pulls and emits reload instructions.
+- Optional Claude plugin refresh is invoked when the CLI is available.

--- a/tests/cli/test-lol-upgrade.sh
+++ b/tests/cli/test-lol-upgrade.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
-# Test: lol upgrade runs make setup after successful git pull
+# Test: lol upgrade switches to default branch unless --keep-branch is set
 
 source "$(dirname "$0")/../common.sh"
 
 LOL_CLI="$PROJECT_ROOT/src/cli/lol.sh"
 
-test_info "lol upgrade runs make setup after successful git pull"
+test_info "lol upgrade switches to default branch unless --keep-branch is set"
 
 # Create temp directory for test environment
 TMP_DIR=$(make_temp_dir "test-lol-upgrade")
 trap 'cleanup_dir "$TMP_DIR"' EXIT
+
+# Create mock remote repo
+REMOTE_REPO="$TMP_DIR/remote.git"
+git init -q --bare "$REMOTE_REPO"
 
 # Create mock AGENTIZE_HOME with git repo
 MOCK_AGENTIZE_HOME="$TMP_DIR/agentize"
@@ -17,9 +21,6 @@ mkdir -p "$MOCK_AGENTIZE_HOME"
 git -C "$MOCK_AGENTIZE_HOME" init -q
 git -C "$MOCK_AGENTIZE_HOME" config user.email "test@test.com"
 git -C "$MOCK_AGENTIZE_HOME" config user.name "Test"
-touch "$MOCK_AGENTIZE_HOME/README.md"
-git -C "$MOCK_AGENTIZE_HOME" add .
-git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Initial commit"
 
 # Create a simple Makefile with setup target that creates a marker file
 cat > "$MOCK_AGENTIZE_HOME/Makefile" << 'MAKEFILE'
@@ -29,48 +30,101 @@ setup:
 	@echo "Setup completed"
 MAKEFILE
 
-# Commit Makefile to avoid dirty-tree guard
-git -C "$MOCK_AGENTIZE_HOME" add Makefile
-git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Add Makefile"
+# Initial commit
+cat > "$MOCK_AGENTIZE_HOME/README.md" << 'EOF_README'
+# Mock Repo
+EOF_README
+git -C "$MOCK_AGENTIZE_HOME" add .
+git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Initial commit"
 
-# Set origin to self (so git pull works)
-git -C "$MOCK_AGENTIZE_HOME" remote add origin "$MOCK_AGENTIZE_HOME"
-git -C "$MOCK_AGENTIZE_HOME" fetch -q origin 2>/dev/null || true
+# Set main branch and push to origin
+# Ensure origin remote exists for upgrade pulls
 
-# Create origin/main branch for pull to succeed
 git -C "$MOCK_AGENTIZE_HOME" branch -M main
-git -C "$MOCK_AGENTIZE_HOME" symbolic-ref refs/remotes/origin/HEAD refs/heads/main 2>/dev/null || true
+git -C "$MOCK_AGENTIZE_HOME" remote add origin "$REMOTE_REPO"
+git -C "$MOCK_AGENTIZE_HOME" push -q -u origin main
+
+# Create a feature branch on origin for --keep-branch testing
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q -b feature/test-branch
+cat > "$MOCK_AGENTIZE_HOME/feature.txt" << 'EOF_FEATURE'
+feature branch content
+EOF_FEATURE
+git -C "$MOCK_AGENTIZE_HOME" add feature.txt
+git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Add feature branch"
+git -C "$MOCK_AGENTIZE_HOME" push -q -u origin feature/test-branch
+
+# Return to main
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q main
+
+# Ensure origin/HEAD resolves to main for default branch detection
+
+git -C "$MOCK_AGENTIZE_HOME" fetch -q origin
+git -C "$MOCK_AGENTIZE_HOME" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
 
 # Set up environment
 export AGENTIZE_HOME="$MOCK_AGENTIZE_HOME"
 source "$LOL_CLI"
 
-# Test 1: Verify make setup is called after git pull
-test_info "Test 1: make setup is called after successful git pull"
+# Test 1: Verify default upgrade switches to main
 
-# Remove any existing marker
+test_info "Test 1: default upgrade switches to default branch"
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q feature/test-branch
 rm -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker"
 
-# Run upgrade
 output=$(lol upgrade 2>&1) || true
 
-# Check if make setup was called (marker file should exist)
 if [ ! -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker" ]; then
     echo "Output:"
     echo "$output"
     test_fail "make setup was not executed - marker file missing"
 fi
 
-# Test 2: Verify output mentions setup completion
-test_info "Test 2: output mentions upgrade success"
-
-if ! echo "$output" | grep -qi "upgrade\|success"; then
+current_branch=$(git -C "$MOCK_AGENTIZE_HOME" rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "main" ]; then
     echo "Output:"
     echo "$output"
-    test_fail "Output should mention successful upgrade"
+    test_fail "Expected to be on main after default upgrade, got '$current_branch'"
+fi
+
+if ! echo "$output" | grep -qi "default branch"; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Output should mention default branch switching"
+fi
+
+# Test 2: Verify --keep-branch preserves current branch
+
+test_info "Test 2: --keep-branch stays on current branch"
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q feature/test-branch
+rm -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker"
+
+output=$(lol upgrade --keep-branch 2>&1) || true
+
+if [ ! -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker" ]; then
+    echo "Output:"
+    echo "$output"
+    test_fail "make setup was not executed with --keep-branch"
+fi
+
+current_branch=$(git -C "$MOCK_AGENTIZE_HOME" rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "feature/test-branch" ]; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Expected to remain on feature/test-branch with --keep-branch"
+fi
+
+if ! echo "$output" | grep -qi "keep.*branch\|keeping"; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Output should mention keeping current branch"
 fi
 
 # Test 3: Verify shell reload instructions are displayed
+
 test_info "Test 3: shell reload instructions are displayed"
 
 if ! echo "$output" | grep -q "reload\|exec"; then
@@ -80,6 +134,7 @@ if ! echo "$output" | grep -q "reload\|exec"; then
 fi
 
 # Test 4: Verify claude plugin update is called when claude is available
+
 test_info "Test 4: claude plugin update is called when claude is available"
 
 # Create a mock claude binary that logs its arguments
@@ -100,6 +155,8 @@ export PATH="$MOCK_BIN_DIR:$PATH"
 rm -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker"
 rm -f "$CLAUDE_LOG"
 
+git -C "$MOCK_AGENTIZE_HOME" checkout -q main
+
 output=$(_lol_cmd_upgrade 2>&1) || true
 
 # Check that claude was called with plugin update arguments
@@ -116,6 +173,7 @@ if ! grep -q "plugin.*update\|plugin.*marketplace" "$CLAUDE_LOG"; then
 fi
 
 # Test 5: Verify upgrade succeeds when claude is NOT available
+
 test_info "Test 5: upgrade succeeds when claude is not available"
 
 # Remove mock claude from PATH
@@ -133,4 +191,4 @@ if [ ! -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker" ]; then
     test_fail "upgrade failed when claude is not available"
 fi
 
-test_pass "lol upgrade correctly runs make setup and optional plugin update"
+test_pass "lol upgrade handles branch switching and setup workflow"

--- a/tests/cli/test-lol-use-branch.md
+++ b/tests/cli/test-lol-use-branch.md
@@ -1,0 +1,11 @@
+# test-lol-use-branch.sh
+
+Validates `lol use-branch` argument handling and branch switching workflow.
+
+## Coverage
+
+- Missing-argument handling with usage guidance.
+- Dirty worktree guard prevents branch switching.
+- Shorthand `<branch>` defaults to the `origin` remote.
+- Remote branch checkout creates a local tracking branch and sets upstream.
+- `make setup` runs and emits reload instructions.

--- a/tests/cli/test-lol-use-branch.sh
+++ b/tests/cli/test-lol-use-branch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Test: lol use-branch switches to remote branch and runs setup
+
+source "$(dirname "$0")/../common.sh"
+
+LOL_CLI="$PROJECT_ROOT/src/cli/lol.sh"
+
+test_info "lol use-branch switches to remote branch and runs setup"
+
+# Create temp directory for test environment
+TMP_DIR=$(make_temp_dir "test-lol-use-branch")
+trap 'cleanup_dir "$TMP_DIR"' EXIT
+
+# Create mock remote repo
+REMOTE_REPO="$TMP_DIR/remote.git"
+git init -q --bare "$REMOTE_REPO"
+
+# Create mock AGENTIZE_HOME with git repo
+MOCK_AGENTIZE_HOME="$TMP_DIR/agentize"
+mkdir -p "$MOCK_AGENTIZE_HOME"
+git -C "$MOCK_AGENTIZE_HOME" init -q
+git -C "$MOCK_AGENTIZE_HOME" config user.email "test@test.com"
+git -C "$MOCK_AGENTIZE_HOME" config user.name "Test"
+
+# Create a simple Makefile with setup target that creates a marker file
+cat > "$MOCK_AGENTIZE_HOME/Makefile" << 'MAKEFILE'
+.PHONY: setup
+setup:
+	@touch setup-was-called.marker
+	@echo "Setup completed"
+MAKEFILE
+
+# Initial commit
+cat > "$MOCK_AGENTIZE_HOME/README.md" << 'EOF_README'
+# Mock Repo
+EOF_README
+git -C "$MOCK_AGENTIZE_HOME" add .
+git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Initial commit"
+
+# Set main branch and push to origin
+
+git -C "$MOCK_AGENTIZE_HOME" branch -M main
+git -C "$MOCK_AGENTIZE_HOME" remote add origin "$REMOTE_REPO"
+git -C "$MOCK_AGENTIZE_HOME" push -q -u origin main
+
+# Create a feature branch on origin
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q -b feature/test-branch
+cat > "$MOCK_AGENTIZE_HOME/feature.txt" << 'EOF_FEATURE'
+feature branch content
+EOF_FEATURE
+git -C "$MOCK_AGENTIZE_HOME" add feature.txt
+git -C "$MOCK_AGENTIZE_HOME" commit -q -m "Add feature branch"
+git -C "$MOCK_AGENTIZE_HOME" push -q -u origin feature/test-branch
+
+# Return to main and delete local feature branch to force tracking checkout
+
+git -C "$MOCK_AGENTIZE_HOME" checkout -q main
+git -C "$MOCK_AGENTIZE_HOME" branch -D feature/test-branch
+
+# Set up environment
+export AGENTIZE_HOME="$MOCK_AGENTIZE_HOME"
+source "$LOL_CLI"
+
+# Test 1: Missing argument prints usage
+
+test_info "Test 1: missing argument prints usage"
+
+output=$(lol use-branch 2>&1 || true)
+if ! echo "$output" | grep -q "Usage: lol use-branch"; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Expected usage guidance when missing branch"
+fi
+
+# Test 2: Dirty worktree guard
+
+test_info "Test 2: dirty worktree guard"
+
+echo "dirty" > "$MOCK_AGENTIZE_HOME/dirty.txt"
+output=$(lol use-branch feature/test-branch 2>&1 || true)
+if ! echo "$output" | grep -qi "uncommitted changes"; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Expected dirty worktree guard message"
+fi
+
+git -C "$MOCK_AGENTIZE_HOME" reset -q --hard
+git -C "$MOCK_AGENTIZE_HOME" clean -q -fd
+
+# Test 3: Switch to remote branch using shorthand
+
+test_info "Test 3: switch to remote branch using shorthand"
+
+rm -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker"
+output=$(lol use-branch feature/test-branch 2>&1) || true
+
+if [ ! -f "$MOCK_AGENTIZE_HOME/setup-was-called.marker" ]; then
+    echo "Output:"
+    echo "$output"
+    test_fail "make setup was not executed"
+fi
+
+current_branch=$(git -C "$MOCK_AGENTIZE_HOME" rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "feature/test-branch" ]; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Expected to be on feature/test-branch, got '$current_branch'"
+fi
+
+upstream=$(git -C "$MOCK_AGENTIZE_HOME" rev-parse --abbrev-ref --symbolic-full-name "@{u}")
+if [ "$upstream" != "origin/feature/test-branch" ]; then
+    echo "Upstream: $upstream"
+    test_fail "Expected upstream to be origin/feature/test-branch"
+fi
+
+if ! echo "$output" | grep -q "reload\|exec"; then
+    echo "Output:"
+    echo "$output"
+    test_fail "Output should include shell reload instructions"
+fi
+
+test_pass "lol use-branch switches to remote branch and runs setup"

--- a/tests/test-all.md
+++ b/tests/test-all.md
@@ -1,0 +1,10 @@
+# test-all.sh
+
+Master test runner for Agentize. Auto-discovers `test-*.sh` scripts in the
+`tests/` subdirectories and executes them under the configured shells.
+
+## Coverage
+
+- Runs category suites (sdk, cli, lint, e2e) with optional filtering.
+- Enforces strict shell availability when `TEST_SHELLS` is explicitly set.
+- Skips bash-only hook tests when running in zsh.

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -131,6 +131,7 @@ for shell in $TEST_SHELLS; do
     FAILED_TESTS=0
 
     # Auto-discover and run tests in categorical subdirectories
+    # Notable CLI additions: test-lol-use-branch.sh, test-lol-upgrade.sh
     for category in $CATEGORIES; do
         category_dir="$SCRIPT_DIR/$category"
 


### PR DESCRIPTION
Add lol use-branch and clarify upgrade branch switching

## Summary
- add lol use-branch command with setup and reload workflow
- make lol upgrade switch to the default branch by default with --keep-branch opt-out
- update completions, docs, and tests for the new command and flag

## Testing
- TEST_SHELLS="bash zsh" make test-fast

Issue 732 resolved
closes #732
Closes #732