### PR TITLE
Create and document agentize:plan label fallback

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -150,7 +150,7 @@ Runs the full multi-agent debate pipeline for a feature description, producing a
 | `--editor` | No | - | Open $EDITOR to compose feature description; when combined with `--refine`, the editor text becomes the refinement focus |
 | `--refine <issue-no> [refinement-instructions]` | No | - | Refine an existing plan issue; if positional instructions are provided with `--editor`, they are appended after the editor text |
 
-By default, `lol plan` creates a GitHub issue when `gh` is available. Use `--dry-run` to skip issue creation and use timestamp-based artifact naming instead.
+By default, `lol plan` creates a GitHub issue when `gh` is available and applies the `agentize:plan` label (creating it on demand if missing). Use `--dry-run` to skip issue creation and use timestamp-based artifact naming instead.
 `--editor` requires `$EDITOR` to be set; if it is not, pass the description directly (for example, `lol plan "Add JWT auth"`).
 
 When `--refine` is set, the issue body is fetched from GitHub and used as the debate context. Optional refinement instructions are appended to the context to guide the agents. Refinement runs write artifacts prefixed with `issue-refine-<N>` and update the existing issue unless `--dry-run` is provided. This mode requires authenticated `gh` access to read the issue body.

--- a/docs/cli/planner.md
+++ b/docs/cli/planner.md
@@ -51,7 +51,7 @@ Stage-specific keys override `planner.backend`. Defaults remain `claude:sonnet` 
 
 ### Default Issue Creation
 
-By default, `lol plan` creates a placeholder GitHub issue before the pipeline runs using a truncated placeholder title (`[plan] placeholder: <first 50 chars>...`), and uses `issue-{N}` artifact naming. After the consensus stage completes, the issue body is updated with the final plan plus a trailing provenance footer (`Plan based on commit <hash>`), the title is set from the first `Implementation Plan:` or `Consensus Plan:` header in the consensus file (fallback: truncated feature description), and the `agentize:plan` label is applied.
+By default, `lol plan` creates a placeholder GitHub issue before the pipeline runs using a truncated placeholder title (`[plan] placeholder: <first 50 chars>...`), and uses `issue-{N}` artifact naming. After the consensus stage completes, the issue body is updated with the final plan plus a trailing provenance footer (`Plan based on commit <hash>`), the title is set from the first `Implementation Plan:` or `Consensus Plan:` header in the consensus file (fallback: truncated feature description), and the `agentize:plan` label is applied (created on demand if missing).
 
 When `--refine` is used, no placeholder issue is created. The issue body is fetched and reused as debate context, and the issue is updated in-place after the consensus stage (unless `--dry-run` is set).
 

--- a/src/cli/planner/github.md
+++ b/src/cli/planner/github.md
@@ -11,8 +11,8 @@ Legacy GitHub issue helpers for default issue creation and refine mode. The Pyth
 | `_planner_gh_available` | Check if `gh` CLI is installed and authenticated |
 | `_planner_issue_create` | Create a placeholder GitHub issue with `[plan] placeholder:` and a truncated feature title |
 | `_planner_issue_fetch` | Fetch issue body (and URL) for refinement runs |
-| `_planner_issue_publish` | Update issue body with consensus plan and add `agentize:plan` label |
+| `_planner_issue_publish` | Update issue body with consensus plan, apply `agentize:plan`, and create/retry once if the label is missing |
 
 ## Design Rationale
 
-GitHub interactions remain isolated here to document the historical shell workflow and provide a fallback implementation when needed. The current `lol plan` execution path uses the Python backend for issue handling, but the same behaviors (placeholder creation, refinement fetch, and label application) are preserved in the new implementation.
+GitHub interactions remain isolated here to document the historical shell workflow and provide a fallback implementation when needed. The current `lol plan` execution path uses the Python backend for issue handling, but the same behaviors (placeholder creation, refinement fetch, and best-effort label application with create-if-missing retry) are preserved in the new implementation.

--- a/src/cli/planner/github.sh
+++ b/src/cli/planner/github.sh
@@ -111,8 +111,16 @@ _planner_issue_publish() {
     local label_exit=$?
 
     if [ $label_exit -ne 0 ]; then
-        echo "Warning: Failed to add agentize:plan label to issue #$issue_number" >&2
-        # Non-fatal: body was already updated
+        gh label create "agentize:plan" \
+            --color "1d76db" \
+            --description "Agentize plan placeholder" >/dev/null 2>&1
+        gh issue edit "$issue_number" \
+            --add-label "agentize:plan" >/dev/null 2>&1
+        label_exit=$?
+        if [ $label_exit -ne 0 ]; then
+            echo "Warning: Failed to add agentize:plan label to issue #$issue_number" >&2
+            # Non-fatal: body was already updated
+        fi
     fi
 
     return 0


### PR DESCRIPTION
Create and document agentize:plan label fallback

Summary:
- Add a create-and-retry fallback for applying the agentize:plan label during planner issue publish.
- Document on-demand label creation behavior in planner and lol CLI docs.

Tests:
- make test-fast TEST_SHELLS="bash zsh"

Issue 795 resolved

closes #795
