### PR TITLE
Unify ACW runner across planner and impl with validation/logging

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -195,7 +195,7 @@ See [planner pipeline module](planner.md) for pipeline stage details and artifac
 
 ### lol impl
 
-Automate the issue-to-implementation loop using `wt` + `acw`.
+Automate the issue-to-implementation loop using `wt` + the shared ACW runner.
 
 ```bash
 lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]

--- a/docs/cli/planner.md
+++ b/docs/cli/planner.md
@@ -104,7 +104,7 @@ When stderr is a TTY, `lol plan` emits visual feedback during pipeline execution
 
 - **Colored "Feature:" label** — highlights the feature description at pipeline start.
 - **Animated stage dots** — expanding/contracting dot pattern (`.. ... .... ..... .... ...`) while each stage runs.
-- **Per-agent timing** — logs elapsed seconds after each stage completes (e.g., `agent understander (claude:sonnet) runs 12s`).
+- **ACW start/finish** — each stage logs `Agent <name> (<provider>:<model>) is running...` and `agent <name> (<provider>:<model>) runs <seconds>s` from the ACW runner.
 - **Issue link** — when issue publish succeeds, prints `See the full plan at: <url>`.
 
 ### Environment Toggles

--- a/python/agentize/workflow/README.md
+++ b/python/agentize/workflow/README.md
@@ -21,8 +21,9 @@ Artifacts (input prompts and outputs) are written to `.tmp/` with a configurable
 
 | Module | Purpose |
 |--------|---------|
-| `__init__.py` | Package exports: `run_acw`, `run_planner_pipeline`, `StageResult`, `PlannerTTY` |
-| `utils.py` | Reusable TTY and shell invocation utilities |
+| `__init__.py` | Package exports: `run_acw`, `list_acw_providers`, `ACW`, `run_planner_pipeline`, `StageResult`, `PlannerTTY` |
+| `utils.py` | Reusable TTY and shell invocation utilities, including ACW validation/logging |
+| `acw_cli.py` | Minimal CLI wrapper for running a single ACW execution from shell workflows |
 | `planner/` | Standalone planning pipeline package (`python -m agentize.workflow.planner`) |
 | `planner.py` | **DEPRECATED** - Re-exports for backward compatibility (will be removed) |
 

--- a/python/agentize/workflow/__init__.md
+++ b/python/agentize/workflow/__init__.md
@@ -38,6 +38,36 @@ Wrapper around the `acw` shell function that builds and executes an ACW command 
 
 **Raises:** `subprocess.TimeoutExpired` if execution exceeds timeout
 
+#### `list_acw_providers`
+
+```python
+def list_acw_providers() -> list[str]
+```
+
+Return the provider list from `acw --complete providers`, using the same script resolution as `run_acw`.
+
+#### `ACW`
+
+```python
+class ACW:
+    def __init__(
+        self,
+        name: str,
+        provider: str,
+        model: str,
+        timeout: int = 900,
+        *,
+        tools: str | None = None,
+        permission_mode: str | None = None,
+        extra_flags: list[str] | None = None,
+        log_writer: Callable[[str], None] | None = None,
+    ) -> None: ...
+
+    def run(self, input_file: str | Path, output_file: str | Path) -> subprocess.CompletedProcess: ...
+```
+
+Class-based ACW runner that validates providers and emits start/finish timing logs for each run.
+
 #### `PlannerTTY`
 
 ```python

--- a/python/agentize/workflow/__init__.py
+++ b/python/agentize/workflow/__init__.py
@@ -2,12 +2,21 @@
 
 Public interfaces for running the 5-stage planner pipeline:
 - run_acw: Wrapper around acw shell function
+- list_acw_providers: Provider completion helper
+- ACW: Class-based runner with validation and timing logs
 - run_planner_pipeline: Execute full pipeline with stage results
 - StageResult: Dataclass for per-stage results
 - PlannerTTY: Terminal output helper with animation support
 """
 
-from agentize.workflow.utils import run_acw, PlannerTTY
+from agentize.workflow.utils import run_acw, list_acw_providers, ACW, PlannerTTY
 from agentize.workflow.planner import run_planner_pipeline, StageResult
 
-__all__ = ["run_acw", "run_planner_pipeline", "StageResult", "PlannerTTY"]
+__all__ = [
+    "run_acw",
+    "list_acw_providers",
+    "ACW",
+    "run_planner_pipeline",
+    "StageResult",
+    "PlannerTTY",
+]

--- a/python/agentize/workflow/acw_cli.md
+++ b/python/agentize/workflow/acw_cli.md
@@ -1,0 +1,48 @@
+# Module: agentize.workflow.acw_cli
+
+CLI wrapper for running a single ACW execution from shell workflows.
+
+## External Interface
+
+### Command
+
+```bash
+python -m agentize.workflow.acw_cli \
+  --name <label> \
+  --provider <provider> \
+  --model <model> \
+  --input <input-file> \
+  --output <output-file> \
+  [--timeout <seconds>] \
+  [--tools <tool-spec>] \
+  [--permission-mode <mode>] \
+  [--yolo]
+```
+
+**Parameters:**
+- `--name`: Label used in ACW start/finish logs.
+- `--provider`: Provider name validated via `acw --complete providers`.
+- `--model`: Provider-specific model identifier.
+- `--input`: Path to the prompt file.
+- `--output`: Path to write the response.
+- `--timeout`: Execution timeout in seconds (default: 900).
+- `--tools`: Tool configuration (Claude provider only).
+- `--permission-mode`: Permission mode override (Claude provider only).
+- `--yolo`: Pass `--yolo` through to the provider CLI.
+
+**Behavior:**
+- Validates the provider using the shared ACW provider list.
+- Emits start/finish timing logs.
+- Invokes `run_acw` with the supplied arguments.
+
+**Exit codes:**
+- `0`: Completed successfully.
+- `1`: Invalid arguments or runtime errors.
+
+## Internal Helpers
+
+### _parse_args()
+Builds the CLI argument parser and returns parsed arguments.
+
+### _build_acw()
+Constructs an `ACW` instance using parsed arguments and applies optional flags.

--- a/python/agentize/workflow/acw_cli.py
+++ b/python/agentize/workflow/acw_cli.py
@@ -1,0 +1,62 @@
+"""CLI wrapper for running a single ACW execution."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentize.workflow.utils import ACW
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a single ACW execution")
+    parser.add_argument("--name", required=True, help="Label for ACW logs")
+    parser.add_argument("--provider", required=True, help="Provider name")
+    parser.add_argument("--model", required=True, help="Model identifier")
+    parser.add_argument("--input", required=True, help="Path to input prompt file")
+    parser.add_argument("--output", required=True, help="Path to output file")
+    parser.add_argument("--timeout", type=int, default=900, help="Timeout in seconds")
+    parser.add_argument("--tools", default=None, help="Tool configuration (Claude only)")
+    parser.add_argument(
+        "--permission-mode",
+        default=None,
+        help="Permission mode override (Claude only)",
+    )
+    parser.add_argument(
+        "--yolo",
+        action="store_true",
+        help="Pass --yolo through to provider CLI",
+    )
+    return parser.parse_args(argv)
+
+
+def _build_acw(args: argparse.Namespace) -> ACW:
+    extra_flags: list[str] = []
+    if args.yolo:
+        extra_flags.append("--yolo")
+
+    return ACW(
+        name=args.name,
+        provider=args.provider,
+        model=args.model,
+        timeout=args.timeout,
+        tools=args.tools,
+        permission_mode=args.permission_mode,
+        extra_flags=extra_flags or None,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    try:
+        runner = _build_acw(args)
+        result = runner.run(args.input, args.output)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/agentize/workflow/planner/__main__.md
+++ b/python/agentize/workflow/planner/__main__.md
@@ -1,0 +1,89 @@
+# Module: agentize.workflow.planner.__main__
+
+Pipeline orchestration and CLI entry point for the 5-stage planner workflow.
+
+## External Interface
+
+### CLI
+
+```bash
+python -m agentize.workflow.planner \
+  --feature-desc "Add dark mode toggle" \
+  --issue-mode true \
+  --verbose false \
+  --refine-issue-number ""
+```
+
+**Parameters:**
+- `--feature-desc`: Feature description or refine focus.
+- `--issue-mode`: `true` or `false` to enable GitHub issue publish flow.
+- `--verbose`: `true` or `false` to enable stage progress logs.
+- `--refine-issue-number`: Issue number to refine (optional).
+
+**Exit codes:**
+- `0`: Success.
+- `1`: Issue publish failure or missing prerequisites.
+- `2`: Invalid argument combination or missing required inputs.
+
+### `StageResult`
+
+```python
+@dataclass
+class StageResult:
+    stage: str
+    input_path: Path
+    output_path: Path
+    process: subprocess.CompletedProcess
+```
+
+Holds per-stage execution metadata and the completed process handle.
+
+### `run_planner_pipeline`
+
+```python
+def run_planner_pipeline(
+    feature_desc: str,
+    *,
+    output_dir: str | Path = ".tmp",
+    backends: dict[str, tuple[str, str]] | None = None,
+    parallel: bool = True,
+    runner: Callable[..., subprocess.CompletedProcess] = run_acw,
+    prefix: str | None = None,
+    output_suffix: str = "-output.md",
+    skip_consensus: bool = False,
+    progress: Optional[PlannerTTY] = None,
+) -> dict[str, StageResult]:
+```
+
+Executes the understander → bold → critique → reducer → consensus pipeline and returns
+per-stage results. When `runner` is `run_acw`, the pipeline wraps each stage with the
+`ACW` runner for provider validation and timing logs.
+
+## Internal Helpers
+
+### Prompt rendering
+- `_strip_yaml_frontmatter()`: Remove YAML frontmatter from prompt templates.
+- `_read_prompt_file()`: Load prompt templates from disk.
+- `_render_stage_prompt()`: Compose stage prompt with feature description and prior output.
+- `_render_consensus_prompt()`: Compose final consensus prompt from prior stage outputs.
+
+### Backend resolution
+- `_resolve_repo_root()`: Determine repository root for config lookup.
+- `_load_planner_backend_config()`: Load backend overrides from YAML config.
+- `_validate_backend_spec()`: Validate provider:model strings.
+- `_split_backend_spec()`: Parse provider/model from backend spec.
+- `_resolve_stage_backends()`: Merge overrides with defaults.
+
+### Issue workflow
+- `_gh_available()`: Check for GitHub CLI availability.
+- `_issue_create()`: Create issue scaffolding for plan output.
+- `_issue_fetch()`: Load issue content for refinement.
+- `_issue_publish()`: Update issue with plan output.
+- `_extract_plan_title()`: Extract plan title from consensus output.
+- `_apply_issue_tag()`: Prefix plan title with issue label.
+
+### Consensus-only runner
+- `_run_consensus_stage()`: Execute just the consensus stage for refinement flows.
+
+### Entry point
+- `main()`: CLI entry point that wires argument parsing, config resolution, and pipeline execution.

--- a/python/agentize/workflow/planner/__main__.py
+++ b/python/agentize/workflow/planner/__main__.py
@@ -13,7 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
-import time
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from agentize.shell import get_agentize_home
-from agentize.workflow.utils import PlannerTTY, run_acw
+from agentize.workflow.utils import PlannerTTY, run_acw, ACW
 
 
 @dataclass
@@ -73,6 +73,15 @@ STAGE_TOOLS = {
 # Permission mode per stage (Claude provider only)
 STAGE_PERMISSION_MODE = {
     "bold": "plan",
+}
+
+# Log label per stage (for ACW start/finish lines)
+STAGE_LOG_NAMES = {
+    "understander": "understander",
+    "bold": "bold-proposer",
+    "critique": "critique",
+    "reducer": "reducer",
+    "consensus": "consensus",
 }
 
 
@@ -241,6 +250,11 @@ def run_planner_pipeline(
         stage_backends.update(backends)
 
     results: dict[str, StageResult] = {}
+    log_lock = threading.Lock()
+
+    def _log_line(message: str) -> None:
+        with log_lock:
+            print(message, file=sys.stderr)
 
     def _backend_label(stage: str) -> str:
         provider, model = stage_backends[stage]
@@ -262,14 +276,26 @@ def run_planner_pipeline(
         provider, model = stage_backends[stage]
 
         # Run stage
-        process = runner(
-            provider,
-            model,
-            input_path,
-            output_file,
-            tools=STAGE_TOOLS.get(stage),
-            permission_mode=STAGE_PERMISSION_MODE.get(stage),
-        )
+        if runner is run_acw:
+            stage_label = STAGE_LOG_NAMES.get(stage, stage)
+            acw_runner = ACW(
+                name=stage_label,
+                provider=provider,
+                model=model,
+                tools=STAGE_TOOLS.get(stage),
+                permission_mode=STAGE_PERMISSION_MODE.get(stage),
+                log_writer=_log_line,
+            )
+            process = acw_runner.run(input_path, output_file)
+        else:
+            process = runner(
+                provider,
+                model,
+                input_path,
+                output_file,
+                tools=STAGE_TOOLS.get(stage),
+                permission_mode=STAGE_PERMISSION_MODE.get(stage),
+            )
 
         return StageResult(
             stage=stage,
@@ -291,7 +317,6 @@ def run_planner_pipeline(
     understander_prompt = _render_stage_prompt(
         "understander", feature_desc, agentize_home
     )
-    t_understander = progress.timer_start() if progress else None
     if progress:
         progress.anim_start(
             f"Stage 1/5: Running understander ({_backend_label('understander')})"
@@ -303,8 +328,7 @@ def run_planner_pipeline(
             progress.anim_stop()
     _check_stage_result(results["understander"])
     understander_output = results["understander"].output_path.read_text()
-    if progress and t_understander is not None:
-        progress.timer_log("understander", t_understander, _backend_label("understander"))
+    if progress:
         progress.log(f"  Understander complete: {results['understander'].output_path}")
         progress.log("")
 
@@ -312,7 +336,6 @@ def run_planner_pipeline(
     bold_prompt = _render_stage_prompt(
         "bold", feature_desc, agentize_home, understander_output
     )
-    t_bold = progress.timer_start() if progress else None
     if progress:
         progress.anim_start(f"Stage 2/5: Running bold-proposer ({_backend_label('bold')})")
     try:
@@ -322,8 +345,7 @@ def run_planner_pipeline(
             progress.anim_stop()
     _check_stage_result(results["bold"])
     bold_output = results["bold"].output_path.read_text()
-    if progress and t_bold is not None:
-        progress.timer_log("bold-proposer", t_bold, _backend_label("bold"))
+    if progress:
         progress.log(f"  Bold-proposer complete: {results['bold'].output_path}")
         progress.log("")
 
@@ -335,7 +357,6 @@ def run_planner_pipeline(
         "reducer", feature_desc, agentize_home, bold_output
     )
 
-    t_parallel = progress.timer_start() if progress else None
     if progress:
         progress.anim_start(
             "Stage 3-4/5: Running critique and reducer in parallel "
@@ -361,10 +382,8 @@ def run_planner_pipeline(
     _check_stage_result(results["reducer"])
     critique_output = results["critique"].output_path.read_text()
     reducer_output = results["reducer"].output_path.read_text()
-    if progress and t_parallel is not None:
-        progress.timer_log("critique", t_parallel, _backend_label("critique"))
+    if progress:
         progress.log(f"  Critique complete: {results['critique'].output_path}")
-        progress.timer_log("reducer", t_parallel, _backend_label("reducer"))
         progress.log(f"  Reducer complete: {results['reducer'].output_path}")
         progress.log("")
 
@@ -375,7 +394,6 @@ def run_planner_pipeline(
     consensus_prompt = _render_consensus_prompt(
         feature_desc, bold_output, critique_output, reducer_output, agentize_home
     )
-    t_consensus = progress.timer_start() if progress else None
     if progress:
         progress.anim_start(
             f"Stage 5/5: Running consensus ({_backend_label('consensus')})"
@@ -386,9 +404,6 @@ def run_planner_pipeline(
         if progress:
             progress.anim_stop()
     _check_stage_result(results["consensus"])
-    if progress and t_consensus is not None:
-        progress.timer_log("consensus", t_consensus, _backend_label("consensus"))
-
     return results
 
 
@@ -660,14 +675,24 @@ def _run_consensus_stage(
     input_path.write_text(consensus_prompt)
 
     provider, model = stage_backends["consensus"]
-    process = runner(
-        provider,
-        model,
-        input_path,
-        output_path,
-        tools=STAGE_TOOLS.get("consensus"),
-        permission_mode=STAGE_PERMISSION_MODE.get("consensus"),
-    )
+    if runner is run_acw:
+        acw_runner = ACW(
+            name=STAGE_LOG_NAMES.get("consensus", "consensus"),
+            provider=provider,
+            model=model,
+            tools=STAGE_TOOLS.get("consensus"),
+            permission_mode=STAGE_PERMISSION_MODE.get("consensus"),
+        )
+        process = acw_runner.run(input_path, output_path)
+    else:
+        process = runner(
+            provider,
+            model,
+            input_path,
+            output_path,
+            tools=STAGE_TOOLS.get("consensus"),
+            permission_mode=STAGE_PERMISSION_MODE.get("consensus"),
+        )
 
     return StageResult(
         stage="consensus",
@@ -767,7 +792,6 @@ def main(argv: list[str]) -> int:
         return 2
 
     consensus_backend = stage_backends["consensus"]
-    t_consensus = tty.timer_start()
     tty.anim_start(f"Stage 5/5: Running consensus ({consensus_backend[0]}:{consensus_backend[1]})")
     try:
         consensus_result = _run_consensus_stage(
@@ -804,8 +828,6 @@ def main(argv: list[str]) -> int:
     except ValueError:
         consensus_display = str(consensus_result.output_path)
     consensus_path = consensus_result.output_path
-
-    tty.timer_log("consensus", t_consensus, f"{consensus_backend[0]}:{consensus_backend[1]}")
 
     tty.log("")
     tty.stage("Pipeline complete!")

--- a/src/cli/lol/commands/impl.md
+++ b/src/cli/lol/commands/impl.md
@@ -1,6 +1,6 @@
 # impl.sh
 
-Implements `lol impl`, the issue-to-implementation loop that drives `acw` iterations, git commits, and PR creation.
+Implements `lol impl`, the issue-to-implementation loop that drives ACW runner iterations, git commits, and PR creation.
 
 ## External Interface
 
@@ -19,7 +19,7 @@ lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]
 **Behavior**:
 - Ensures a worktree exists for the issue, then switches into it.
 - Prefetches issue content via `gh issue view`; if it fails, the command exits with an error.
-- Iterates `acw` runs, requiring a per-iteration commit report file in `.tmp/commit-report-iter-<iter>.txt`.
+- Iterates ACW runner executions, requiring a per-iteration commit report file in `.tmp/commit-report-iter-<iter>.txt`.
 - Stages and commits changes each iteration when there are staged diffs.
 - Detects completion via `.tmp/finalize.txt` when it contains `Issue <no> resolved`.
 - Pushes the branch to a detected remote and opens a PR using the completion file contents.
@@ -48,7 +48,7 @@ Private entrypoint function for the command implementation. It validates argumen
 
 ### Iteration loop
 - Builds `.tmp/impl-input-<iter>.txt` from the base prompt plus previous output.
-- Invokes `acw` with provider/model plus optional `--yolo`.
+- Invokes the ACW Python runner with provider/model plus optional `--yolo`.
 - Requires `.tmp/commit-report-iter-<iter>.txt` and commits changes when present.
 
 ### Completion detection and PR creation

--- a/tests/cli/test-lol-impl-stubbed.md
+++ b/tests/cli/test-lol-impl-stubbed.md
@@ -8,7 +8,8 @@ Validate `lol impl` behavior with deterministic stubs for external tools.
 
 - `git`: Simulate repository interactions (add, diff, commit, remote, push)
 - `wt`: Return predictable worktree paths
-- `acw`: Return canned planner/impl outputs
+- `python`: Intercept `python -m agentize.workflow.acw_cli` and forward to the local `acw` stub
+- `acw`: Return canned planner/impl outputs for each iteration
 - `gh`: Return mocked issue data and PR creation responses
 
 Stubs are defined in the test shell and used by sourced CLI code to keep behavior shell-neutral. No `export -f` is used since the CLI is sourced (not invoked as a subprocess).

--- a/tests/cli/test-lol-impl-stubbed.sh
+++ b/tests/cli/test-lol-impl-stubbed.sh
@@ -121,6 +121,62 @@ acw() {
     return 0
 }
 
+# Stub python entrypoint for agentize.workflow.acw_cli
+python() {
+    if [ "$1" = "-m" ] && [ "$2" = "agentize.workflow.acw_cli" ]; then
+        shift 2
+        local provider=""
+        local model=""
+        local input_file=""
+        local output_file=""
+        local yolo_flag=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --provider)
+                    provider="$2"
+                    shift 2
+                    ;;
+                --model)
+                    model="$2"
+                    shift 2
+                    ;;
+                --input)
+                    input_file="$2"
+                    shift 2
+                    ;;
+                --output)
+                    output_file="$2"
+                    shift 2
+                    ;;
+                --yolo)
+                    yolo_flag="--yolo"
+                    shift
+                    ;;
+                --name|--timeout|--tools|--permission-mode)
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+
+        if [ -z "$provider" ] || [ -z "$model" ] || [ -z "$input_file" ] || [ -z "$output_file" ]; then
+            echo "Error: stubbed python missing acw_cli args" >&2
+            return 1
+        fi
+
+        if [ -n "$yolo_flag" ]; then
+            acw "$provider" "$model" "$input_file" "$output_file" "$yolo_flag"
+            return $?
+        fi
+        acw "$provider" "$model" "$input_file" "$output_file"
+        return $?
+    fi
+
+    command python "$@"
+}
+
 # Stub gh function
 gh() {
     echo "gh $*" >> "$GH_CALL_LOG"

--- a/tests/cli/test-lol-plan-github-stubbed.sh
+++ b/tests/cli/test-lol-plan-github-stubbed.sh
@@ -76,6 +76,14 @@ STUB_ACW="$TMP_DIR/acw-stub.sh"
 cat > "$STUB_ACW" <<'STUBEOF'
 #!/usr/bin/env bash
 acw() {
+    if [ "$1" = "--complete" ]; then
+        if [ "$2" = "providers" ]; then
+            printf "%s\n" claude codex opencode cursor
+            return 0
+        fi
+        return 1
+    fi
+
     local provider="$1"
     local model="$2"
     local input_file="$3"

--- a/tests/cli/test-lol-plan-issue-mode.sh
+++ b/tests/cli/test-lol-plan-issue-mode.sh
@@ -84,6 +84,14 @@ STUB_ACW="$TMP_DIR/acw-stub.sh"
 cat > "$STUB_ACW" <<'STUBEOF'
 #!/usr/bin/env bash
 acw() {
+    if [ "$1" = "--complete" ]; then
+        if [ "$2" = "providers" ]; then
+            printf "%s\n" claude codex opencode cursor
+            return 0
+        fi
+        return 1
+    fi
+
     local cli_name="$1"
     local model_name="$2"
     local input_file="$3"

--- a/tests/cli/test-lol-plan-pipeline-stubbed.sh
+++ b/tests/cli/test-lol-plan-pipeline-stubbed.sh
@@ -33,6 +33,14 @@ STUB_ACW="$TMP_DIR/acw-stub.sh"
 cat > "$STUB_ACW" <<'STUBEOF'
 #!/usr/bin/env bash
 acw() {
+    if [ "$1" = "--complete" ]; then
+        if [ "$2" = "providers" ]; then
+            printf "%s\n" claude codex opencode cursor
+            return 0
+        fi
+        return 1
+    fi
+
     local provider="$1"
     local model="$2"
     local input_file="$3"


### PR DESCRIPTION
Unify ACW runner across planner and impl with validation/logging
Summary:
- Add ACW class with provider validation, timing logs, and a minimal acw_cli wrapper.
- Route planner stages and lol impl iterations through the shared ACW runner and update docs/log format.
- Extend tests and stubs to cover ACW validation and provider completion.
Tests:
- export TEST_SHELLS="bash zsh"; make test-fast
Issue 770 resolved
closes #770