### PR TITLE
[refactor][#778] Remove runner is run_acw identity branching in planner pipeline

### DIFF
--- a/docs/cli/planner.md
+++ b/docs/cli/planner.md
@@ -104,7 +104,7 @@ When stderr is a TTY, `lol plan` emits visual feedback during pipeline execution
 
 - **Colored "Feature:" label** — highlights the feature description at pipeline start.
 - **Animated stage dots** — expanding/contracting dot pattern (`.. ... .... ..... .... ...`) while each stage runs.
-- **ACW start/finish** — logs `agent <stage> (<provider>:<model>) is running...` at stage start and `agent <stage> (<provider>:<model>) runs <seconds>s` on completion.
+- **ACW start/finish** — When using the default `acw` runner, logs `agent <stage> (<provider>:<model>) is running...` at stage start and `agent <stage> (<provider>:<model>) runs <seconds>s` on completion. These logs are emitted via the `ACW` class regardless of runner identity.
 - **Issue link** — when issue publish succeeds, prints `See the full plan at: <url>`.
 
 ### Environment Toggles

--- a/python/agentize/workflow/planner/__main__.md
+++ b/python/agentize/workflow/planner/__main__.md
@@ -77,7 +77,9 @@ output. Returns process exit code.
 
 ## Design Rationale
 
-- **Unified ACW runner**: The pipeline uses the `ACW` class when invoking `acw` so
-  provider validation and timing logs are centralized.
+- **Unified runner path**: The pipeline always uses `ACW` class for stage execution.
+  Custom runners (for testing) are injected via the `ACW.runner` parameter, avoiding
+  identity checks like `runner is run_acw`. This keeps ACW timing logs available
+  regardless of the underlying runner function.
 - **Isolation**: Prompt rendering and issue/publish logic are kept in helpers to reduce
   coupling between orchestration and IO concerns.


### PR DESCRIPTION
## Summary

Refactored the planner pipeline to use a unified execution path through the `ACW` class,
eliminating verbose `runner is run_acw` identity checks. Custom runners (for testing)
are now injected via a new `ACW.runner` parameter, maintaining the same logging and
interface behavior while simplifying the codebase.

## Changes

- Modified `python/agentize/workflow/utils.py:254-319` to add optional `runner` parameter
  to the `ACW` class, skipping provider validation when custom runner is provided
- Updated `python/agentize/workflow/planner/__main__.py:244-385` to remove `use_acw_runner`
  identity checks and redundant `PlannerTTY` timer code (ACW handles timing internally)
- Updated `python/agentize/workflow/planner/__main__.py:652-674` to use unified ACW path
  in `_run_consensus_stage`
- Updated `python/agentize/workflow/planner/__main__.py:766-810` to remove identity checks
  in `main()` function
- Modified `python/agentize/workflow/planner/__main__.md` to describe unified runner path
- Updated `docs/cli/planner.md:107` to clarify ACW start/finish logging behavior

## Testing

- Added `python/tests/test_planner_workflow.py:368-406` test `test_custom_runner_invoked`
  to verify ACW correctly invokes custom runners
- All 22 tests in `test_planner_workflow.py` pass
- All 261 tests in the full test suite pass

## Related Issue

Closes #778
