### PR TITLE
Sync lol impl branch before iterations

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -220,6 +220,8 @@ The first line of the completion file is used as the PR title.
 
 #### Git workflow
 
+Before the iteration loop, `lol impl` syncs the issue branch by fetching and rebasing onto the default branch (`upstream/master` or `origin/main`). If a rebase conflict occurs, the command exits with an error and expects manual resolution before retrying.
+
 Each iteration stages and commits changes (skipping commits when there are no changes). A `.tmp/commit-report-iter-<N>.txt` file is required for each iteration and is used as the commit message for iteration `<N>`. On completion, the branch is pushed to `upstream` (or `origin`) and the PR targets `master` (or `main`).
 
 #### Example

--- a/src/cli/lol/commands/impl.md
+++ b/src/cli/lol/commands/impl.md
@@ -18,6 +18,7 @@ lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]
 
 **Behavior**:
 - Ensures a worktree exists for the issue, then switches into it.
+- Syncs the issue branch by fetching and rebasing onto the default branch before starting iterations.
 - Prefetches issue content via `gh issue view`; if it fails, the command exits with an error.
 - Iterates `acw` runs, requiring a per-iteration commit report file in `.tmp/commit-report-iter-<iter>.txt`.
 - Stages and commits changes each iteration when there are staged diffs.
@@ -30,6 +31,7 @@ lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]
 
 **Failure conditions**:
 - Invalid arguments (non-numeric issue or malformed backend).
+- Sync failures (missing remote/default branch, fetch failure, or rebase conflict).
 - Missing per-iteration commit report file.
 - Max-iteration limit reached without a completion marker.
 - Missing git remote or base branch for PR creation.

--- a/tests/cli/test-lol-impl-stubbed.md
+++ b/tests/cli/test-lol-impl-stubbed.md
@@ -6,7 +6,7 @@ Validate `lol impl` behavior with deterministic stubs for external tools.
 
 ## Stubs
 
-- `git`: Simulate repository interactions (add, diff, commit, remote, push)
+- `git`: Simulate repository interactions (add, diff, commit, remote, fetch, rebase, push)
 - `wt`: Return predictable worktree paths
 - `acw`: Return canned planner/impl outputs
 - `gh`: Return mocked issue data and PR creation responses
@@ -30,6 +30,11 @@ Stubs are defined in the test shell and used by sourced CLI code to keep behavio
 13. Base branch selection (master over main)
 14. Fallback to origin and main when upstream/master unavailable
 15. PR body closes-line deduplication and append behavior
+16. Sync fetch ordering before iterations
+17. Sync rebase uses upstream/master
+18. Sync rebase falls back to origin/main
+19. Sync fetch failure handling
+20. Sync rebase conflict handling
 
 ## Usage
 


### PR DESCRIPTION
Sync lol impl branch before iterations

## Summary
- sync issue branch with upstream via fetch/rebase before iterations using detected remote/default branch
- reuse detected remote/base for PR creation to avoid duplicate detection logic
- expand sync documentation and stubbed tests for ordering/failure cases

## Tests
- `make test-fast TEST_SHELLS="bash zsh"`

Issue 764 resolved
closes #764