### PR TITLE
acw: capture provider stderr to sidecar in file mode

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -64,6 +64,7 @@ acw --help
 ```bash
 # Invoke Claude with a prompt file
 acw claude claude-sonnet-4-20250514 prompt.txt response.txt
+# Provider stderr is written to response.txt.stderr in file mode
 
 # Invoke Codex
 acw codex gpt-4o prompt.txt response.txt
@@ -172,6 +173,7 @@ autoload -Uz compinit && compinit
 - Only `acw` is the public function; all helper functions (provider invocation, completion, validation) are internal (prefixed with `_acw_`) and won't appear in tab completion
 - `acw` flags must appear before `cli-name`. Use `--` to pass provider options that collide with `acw` flags.
 - `--stdout` merges provider stderr into stdout so progress and output can be piped together.
+- In file mode (no `--stdout`), provider stderr is written to `<output-file>.stderr`. Empty sidecar files are removed after the provider exits.
 
 ## See Also
 

--- a/src/cli/acw.md
+++ b/src/cli/acw.md
@@ -36,6 +36,7 @@ Validates arguments, dispatches to provider function, returns provider exit code
 **Flag behavior:**
 - `--editor` uses `$EDITOR` to create the input content (mutually exclusive with `input-file`)
 - `--stdout` writes output to stdout and merges provider stderr into stdout (mutually exclusive with `output-file`)
+- In file mode, provider stderr is written to `<output-file>.stderr` to keep terminal output quiet.
 - `acw` flags must appear before `cli-name`; use `--` to pass provider options that collide with `acw` flags
 
 This is the **only public function** exported by `acw.sh`. All other functions are internal (prefixed with `_acw_`).

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -28,6 +28,8 @@ acw --chat-list
   exit with status 0 and the file must contain non-whitespace content.
 - `--stdout`: Routes output to `/dev/stdout` and merges provider stderr into
   stdout for the invocation.
+- File mode (no `--stdout`) redirects provider stderr to `<output-file>.stderr`
+  and removes the sidecar file when stderr is empty.
 - `--complete <topic>`: Prints completion values for the given topic.
 - `--help`: Prints usage text.
 

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -355,6 +355,11 @@ acw() {
 
     # Remaining arguments are provider options
     local provider_exit=0
+    local stderr_file=""
+
+    if [ "$stdout_mode" -eq 0 ]; then
+        stderr_file="${output_file}.stderr"
+    fi
 
     # Dispatch to provider function
     case "$cli_name" in
@@ -362,7 +367,11 @@ acw() {
             if [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 0 ]; then
                 _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@" 2>&1
             else
-                _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@"
+                if [ -n "$stderr_file" ]; then
+                    _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
+                else
+                    _acw_invoke_claude "$model_name" "$input_file" "$output_file" "$@"
+                fi
             fi
             provider_exit=$?
             ;;
@@ -370,7 +379,11 @@ acw() {
             if [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 0 ]; then
                 _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@" 2>&1
             else
-                _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@"
+                if [ -n "$stderr_file" ]; then
+                    _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
+                else
+                    _acw_invoke_codex "$model_name" "$input_file" "$output_file" "$@"
+                fi
             fi
             provider_exit=$?
             ;;
@@ -378,7 +391,11 @@ acw() {
             if [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 0 ]; then
                 _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@" 2>&1
             else
-                _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@"
+                if [ -n "$stderr_file" ]; then
+                    _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
+                else
+                    _acw_invoke_opencode "$model_name" "$input_file" "$output_file" "$@"
+                fi
             fi
             provider_exit=$?
             ;;
@@ -386,11 +403,19 @@ acw() {
             if [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 0 ]; then
                 _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@" 2>&1
             else
-                _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@"
+                if [ -n "$stderr_file" ]; then
+                    _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
+                else
+                    _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@"
+                fi
             fi
             provider_exit=$?
             ;;
     esac
+
+    if [ -n "$stderr_file" ] && [ -f "$stderr_file" ] && [ ! -s "$stderr_file" ]; then
+        rm -f "$stderr_file"
+    fi
 
     # Chat mode cleanup and append turn
     if [ "$chat_mode" -eq 1 ]; then

--- a/tests/cli/test-acw-flags.md
+++ b/tests/cli/test-acw-flags.md
@@ -1,0 +1,35 @@
+# test-acw-flags.sh
+
+## Purpose
+
+Validate `acw` flag behavior for `--editor`, `--stdout`, and file-mode stderr capture.
+
+## Test Cases
+
+### editor_unset
+**Purpose**: `--editor` fails when `EDITOR` is unset.
+**Expected**: Non-zero exit with message mentioning `EDITOR`.
+
+### editor_empty_content
+**Purpose**: `--editor` rejects whitespace-only content.
+**Expected**: Non-zero exit mentioning empty content.
+
+### editor_success
+**Purpose**: `--editor` uses editor content as input.
+**Expected**: Output file contains editor content.
+
+### stdout_merges_stderr
+**Purpose**: `--stdout` merges provider stderr into stdout.
+**Expected**: Captured output includes prompt content and `stub-stderr`.
+
+### file_mode_stderr_sidecar
+**Purpose**: File mode captures provider stderr in `<output-file>.stderr`.
+**Expected**: Sidecar file contains `stub-stderr`, terminal stderr is quiet.
+
+### file_mode_empty_stderr_cleanup
+**Purpose**: Empty stderr does not leave a sidecar file.
+**Expected**: `<output-file>.stderr` is removed when provider writes no stderr.
+
+### stdout_output_file_rejected
+**Purpose**: `--stdout` rejects an output-file positional argument.
+**Expected**: Non-zero exit mentioning stdout.


### PR DESCRIPTION
acw: capture provider stderr to sidecar in file mode

## Summary
- Redirect provider stderr to `<output-file>.stderr` in file mode and remove empty sidecars.
- Document file-mode sidecar behavior in user and interface docs.
- Add tests for sidecar capture and empty-stderr cleanup.

Issue 741 resolved.

## Testing
- TEST_SHELLS="bash zsh" make test-fast

closes #741
Closes #741