### PR TITLE
[docs][#776] Add Plan→Impl tutorial bridge and planner backend config

### DIFF
--- a/docs/envvar.md
+++ b/docs/envvar.md
@@ -60,6 +60,14 @@ workflows:
     model: sonnet                  # Dev-req planning
   rebase:
     model: haiku                   # PR rebase
+
+# Planner Backends - lol plan stage configuration
+planner:
+  backend: claude:opus             # Default backend for all stages
+  understander: claude:sonnet      # Override understander stage
+  bold: claude:opus                # Override bold-proposer stage
+  critique: claude:opus            # Override critique stage
+  reducer: claude:opus             # Override reducer stage
 ```
 
 ## YAML Settings Reference
@@ -108,6 +116,20 @@ See [Telegram Approval](feat/permissions/telegram.md) for detailed documentation
 | `workflows.refine.model` | string | - | Model for refinement workflows |
 | `workflows.dev_req.model` | string | - | Model for dev-req planning |
 | `workflows.rebase.model` | string | - | Model for PR rebase |
+
+**Note:** `workflows.impl.model` sets the default model for impl workflows; `lol impl --backend <provider:model>` overrides per run (see `docs/cli/lol.md`).
+
+### Planner Backends
+
+| YAML Path | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `planner.backend` | string | `claude:opus` | Default backend for all planner stages |
+| `planner.understander` | string | - | Override understander stage |
+| `planner.bold` | string | - | Override bold-proposer stage |
+| `planner.critique` | string | - | Override critique stage |
+| `planner.reducer` | string | - | Override reducer stage |
+
+Planner backends use the format `<provider>:<model>` (e.g., `claude:opus`, `claude:sonnet`). Per-stage overrides take precedence over `planner.backend`.
 
 ## Environment-Only Variables
 

--- a/docs/tutorial/01-ultra-planner.md
+++ b/docs/tutorial/01-ultra-planner.md
@@ -172,12 +172,33 @@ lol plan --dry-run "Add user authentication with JWT tokens"
 
 **Value of full path**: Multiple perspectives, thorough validation, balanced plans
 
+## Plan → Impl (End-to-End)
+
+After `lol plan` creates your GitHub issue, continue with `lol impl <issue-number>` (see `docs/tutorial/02-issue-to-impl.md`).
+
+### Backend Configuration
+
+Configure planner backends in `.agentize.local.yaml`:
+
+```yaml
+planner:
+  backend: claude:opus             # Default backend for all stages
+  understander: claude:sonnet      # Override understander stage
+  bold: claude:opus                # Override bold-proposer stage
+  critique: claude:opus            # Override critique stage
+  reducer: claude:opus             # Override reducer stage
+
+workflows:
+  impl:
+    model: opus                    # Default model for lol impl
+```
+
+**Note:** `lol impl --backend <provider:model>` overrides `workflows.impl.model` for a single run (see `docs/cli/lol.md`).
+
 ## Next Steps
 
-After `lol plan` creates your GitHub issue:
-
-1. Review the issue on GitHub
-2. Use `lol impl <issue-number>` to start implementation (Tutorial 02)
-3. Validate and adjust the plan as you implement
+1. Review the plan issue on GitHub
+2. Run `lol impl <issue-number>` to start implementation (Tutorial 02)
+3. Use `lol plan --refine <issue>` if the plan needs adjustments
 
 **When in doubt**: Use `lol plan` - it keeps planning CLI-first while the Claude UI remains available.

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -8,7 +8,7 @@ Complete all tutorials in 15-25 minutes (3-5 minutes each):
 
 1. `00-initialize.md` - Project initialization and setup
 2. `01-ultra-planner.md` - CLI planning with `lol plan --editor` (recommended)
-3. `02-issue-to-impl.md` - CLI implementation loop with `lol impl <issue-no>`
+3. `02-issue-to-impl.md` - Implementation; together with 01 this forms the end-to-end flow
 4. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
 5. `04-project.md` - Configuring project board automation with PAT
 


### PR DESCRIPTION
## Summary

Added a Plan→Impl bridge section to the planning tutorial and documented planner backend configuration in the configuration reference. This provides a complete learning path from planning to implementation and clarifies how to configure backend model selection.

## Changes

- Modified `docs/tutorial/01-ultra-planner.md:175-204` to add "Plan → Impl (End-to-End)" section with backend configuration snippet showing `planner.*` and `workflows.impl.model` settings
- Updated `docs/tutorial/README.md:11` to clarify that tutorials 01 and 02 form the end-to-end plan→impl flow
- Extended `docs/envvar.md:64-70` to add `planner.*` schema in YAML example
- Added `docs/envvar.md:120-132` with Planner Backends reference table and note about `lol impl --backend` override

## Testing

- Documentation-only change; no runtime behavior to test
- Verified all file references and cross-links are accurate
- Confirmed YAML snippets match `.agentize.local.example.yaml` format

## Related Issue

Closes #776
