### PR TITLE
Unify CLI version banner format

### DIFF
--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -45,7 +45,16 @@ acw --chat-list
 ## Internal Helpers
 
 ### _acw_usage()
-Prints usage text, options, providers, and examples.
+Prints usage text, options, providers, and examples. Emits the version banner
+to stderr via `_acw_log_version()` so help output always includes the current
+agentize version context.
+
+### _acw_log_version()
+
+Writes the version banner to stderr in the format
+`[agentize] <branch> @<short-hash>`. The branch and short hash are resolved from
+`AGENTIZE_HOME` (or the current directory when unset) and fall back to `unknown`
+when git metadata is unavailable.
 
 ### _acw_validate_no_positional_args()
 Ensures editor/stdout modes do not accept extra positional arguments. Allows

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -2,8 +2,23 @@
 # acw CLI main dispatcher
 # Entry point and help text
 
+# Log version information to stderr
+_acw_log_version() {
+    local git_dir="${AGENTIZE_HOME:-.}"
+    local branch="unknown"
+    local hash="unknown"
+
+    if command -v git >/dev/null 2>&1; then
+        branch=$(git -C "$git_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        hash=$(git -C "$git_dir" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+    fi
+
+    echo "[agentize] $branch @$hash" >&2
+}
+
 # Print usage information
 _acw_usage() {
+    _acw_log_version
     cat <<'EOF'
 acw: Agent CLI Wrapper
 

--- a/src/cli/lol/dispatch.md
+++ b/src/cli/lol/dispatch.md
@@ -22,6 +22,8 @@ top-level flags.
 
 ### _lol_log_version()
 
-Writes a stable version banner to stderr using the git tag (or short hash) and
-full commit hash from `AGENTIZE_HOME`. This keeps diagnostics consistent across
-commands and avoids polluting completion output.
+Writes a stable version banner to stderr in the format
+`[agentize] <branch> @<short-hash>`. The branch and short hash are resolved from
+`AGENTIZE_HOME` (or the current directory when unset) and fall back to
+`unknown` when git metadata is unavailable. This keeps diagnostics consistent
+across commands and avoids polluting completion output.

--- a/src/cli/lol/dispatch.sh
+++ b/src/cli/lol/dispatch.sh
@@ -4,20 +4,16 @@
 
 # Log version information to stderr
 _lol_log_version() {
-    # Get version from git describe or short commit hash (from AGENTIZE_HOME)
-    local version="unknown"
-    if [ -n "$AGENTIZE_HOME" ] && command -v git >/dev/null 2>&1; then
-        # Try to get tag, fall back to short commit hash
-        version=$(git -C "$AGENTIZE_HOME" describe --tags --always 2>/dev/null || echo "unknown")
+    local git_dir="${AGENTIZE_HOME:-.}"
+    local branch="unknown"
+    local hash="unknown"
+
+    if command -v git >/dev/null 2>&1; then
+        branch=$(git -C "$git_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        hash=$(git -C "$git_dir" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
     fi
 
-    # Get full commit hash (from AGENTIZE_HOME)
-    local commit="unknown"
-    if [ -n "$AGENTIZE_HOME" ] && command -v git >/dev/null 2>&1; then
-        commit=$(git -C "$AGENTIZE_HOME" rev-parse HEAD 2>/dev/null || echo "unknown")
-    fi
-
-    echo "[agentize] $version @ $commit" >&2
+    echo "[agentize] $branch @$hash" >&2
 }
 
 # Main lol function

--- a/src/cli/wt/dispatch.md
+++ b/src/cli/wt/dispatch.md
@@ -1,0 +1,27 @@
+# dispatch.sh
+
+Dispatch layer for the `wt` CLI, including command routing and version logging.
+
+## External Interface
+
+### wt()
+
+Routes subcommands to their handlers and manages help/error output.
+
+**Parameters**:
+- `$1`: Subcommand or flag (`clone`, `init`, `help`, `--complete`, etc.).
+- `$@`: Remaining arguments passed to the handler.
+
+**Behavior**:
+- Logs the version banner for help and unknown commands via `_wt_log_version`.
+- Keeps completion output clean by skipping logging for `--complete`.
+- Delegates to `cmd_*` handlers for command execution.
+
+## Internal Helpers
+
+### _wt_log_version()
+
+Writes the version banner to stderr in the format
+`[agentize] <branch> @<short-hash>`. The branch and short hash are resolved from
+the current git worktree root and fall back to `unknown` when git metadata is
+unavailable. Accepts the current command to suppress output during `--complete`.

--- a/src/cli/wt/dispatch.sh
+++ b/src/cli/wt/dispatch.sh
@@ -9,25 +9,17 @@ _wt_log_version() {
         return 0
     fi
 
-    # Get version from git describe or short commit hash
-    local version="unknown"
+    local git_dir="."
+    local branch="unknown"
+    local hash="unknown"
+
     if command -v git >/dev/null 2>&1; then
-        # Try to get tag, fall back to short commit hash
-        version=$(git describe --tags --always 2>/dev/null || echo "unknown")
+        git_dir=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+        branch=$(git -C "$git_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        hash=$(git -C "$git_dir" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
     fi
 
-    # Get full commit hash
-    local commit="unknown"
-    if command -v git >/dev/null 2>&1; then
-        commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-    fi
-
-    # If AGENTIZE_HOME is not set, log as "standalone"
-    if [ -z "$AGENTIZE_HOME" ]; then
-        version="$version-standalone"
-    fi
-
-    echo "[agentize] $version @ $commit" >&2
+    echo "[agentize] $branch @$hash" >&2
 }
 
 # Main wt function

--- a/tests/cli/test-acw-logging.sh
+++ b/tests/cli/test-acw-logging.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Test: acw CLI version logging in help output
+
+source "$(dirname "$0")/../common.sh"
+
+ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
+
+test_info "acw CLI version logging in help output"
+
+export AGENTIZE_HOME="$PROJECT_ROOT"
+source "$ACW_CLI"
+
+# Test 0: Verify logging appears on --help
+test_info "Test 0: Verify logging appears on --help"
+output=$(acw --help 2>&1)
+echo "$output" | grep -q "^\[agentize\]" || test_fail "Logging output missing from help"
+test_info "  ✓ Logging appears on --help"
+
+# Test 1: Verify logging format includes branch name and short hash
+test_info "Test 1: Verify logging format includes branch name and short hash"
+banner=$(echo "$output" | grep "^\[agentize\]" | head -n 1)
+if [ -z "$banner" ]; then
+  test_fail "Version banner missing"
+fi
+if ! echo "$banner" | grep -qE '^\[agentize\] [^ ]+ @[a-f0-9]{7}$'; then
+  test_fail "Version banner format incorrect: $banner"
+fi
+test_info "  ✓ Version banner format correct"
+
+test_pass "acw CLI version logging verified successfully"

--- a/tests/cli/test-lol-logging.sh
+++ b/tests/cli/test-lol-logging.sh
@@ -19,39 +19,22 @@ test_info "  ✓ Version logging moved from startup to conditional handlers"
 test_info "Test 1: Verify logging appears in stderr on --version command"
 output=$(lol --version 2>&1 >/dev/null)
 echo "$output" | grep -q "^\[agentize\]" || test_fail "Logging output missing from stderr"
-echo "$output" | grep -q "@" || test_fail "Logging format incorrect - missing commit hash separator"
 test_info "  ✓ Logging appears on --version"
 
-# Test 2: Verify logging includes version tag or commit hash
-test_info "Test 2: Verify logging includes version tag or commit hash"
+# Test 2: Verify logging format includes branch name and short hash
+test_info "Test 2: Verify logging format includes branch name and short hash"
 output=$(lol --version 2>&1 >/dev/null)
-# Extract the part between [agentize] and @
-version_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/\[agentize\] //;s/ @.*//')
-if [ -z "$version_part" ]; then
-  test_fail "Version part is empty"
+banner=$(echo "$output" | grep "^\[agentize\]" | head -n 1)
+if [ -z "$banner" ]; then
+  test_fail "Version banner missing"
 fi
-# Should match either a tag (e.g., v1.0.8) or a commit hash (7+ hex chars)
-if ! echo "$version_part" | grep -qE '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,40})$'; then
-  test_fail "Version part format incorrect: $version_part"
+if ! echo "$banner" | grep -qE '^\[agentize\] [^ ]+ @[a-f0-9]{7}$'; then
+  test_fail "Version banner format incorrect: $banner"
 fi
-test_info "  ✓ Version format correct"
+test_info "  ✓ Version banner format correct"
 
-# Test 3: Verify logging format includes full commit hash
-test_info "Test 3: Verify logging format includes full commit hash"
-output=$(lol --version 2>&1 >/dev/null)
-# Extract the part after @ (commit hash)
-commit_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/.* @ //')
-if [ -z "$commit_part" ]; then
-  test_fail "Commit hash part is empty"
-fi
-# Should be at least 7 characters (short hash) or 40 (full hash)
-if ! echo "$commit_part" | grep -qE '^[a-f0-9]{7,40}$'; then
-  test_fail "Commit hash format incorrect: $commit_part"
-fi
-test_info "  ✓ Commit hash format correct"
-
-# Test 4: Verify no logging in --complete mode
-test_info "Test 4: Verify no logging in --complete mode"
+# Test 3: Verify no logging in --complete mode
+test_info "Test 3: Verify no logging in --complete mode"
 output=$(lol --complete commands 2>&1)
 if echo "$output" | grep -q "^\[agentize\]"; then
   test_fail "Logging should be suppressed in --complete mode"
@@ -60,8 +43,8 @@ fi
 echo "$output" | grep -q "upgrade" || test_fail "Completion data missing when logging suppressed"
 test_info "  ✓ No logging in --complete mode"
 
-# Test 5: Verify logging includes agentize branding
-test_info "Test 5: Verify logging includes agentize branding"
+# Test 4: Verify logging includes agentize branding
+test_info "Test 4: Verify logging includes agentize branding"
 output=$(lol --version 2>&1 >/dev/null)
 echo "$output" | grep -q "^\[agentize\]" || test_fail "Missing agentize branding in logging"
 test_info "  ✓ Agentize branding present"

--- a/tests/cli/test-wt-logging.sh
+++ b/tests/cli/test-wt-logging.sh
@@ -20,39 +20,22 @@ test_info "  ✓ Logging appears on invalid command"
 test_info "Test 1: Verify logging appears in stderr on help command"
 output=$(wt help 2>&1 >/dev/null)
 echo "$output" | grep -q "^\[agentize\]" || test_fail "Logging output missing from stderr"
-echo "$output" | grep -q "@" || test_fail "Logging format incorrect - missing commit hash separator"
 test_info "  ✓ Logging appears on help"
 
-# Test 2: Verify logging includes version tag or commit hash
-test_info "Test 2: Verify logging includes version tag or commit hash"
+# Test 2: Verify logging format includes branch name and short hash
+test_info "Test 2: Verify logging format includes branch name and short hash"
 output=$(wt help 2>&1 >/dev/null)
-# Extract the part between [agentize] and @
-version_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/\[agentize\] //;s/ @.*//')
-if [ -z "$version_part" ]; then
-  test_fail "Version part is empty"
+banner=$(echo "$output" | grep "^\[agentize\]" | head -n 1)
+if [ -z "$banner" ]; then
+  test_fail "Version banner missing"
 fi
-# Should match either a tag (e.g., v1.0.8) or a commit hash (40 hex chars)
-if ! echo "$version_part" | grep -qE '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,40})$'; then
-  test_fail "Version part format incorrect: $version_part"
+if ! echo "$banner" | grep -qE '^\[agentize\] [^ ]+ @[a-f0-9]{7}$'; then
+  test_fail "Version banner format incorrect: $banner"
 fi
-test_info "  ✓ Version format correct"
+test_info "  ✓ Version banner format correct"
 
-# Test 3: Verify logging format includes full commit hash
-test_info "Test 3: Verify logging format includes full commit hash"
-output=$(wt help 2>&1 >/dev/null)
-# Extract the part after @ (commit hash)
-commit_part=$(echo "$output" | grep "^\[agentize\]" | sed 's/.* @ //')
-if [ -z "$commit_part" ]; then
-  test_fail "Commit hash part is empty"
-fi
-# Should be at least 7 characters (short hash) or 40 (full hash)
-if ! echo "$commit_part" | grep -qE '^[a-f0-9]{7,40}$'; then
-  test_fail "Commit hash format incorrect: $commit_part"
-fi
-test_info "  ✓ Commit hash format correct"
-
-# Test 4: Verify no logging in --complete mode
-test_info "Test 4: Verify no logging in --complete mode"
+# Test 3: Verify no logging in --complete mode
+test_info "Test 3: Verify no logging in --complete mode"
 output=$(wt --complete commands 2>&1)
 if echo "$output" | grep -q "^\[agentize\]"; then
   test_fail "Logging should be suppressed in --complete mode"
@@ -61,8 +44,8 @@ fi
 echo "$output" | grep -q "^clone$" || test_fail "Completion data missing when logging suppressed"
 test_info "  ✓ No logging in --complete mode"
 
-# Test 5: Verify logging includes agentize branding
-test_info "Test 5: Verify logging includes agentize branding"
+# Test 4: Verify logging includes agentize branding
+test_info "Test 4: Verify logging includes agentize branding"
 output=$(wt help 2>&1 >/dev/null)
 echo "$output" | grep -q "^\[agentize\]" || test_fail "Missing agentize branding in logging"
 test_info "  ✓ Agentize branding present"

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -131,8 +131,8 @@ for shell in $TEST_SHELLS; do
     FAILED_TESTS=0
 
     # Auto-discover and run tests in categorical subdirectories
-    # Notable CLI additions: test-lol-use-branch.sh, test-lol-upgrade.sh,
-    # test-lol-plan-github-stubbed.sh
+    # Notable CLI additions: test-acw-logging.sh, test-lol-use-branch.sh,
+    # test-lol-upgrade.sh, test-lol-plan-github-stubbed.sh
     for category in $CATEGORIES; do
         category_dir="$SCRIPT_DIR/$category"
 


### PR DESCRIPTION
Unify CLI version banner format

## Summary
- Standardize lol/wt/acw version banners to "[agentize] <branch> @<short-hash>" and add acw help logging.
- Update dispatch documentation for lol/wt/acw to describe the unified banner output.
- Refresh CLI logging tests and add acw banner coverage.

## Testing
- make test-fast TEST_SHELLS="bash zsh"

Issue 763 resolved
closes #763