### PR TITLE
fix(wt): use --json flag in spawn issue validation to avoid Projects Classic deprecation error

### DIFF
--- a/src/cli/wt/commands.sh
+++ b/src/cli/wt/commands.sh
@@ -200,7 +200,7 @@ cmd_spawn() {
 
     # Check if gh is available and validate issue exists
     if command -v gh >/dev/null 2>&1; then
-        if ! gh issue view "$issue_no" >/dev/null 2>&1; then
+        if ! gh issue view "$issue_no" --json number >/dev/null 2>&1; then
             echo "Error: Issue #$issue_no not found" >&2
             return 1
         fi


### PR DESCRIPTION
## Summary

- Fix `wt spawn` failing to validate issue numbers due to GitHub Projects Classic deprecation warning in `gh issue view` output
- Use `gh issue view --json number` for structured output that bypasses the deprecated rendering path

Fixes #765

## Test plan

- [ ] Run `wt spawn <valid-issue-number>` and verify it correctly validates the issue
- [ ] Run `wt spawn <invalid-issue-number>` and verify it reports the issue as not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)