### PR TITLE
feat: append commit provenance footer to lol plan output

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -139,7 +139,7 @@ lol plan [--dry-run] [--verbose] [--editor] [--refine <issue-no> [refinement-ins
 lol plan --refine <issue-no> [refinement-instructions]
 ```
 
-Runs the full multi-agent debate pipeline for a feature description, producing a consensus implementation plan. This is the preferred entrypoint for the planner pipeline.
+Runs the full multi-agent debate pipeline for a feature description, producing a consensus implementation plan. This is the preferred entrypoint for the planner pipeline. The consensus plan ends with a provenance footer: `Plan based on commit <hash>`.
 
 #### Options
 

--- a/docs/cli/planner.md
+++ b/docs/cli/planner.md
@@ -28,7 +28,7 @@ Skips GitHub issue creation and uses timestamp-based artifact naming. The pipeli
 
 ### `--refine <issue-no> [refinement-instructions]`
 
-Refines an existing plan issue by fetching its body from GitHub and rerunning the debate. Optional refinement instructions are appended to the context to steer the agents. Refinement runs still write artifacts with `issue-refine-<N>` prefixes and update the existing issue unless `--dry-run` is set. Requires authenticated `gh` access to read the issue body.
+Refines an existing plan issue by fetching its body from GitHub and rerunning the debate. Optional refinement instructions are appended to the context to steer the agents. The fetched issue body has the trailing provenance footer stripped before reuse as debate context. Refinement runs still write artifacts with `issue-refine-<N>` prefixes and update the existing issue unless `--dry-run` is set. Requires authenticated `gh` access to read the issue body.
 
 ### `--verbose` (optional flag)
 
@@ -51,7 +51,7 @@ Stage-specific keys override `planner.backend`. Defaults remain `claude:sonnet` 
 
 ### Default Issue Creation
 
-By default, `lol plan` creates a placeholder GitHub issue before the pipeline runs using a truncated placeholder title (`[plan] placeholder: <first 50 chars>...`), and uses `issue-{N}` artifact naming. After the consensus stage completes, the issue body is updated with the final plan, the title is set from the first `Implementation Plan:` or `Consensus Plan:` header in the consensus file (fallback: truncated feature description), and the `agentize:plan` label is applied.
+By default, `lol plan` creates a placeholder GitHub issue before the pipeline runs using a truncated placeholder title (`[plan] placeholder: <first 50 chars>...`), and uses `issue-{N}` artifact naming. After the consensus stage completes, the issue body is updated with the final plan plus a trailing provenance footer (`Plan based on commit <hash>`), the title is set from the first `Implementation Plan:` or `Consensus Plan:` header in the consensus file (fallback: truncated feature description), and the `agentize:plan` label is applied.
 
 When `--refine` is used, no placeholder issue is created. The issue body is fetched and reused as debate context, and the issue is updated in-place after the consensus stage (unless `--dry-run` is set).
 

--- a/python/agentize/workflow/planner/__main__.md
+++ b/python/agentize/workflow/planner/__main__.md
@@ -45,8 +45,9 @@ def main(argv: list[str]) -> int
 ```
 
 CLI entrypoint for the planner backend. Parses args, resolves repo root and backend
-configuration, runs stages, publishes plan updates (when enabled), and prints plain-text
-progress output. Returns process exit code.
+configuration, runs stages, publishes plan updates with a trailing commit provenance
+footer (when enabled), and prints plain-text progress output. Refinement fetches strip
+the footer before reuse as debate context. Returns process exit code.
 
 ## Internal Helpers
 
@@ -68,6 +69,9 @@ progress output. Returns process exit code.
 - `_issue_create()`, `_issue_fetch()`, `_issue_publish()`: GitHub issue lifecycle for
   plan publishing.
 - `_extract_plan_title()`, `_apply_issue_tag()`: Plan title parsing and issue tagging.
+- `_resolve_commit_hash()`: Resolves the current repo `HEAD` commit for provenance.
+- `_append_plan_footer()`: Appends `Plan based on commit <hash>` to consensus output.
+- `_strip_plan_footer()`: Removes the trailing provenance footer from issue bodies.
 
 ### Backend selection
 

--- a/src/cli/lol/commands/plan.md
+++ b/src/cli/lol/commands/plan.md
@@ -7,7 +7,7 @@ Planning pipeline entrypoint for multi-agent debate workflows.
 ### lol plan
 
 Runs the debate pipeline for a feature description or refines an existing plan
-issue.
+issue. The generated consensus plan ends with `Plan based on commit <hash>`.
 
 **Usage**:
 ```bash

--- a/tests/cli/test-lol-plan-pipeline-stubbed.sh
+++ b/tests/cli/test-lol-plan-pipeline-stubbed.sh
@@ -135,6 +135,17 @@ for stage in bold critique reducer; do
     fi
 done
 
+# Verify consensus output includes commit provenance footer
+CONSENSUS_PATH="${PREFIX}-consensus.md"
+if [ ! -s "$CONSENSUS_PATH" ]; then
+    test_fail "Expected consensus .md artifact"
+fi
+FOOTER_LINE=$(tail -n 1 "$CONSENSUS_PATH")
+echo "$FOOTER_LINE" | grep -qE "^Plan based on commit ([0-9a-f]+|unknown)$" || {
+    echo "Consensus footer line: $FOOTER_LINE" >&2
+    test_fail "Consensus plan should end with commit provenance footer"
+}
+
 # ── Test 2: --verbose mode outputs detailed stage info ──
 > "$CALL_LOG"
 


### PR DESCRIPTION
feat: append commit provenance footer to lol plan output

Summary:
- Append commit provenance footer to consensus plans and strip it during refinement fetches.
- Document footer behavior in planner and lol plan docs.
- Add stubbed pipeline coverage for the footer line.

Testing:
- make test-fast TEST_SHELLS="bash zsh"

Issue 794 resolved
closes #794