### PR TITLE
Prompt-first echo for acw chat stdout

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -175,7 +175,7 @@ autoload -Uz compinit && compinit
 - `--stdout` behavior:
   - Without `--chat`: merges provider stderr into stdout so progress and output can be piped together.
   - With `--chat`: provider stderr is appended to `.tmp/acw-sessions/<session-id>.stderr` to keep stdout clean for piping. Empty sidecar files created by `acw` are automatically removed.
-  - With `--chat --editor`: when stdout is a TTY, the editor prompt is echoed to stdout before assistant output.
+  - With `--chat --editor`: when stdout is a TTY, the user prompt is echoed immediately before provider invocation, so it appears before assistant output.
 - In file mode (no `--stdout`), provider stderr is written to `<output-file>.stderr`. Empty sidecar files are removed after the provider exits.
 
 ## See Also

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -74,7 +74,8 @@ and turn appending:
 output is captured to a temp file. After the provider exits, the captured
 content is emitted to stdout and the assistant response is appended to the
 session file. If `--editor` is used and stdout is a TTY, the editor prompt
-is echoed to stdout before the assistant output.
+is echoed to stdout before provider invocation so it appears before assistant
+output.
 
 **Stderr sidecar**: When `--stdout` is combined with `--chat`, provider stderr
 is appended to `<session-id>.stderr` beside the session file rather than

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -368,6 +368,12 @@ acw() {
         fi
     fi
 
+    if [ "$chat_mode" -eq 1 ] && [ "$stdout_mode" -eq 1 ] && [ "$use_editor" -eq 1 ] && [ -t 1 ]; then
+        echo "User Prompt:"
+        cat "$original_input_file"
+        echo ""
+    fi
+
     # Remaining arguments are provider options
     local provider_exit=0
     local stderr_file=""
@@ -452,11 +458,6 @@ acw() {
             local assistant_response=""
             if [ "$stdout_mode" -eq 1 ]; then
                 assistant_response="$chat_output_capture"
-                if [ "$use_editor" -eq 1 ] && [ -t 1 ]; then
-                    echo "User Prompt:"
-                    cat "$original_input_file"
-                    echo ""
-                fi
                 # Emit captured output to stdout
                 cat "$chat_output_capture"
             else

--- a/tests/cli/test-acw-chat.md
+++ b/tests/cli/test-acw-chat.md
@@ -24,6 +24,7 @@ End-to-end tests for `acw` chat session functionality (`--chat` and `--chat-list
 ### Stdout Capture
 - `--chat --stdout` captures and emits assistant output
 - Captured output is also appended to session file
+- `--chat --editor --stdout` on TTY echoes the user prompt before assistant output
 
 ### Stderr Sidecar (--chat --stdout)
 - Provider stderr is written to `<session-id>.stderr` sidecar file


### PR DESCRIPTION
Prompt-first echo for acw chat stdout

## Summary
- echo chat editor prompt before provider invocation on TTY stdout
- document prompt timing in acw CLI docs
- cover TTY prompt ordering in chat stdout tests

Issue 800 resolved.

## Testing
- make test-fast TEST_SHELLS="bash zsh"

closes #800
