### PR TITLE
Add termination-intent guidance for planner outputs

### DIFF
--- a/.claude-plugin/agents/planner-lite.md
+++ b/.claude-plugin/agents/planner-lite.md
@@ -64,6 +64,7 @@ Your output must match the consensus format so it integrates with the rest of ul
 **Feature**: [1-2 sentence description]
 **Estimated LOC**: ~[N] (Small)
 **Path**: Lite (single-agent)
+**Termination intent**: [Only if user explicitly requested to end/stop the session; one sentence, keep plan minimal]
 
 ## Proposed Solution
 
@@ -98,7 +99,9 @@ Your output must match the consensus format so it integrates with the rest of ul
 ## Key Behaviors
 
 - **Be concise**: Simple features need simple plans
+- **Honor termination intent**: If the user asks to end/stop, acknowledge in the Summary and keep the plan minimal while still completing required sections
 - **Be practical**: Focus on what matters, skip unnecessary analysis
+- **Cite workflow references**: When mentioning planner commands or workflows, cite `docs/feat/core/ultra-planner.md`, `docs/tutorial/01-ultra-planner.md`, and `docs/commands.md` as applicable
 - **Follow patterns**: Match existing codebase conventions
 - **Stay within scope**: Don't expand beyond the original request
 

--- a/.claude-plugin/skills/external-consensus/external-review-prompt.md
+++ b/.claude-plugin/skills/external-consensus/external-review-prompt.md
@@ -44,6 +44,8 @@ Generate a final implementation plan that follows the plan-guideline structure a
 - **Include dependencies** for each step so ordering is enforced.
 - **For every step, list correspondence** to documentation and test cases (what it updates, depends on, or satisfies).
 - **If this is a bug fix**, include Bug Reproduction (or explicit skip reason).
+- **Termination-intent handling**: If the request indicates the user wants to end/stop the session, add a single-sentence acknowledgement in `## Consensus Summary` and keep the plan concise while still completing every required section.
+- **Command/workflow citations**: When referencing planner commands or workflows (e.g., `/ultra-planner`, `/issue-to-impl`, `lol plan`), cite `docs/feat/core/ultra-planner.md`, `docs/tutorial/01-ultra-planner.md`, and `docs/commands.md` as applicable.
 - **No preamble**: Do not include any lead-in or meta commentary. The first line must be the plan title header.
 
 ```markdown

--- a/docs/feat/core/ultra-planner.md
+++ b/docs/feat/core/ultra-planner.md
@@ -219,6 +219,10 @@ When using `/doc-architect --diff`, the Documentation Planning section includes 
 - Reduces ambiguity in documentation requirements
 - `/issue-to-impl` Step 5 can apply diff specifications directly
 
+### 4. Termination-Intent Handling (Response-Only)
+
+If a user explicitly asks to end/stop the session during planning, the planner still returns a minimal, structured plan that satisfies the required sections. The response acknowledges the termination intent in the plan summary and keeps each section concise, while preserving the workflow artifacts and issue update behavior.
+
 The consensus plan references command interfaces by citing actual `docs/` files (e.g., `docs/workflows/ultra-planner.md`, `docs/tutorial/02-issue-to-impl.md`) to ensure accuracy and grounding.
 
 **Skill integration:**
@@ -401,4 +405,3 @@ This does not change the `/ultra-planner` command interface documented above. Se
 | **Workflow** | Approval → Issue → Impl | Issue → Refine* → Impl |
 
 *Refinement is optional and can be done multiple times using `--refine`
-


### PR DESCRIPTION
Add termination-intent guidance for planner outputs

## Summary
- Add termination-intent acknowledgement and citation guidance to the consensus prompt and planner-lite output.
- Document response-only termination handling in the ultra-planner workflow.

## Testing
- make test-fast TEST_SHELLS="bash zsh"

Issue 786 resolved.
closes #786