### PR TITLE
Add Response header for acw TTY stdout

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -175,7 +175,7 @@ autoload -Uz compinit && compinit
 - `--stdout` behavior:
   - Without `--chat`: merges provider stderr into stdout so progress and output can be piped together.
   - With `--chat`: provider stderr is appended to `.tmp/acw-sessions/<session-id>.stderr` to keep stdout clean for piping. Empty sidecar files created by `acw` are automatically removed.
-  - With `--chat --editor`: when stdout is a TTY, the user prompt is echoed immediately before provider invocation, so it appears before assistant output.
+  - With `--chat --editor`: when stdout is a TTY, the user prompt is echoed immediately before provider invocation, followed by a `Response:` header before assistant output.
 - In file mode (no `--stdout`), provider stderr is written to `<output-file>.stderr`. Empty sidecar files are removed after the provider exits.
 
 ## See Also

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -74,8 +74,8 @@ and turn appending:
 output is captured to a temp file. After the provider exits, the captured
 content is emitted to stdout and the assistant response is appended to the
 session file. If `--editor` is used and stdout is a TTY, the editor prompt
-is echoed to stdout before provider invocation so it appears before assistant
-output.
+is echoed to stdout before provider invocation, followed by a `Response:`
+header so it appears before assistant output.
 
 **Stderr sidecar**: When `--stdout` is combined with `--chat`, provider stderr
 is appended to `<session-id>.stderr` beside the session file rather than

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -372,6 +372,7 @@ acw() {
         echo "User Prompt:"
         cat "$original_input_file"
         echo ""
+        echo "Response:"
     fi
 
     # Remaining arguments are provider options

--- a/tests/cli/test-acw-flags.md
+++ b/tests/cli/test-acw-flags.md
@@ -36,7 +36,7 @@ Validate `acw` flag behavior for `--editor`, `--stdout`, and file-mode stderr ca
 
 ### chat_editor_stdout_tty_echo
 **Purpose**: `--chat --editor --stdout` echoes the editor prompt when stdout is a TTY.
-**Expected**: Output includes `User Prompt:` and editor content before assistant output.
+**Expected**: Output includes `User Prompt:` and editor content, then `Response:` before assistant output.
 
 ### chat_editor_stdout_non_tty_no_echo
 **Purpose**: `--chat --editor --stdout` keeps stdout assistant-only when stdout is not a TTY.


### PR DESCRIPTION
Add Response header for acw TTY stdout

## Summary
- emit a Response header between the echoed editor prompt and assistant output on TTY stdout
- document the TTY stdout Response header behavior in acw CLI and dispatch docs
- update the TTY stdout test expectations for Response header ordering
- Issue 798 resolved

## Testing
- bash tests/cli/test-acw-flags.sh

closes #798
