### PR TITLE
Align acw zsh completion with cli-options

### DIFF
--- a/src/completion/_acw
+++ b/src/completion/_acw
@@ -42,6 +42,11 @@ _acw() {
         '-h[Show help message]' \
         '--editor[Compose input in $EDITOR]' \
         '--stdout[Write output to stdout (merge provider stderr)]' \
+        '--chat[Start or continue chat session]::session-id:' \
+        '--chat-list[List chat sessions]' \
+        '--model[Provider model identifier]:model:' \
+        '--max-tokens[Maximum tokens to generate]:number:' \
+        '--yolo[Enable dangerous mode]' \
         '--complete[Shell completion helper]:topic:(providers cli-options)' \
         '1:provider:->provider' \
         '2:model:' \

--- a/src/completion/_acw.md
+++ b/src/completion/_acw.md
@@ -15,7 +15,10 @@ The file defines the `_acw` completion function and registers it for `acw` via
 - Uses `acw --complete providers` when available to populate provider names.
 - Falls back to a static provider list with descriptions if dynamic completion
   is unavailable.
-- Offers flags including `--editor`, `--stdout`, `--help`, and `--complete`.
+- Offers flags from `acw --complete cli-options` (see `docs/cli/acw.md`) plus
+  completion-only flags like `--complete` and `-h`.
+- Treats `--chat` as an optional session-id and lists common provider options
+  (`--model`, `--max-tokens`, `--yolo`) as hintable flags.
 - Marks input/output positions as optional to reflect editor/stdout modes.
 
 ## Internal Helpers


### PR DESCRIPTION
Align acw zsh completion with cli-options

## Summary
- add chat and provider flags to the zsh completion list
- document static completion parity with acw cli-options
- extend completion tests for --max-tokens and static parity

## Testing
- bash tests/cli/test-acw-completion.sh

Issue 739 resolved
closes #739