### PR TITLE
docs: move tutorials to CLI-first planning/impl

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -151,6 +151,7 @@ Runs the full multi-agent debate pipeline for a feature description, producing a
 | `--refine <issue-no> [refinement-instructions]` | No | - | Refine an existing plan issue; if positional instructions are provided with `--editor`, they are appended after the editor text |
 
 By default, `lol plan` creates a GitHub issue when `gh` is available. Use `--dry-run` to skip issue creation and use timestamp-based artifact naming instead.
+`--editor` requires `$EDITOR` to be set; if it is not, pass the description directly (for example, `lol plan "Add JWT auth"`).
 
 When `--refine` is set, the issue body is fetched from GitHub and used as the debate context. Optional refinement instructions are appended to the context to guide the agents. Refinement runs write artifacts prefixed with `issue-refine-<N>` and update the existing issue unless `--dry-run` is provided. This mode requires authenticated `gh` access to read the issue body.
 
@@ -211,7 +212,7 @@ lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]
 
 #### Issue prefetch
 
-Before the loop starts, `lol impl` attempts to fetch the issue title/body (and labels if present) via `gh issue view` and writes it to `.tmp/issue-<N>.md`. If the fetch fails or the file is empty, `lol impl` exits with an error.
+Before the loop starts, `lol impl` attempts to fetch the issue title/body (and labels if present) via `gh issue view` and writes it to `.tmp/issue-<N>.md`. If the fetch fails or the file is empty, `lol impl` exits with an error. Ensure `gh` is authenticated and the issue exists in the current repository.
 
 #### Completion marker
 

--- a/docs/tutorial/00-initialize.md
+++ b/docs/tutorial/00-initialize.md
@@ -38,7 +38,14 @@ claude plugin install agentize@agentize
 
 ## Verify Installation
 
-After setup, verify Claude Code recognizes your configuration:
+After setup, verify the CLI entrypoints are available:
+
+```bash
+lol plan --help
+lol impl --help
+```
+
+Optional Claude UI check (see `docs/feat/core/ultra-planner.md` and `docs/feat/core/issue-to-impl.md`):
 
 ```bash
 # In your project directory with Claude Code
@@ -64,8 +71,8 @@ For example, you might add project-specific tags like:
 ## Next Steps
 
 Once initialized:
-- **Tutorial 01**: Learn how to create implementation plans with `/ultra-planner` (uses the git tags you just customized)
-- **Tutorial 02**: Learn the full development workflow with `/issue-to-impl`
+- **Tutorial 01**: Learn CLI planning with `lol plan --editor` (uses the git tags you just customized)
+- **Tutorial 02**: Learn the CLI implementation loop with `lol impl <issue-no>`
 - **Tutorial 03**: Scale up with parallel development workflows
 
 ## Configuration Options

--- a/docs/tutorial/01-ultra-planner.md
+++ b/docs/tutorial/01-ultra-planner.md
@@ -1,14 +1,46 @@
-# Tutorial 01: Ultra Planner (Primary Planning)
+# Tutorial 01: CLI Planning with `lol plan`
 
 **Primary planning tutorial**: Use this as the default entry point for planning features.
 
 **Read time: 5 minutes**
 
-Learn how to use multi-agent debate-based planning for complex features with `/ultra-planner`.
+Learn how to use multi-agent debate-based planning with `lol plan --editor` (CLI-first). If you prefer the Claude UI, `/ultra-planner` provides auto-routing and `--force-full` (see `docs/feat/core/ultra-planner.md`).
 
-## What is `/ultra-planner`?
+## What is `lol plan`?
 
-`/ultra-planner` automatically routes to the optimal planning workflow based on estimated complexity:
+`lol plan` runs the multi-agent debate pipeline to produce a consensus implementation plan. It is the preferred CLI entrypoint for planning and is documented in `docs/cli/lol.md` and `docs/cli/planner.md`.
+
+### Basic usage
+
+Compose the feature description in your editor:
+
+```
+lol plan --editor
+```
+
+`--editor` opens `$EDITOR`. If `$EDITOR` is not set, pass the description directly:
+
+```
+lol plan "Add user authentication with JWT tokens and role-based access control"
+```
+
+### Refinement with `--refine`
+
+Improve an existing plan issue by running the debate again:
+
+```
+lol plan --refine 42
+```
+
+Optional refinement focus:
+
+```
+lol plan --refine 42 "Focus on reducing complexity"
+```
+
+## Claude UI Equivalent: `/ultra-planner`
+
+`/ultra-planner` is the Claude UI interface for planning. It uses auto-routing and supports `--force-full`. See `docs/feat/core/ultra-planner.md` for full behavior details.
 
 ### Automatic Routing
 
@@ -32,10 +64,9 @@ Bold-proposer runs first to generate a concrete proposal, then Critique and Redu
 
 ## When to Use It?
 
-**Use `/ultra-planner`** for all feature planning. It automatically routes:
+**Use `lol plan`** for all feature planning in the CLI. It always runs the multi-agent pipeline documented in `docs/cli/lol.md`.
 
-- **Simple changes** (repo-only, <5 files, <150 LOC) → Lite path (1-2 min, ~$0.30-0.80)
-- **Complex features** (needs research or larger scope) → Full debate (6-12 min, ~$2.50-6)
+**Use `/ultra-planner`** when you want Claude UI convenience or auto-routing.
 
 **Use `/ultra-planner --force-full`** when:
 - You want thorough multi-perspective analysis even for simple changes
@@ -49,7 +80,7 @@ Bold-proposer runs first to generate a concrete proposal, then Critique and Redu
 
 **1. Invoke the command:**
 ```
-User: /ultra-planner Add user authentication with JWT tokens and role-based access control
+lol plan "Add user authentication with JWT tokens and role-based access control"
 ```
 
 **2. Bold-proposer generates proposal (1-2 minutes):**
@@ -81,26 +112,12 @@ Documentation Planning:
 Plan issue #42 updated with consensus plan.
 URL: https://github.com/user/repo/issues/42
 
-To refine: /ultra-planner --refine 42
-To implement: /issue-to-impl 42
+To refine (CLI): lol plan --refine 42
+To refine (Claude UI): /ultra-planner --refine 42
+To implement (CLI): lol impl 42
 ```
 
-## Refinement with `--refine` Mode
-
-Improve an existing plan issue by running the debate again:
-
-```
-/ultra-planner --refine 42
-```
-
-The agents analyze the current plan and propose improvements. Useful when the initial consensus feels over-complicated or you want to explore simpler alternatives.
-
-**Optional refinement focus:**
-```
-/ultra-planner --refine 42 Focus on reducing complexity
-```
-
-### Label-Based Auto Refinement
+## Label-Based Auto Refinement
 
 When running with `lol serve`, you can trigger refinement without invoking the command manually:
 
@@ -109,7 +126,7 @@ When running with `lol serve`, you can trigger refinement without invoking the c
    ```bash
    gh issue edit 42 --add-label agentize:refine
    ```
-3. The server will pick up the issue on the next poll and run refinement automatically
+3. The server will pick up the issue on the next poll and run `/ultra-planner --refine` (current server behavior per `docs/cli/lol.md`)
 4. After refinement completes, the label is removed and status stays `Proposed`
 
 This enables stakeholders to request plan improvements without CLI access.
@@ -119,15 +136,15 @@ This enables stakeholders to request plan improvements without CLI access.
 1. **Provide context**: "Add JWT auth for API access" (not just "Add auth")
 2. **Right-size features**: Don't use for trivial changes, do use for complex ones
 3. **Review all perspectives**: Bold shows innovation, Critique shows risks, Reducer shows simplicity
-4. **Refine when needed**: First consensus not perfect? Use `--refine`
-5. **Trust auto-routing**: `/ultra-planner` automatically uses the lite path for simple changes
+4. **Refine when needed**: First consensus not perfect? Use `lol plan --refine`
+5. **Choose your interface**: `lol plan` for CLI, `/ultra-planner` for auto-routing in Claude UI
 
 ## Dry-Run Mode
 
 Preview what would be created without making GitHub changes:
 
 ```
-/ultra-planner --dry-run Add user authentication with JWT tokens
+lol plan --dry-run "Add user authentication with JWT tokens"
 ```
 
 **What happens:**
@@ -142,9 +159,9 @@ Preview what would be created without making GitHub changes:
 
 **Cost note:** Token costs are similar to regular runs since agents still execute. Use `--dry-run` when you want to review the plan before committing to GitHub.
 
-## Cost & Time
+## Cost & Time (Claude UI Auto-Routing)
 
-**With automatic routing:**
+**With automatic routing in `/ultra-planner`:**
 
 | Path | Conditions | Time | Cost |
 |------|------------|------|------|
@@ -157,10 +174,10 @@ Preview what would be created without making GitHub changes:
 
 ## Next Steps
 
-After `/ultra-planner` creates your GitHub issue:
+After `lol plan` creates your GitHub issue:
 
 1. Review the issue on GitHub
-2. Use `/issue-to-impl <issue-number>` to start implementation (Tutorial 02)
+2. Use `lol impl <issue-number>` to start implementation (Tutorial 02)
 3. Validate and adjust the plan as you implement
 
-**When in doubt**: Use `/ultra-planner` - it auto-routes to the appropriate path based on complexity.
+**When in doubt**: Use `lol plan` - it keeps planning CLI-first while the Claude UI remains available.

--- a/docs/tutorial/02-issue-to-impl.md
+++ b/docs/tutorial/02-issue-to-impl.md
@@ -1,10 +1,52 @@
-# Tutorial 02: Issue to Implementation
+# Tutorial 02: CLI Implementation with `lol impl`
 
 **Read time: 3-5 minutes**
 
-This tutorial covers the complete development cycle from a GitHub issue to merge-ready code.
+This tutorial covers the complete development cycle from a GitHub issue to merge-ready code using the CLI-first workflow.
 
-## What is `/issue-to-impl`?
+## What is `lol impl`?
+
+`lol impl` automates the issue-to-implementation loop using `wt` + `acw` (see `docs/cli/lol.md`). It expects a real GitHub issue and coordinates iterative implementation steps until completion.
+
+### Requirements
+
+- `gh` must be authenticated and able to read the issue
+- The issue number must exist in the current repository
+- Each iteration needs `.tmp/commit-report-iter-<N>.txt` as the commit message
+- Completion requires `.tmp/finalize.txt` (first line is PR title; include `Issue <N> resolved` in the body)
+
+### Workflow Summary
+
+1. Prefetches issue content via `gh issue view` and writes `.tmp/issue-<N>.md`
+2. Exits with an error if the fetch fails or the issue content is empty
+3. Syncs the issue branch by fetching and rebasing onto the default branch
+4. Runs iterative `wt + acw` loops, committing when changes exist
+5. Finishes when `.tmp/finalize.txt` is present and contains `Issue <N> resolved`
+
+## Basic Usage
+
+```
+lol impl 42
+```
+
+Replace `42` with your issue number from Tutorial 01.
+
+## CLI Example (High-Level)
+
+```
+User: lol impl 42
+Agent: Prefetching issue #42 with gh...
+Agent: Syncing branch onto origin/main...
+Agent: Iteration 1 (uses .tmp/commit-report-iter-1.txt)
+...
+Agent: Completion detected in .tmp/finalize.txt
+```
+
+## Claude UI Equivalent: `/issue-to-impl` (Milestones)
+
+`/issue-to-impl` is the Claude UI workflow. It uses a milestone-based implementation loop and is documented in `docs/feat/core/issue-to-impl.md`. Use this if you prefer the Claude UI or want the built-in milestone checkpoints.
+
+### What is `/issue-to-impl`?
 
 `/issue-to-impl` orchestrates the full implementation workflow:
 1. Creates a development branch
@@ -13,7 +55,7 @@ This tutorial covers the complete development cycle from a GitHub issue to merge
 4. Implements the feature incrementally
 5. Tracks progress through milestones
 
-## How It Works
+### How It Works
 
 The command follows a milestone-based approach:
 
@@ -23,15 +65,13 @@ The command follows a milestone-based approach:
 
 This allows large features to span multiple work sessions while maintaining clear context.
 
-## Basic Usage
+### Basic Usage (Claude UI)
 
 ```
 /issue-to-impl 42
 ```
 
-Replace `42` with your issue number from Tutorial 01.
-
-## What Happens Automatically
+### What Happens Automatically
 
 When you run `/issue-to-impl`:
 
@@ -70,7 +110,7 @@ When you run `/issue-to-impl`:
 - Stops at 800 LOC if tests incomplete → creates Milestone 2
 - OR continues until all tests pass → completion
 
-## Example: Complete Flow
+### Example: Milestone-Based Flow (Claude UI)
 
 **Step 1: Start implementation**
 ```
@@ -114,7 +154,7 @@ Implementation complete:
 Next step: Review with /code-review
 ```
 
-## Resuming from Milestones
+## Resuming from Milestones (Claude UI)
 
 If implementation creates a milestone (doesn't complete), resume with natural language:
 
@@ -184,70 +224,7 @@ The PR number is automatically recorded in the session state, enabling the serve
 
 **Note on Commands vs Skills**: Slash commands (like `/code-review`) are pre-defined prompts you invoke directly, while skills (like `open-pr`) are routines implicitly invoked by Claude when you use natural language requests.
 
-## Complete Workflow Example
-
-Here's the full cycle for issue #42:
-
-```
-# 1. Start implementation
-/issue-to-impl 42
-[... Milestone 2 created at 820 LOC ...]
-
-# 2. Resume (next session)
-User: Continue from the latest milestone
-[... All tests pass! ...]
-
-# 3. Review code
-/code-review
-[... ✅ APPROVED ...]
-
-# 4. Sync with main and rebase your branch
-git checkout main
-git pull --rebase origin main
-git checkout issue-42
-git rebase main
-
-# 5. Create PR
-User: Create a pull request
-[... Claude invokes open-pr skill ...]
-[... PR created: https://github.com/your-repo/pull/123 ...]
-
-# 6. Merge (after approval)
-[Merge via GitHub UI or gh pr merge]
-```
-
-## Understanding Milestones
-
-Milestones are checkpoint documents in `.tmp/milestones/`:
-
-```
-.tmp/milestones/
-├── issue-42-milestone-1.md
-├── issue-42-milestone-2.md
-└── issue-42-milestone-3.md
-```
-
-Each milestone contains:
-- **Header**: branch, datetime, LOC, test status
-- **Work Remaining**: incomplete implementation steps
-- **Next File Changes**: files to modify next
-- **Test Status**: passed and failed tests with details
-
-See `docs/milestone-workflow.md` for complete documentation.
-
-## Tips
-
-1. **Let it run**: `/issue-to-impl` works automatically - let it complete or reach a milestone
-2. **Review milestones**: Check `.tmp/milestones/` files to understand progress
-3. **Always sync**: Sync with main and rebase your branch before creating PRs to avoid conflicts
-4. **Fix review issues**: Address `/code-review` findings before merging
-5. **Clean working directory**: Commit changes before syncing or `/issue-to-impl` (requires clean working tree for rebasing)
-
-## Next Steps
-
-- **Tutorial 03**: Learn how to scale up with parallel development (multiple issues at once)
-
-## Dry-Run Mode
+## Dry-Run Mode (Claude UI)
 
 Preview the implementation plan before making changes:
 
@@ -282,3 +259,7 @@ Use dry-run to verify an issue has a complete plan before starting implementatio
 **"Rebase conflict detected"**
 - Your changes conflict with main branch
 - Solution: Manually resolve conflicts, `git add` files, `git rebase --continue`
+
+## Next Steps
+
+- **Tutorial 03**: Learn how to scale up with parallel development (multiple issues at once)

--- a/docs/tutorial/04-automation.md
+++ b/docs/tutorial/04-automation.md
@@ -46,7 +46,6 @@ to your Telegram bot.
 
 Once there is:
 - An issue with `agentize:plan` label and project status `Plan Accepted`, a new development session will be started.
-- An issue that with `agentize:dev-req` label, a new `/ultra-planner` session will be started to generate a detailed plan.
+- An issue with `agentize:dev-req` label triggers `/ultra-planner --refine` (current server behavior per `docs/cli/lol.md`).
 - A PR with unmerge-able status, a `/sync-master` session will be started to rebase the PR branch onto master.
 - A permission that is not determined yet, a permission request message will be sent to your Telegram bot for you to click the buttons to approve or reject.
-

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -7,8 +7,8 @@ This directory contains step-by-step tutorials for learning Agentize.
 Complete all tutorials in 15-25 minutes (3-5 minutes each):
 
 1. `00-initialize.md` - Project initialization and setup
-2. `01-ultra-planner.md` - Primary planning tutorial (recommended)
-3. `02-issue-to-impl.md` - Complete development cycle from issue to PR
+2. `01-ultra-planner.md` - CLI planning with `lol plan --editor` (recommended)
+3. `02-issue-to-impl.md` - CLI implementation loop with `lol impl <issue-no>`
 4. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
 5. `04-project.md` - Configuring project board automation with PAT
 


### PR DESCRIPTION
docs: move tutorials to CLI-first planning/impl

## Summary
- prioritize CLI-first planning/implementation guidance in tutorials
- keep Claude UI equivalents for `/ultra-planner` and `/issue-to-impl`
- clarify automation refinement behavior and `lol` CLI prerequisites
- Issue 771 resolved

## Testing
- `make test-fast TEST_SHELLS="bash zsh"`

closes #771