### PR TITLE
Add kimi provider support to acw

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -13,13 +13,13 @@ acw --help
 
 ## Description
 
-`acw` provides a consistent interface for invoking different AI CLI tools (claude, codex, opencode, cursor/agent) with file-based input/output. Optional flags allow editor-based input and stdout output while preserving the default file-based workflow. Python workflows wrap `acw` through `agentize.workflow.api.acw` to preserve the same invocation semantics and timing logs.
+`acw` provides a consistent interface for invoking different AI CLI tools (claude, codex, opencode, cursor/agent, kimi) with file-based input/output. Optional flags allow editor-based input and stdout output while preserving the default file-based workflow. Python workflows wrap `acw` through `agentize.workflow.api.acw` to preserve the same invocation semantics and timing logs.
 
 ## Arguments
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `cli-name` | Yes | Provider name: `claude`, `codex`, `opencode`, `cursor` |
+| `cli-name` | Yes | Provider name: `claude`, `codex`, `opencode`, `cursor`, `kimi` |
 | `model-name` | Yes | Model identifier passed to the provider |
 | `input-file` | Conditional | Path to file containing the prompt (required unless `--editor` is used) |
 | `output-file` | Conditional | Path where response will be written (required unless `--stdout` is used) |
@@ -44,6 +44,7 @@ acw --help
 | `codex` | `codex` | Full support |
 | `opencode` | `opencode` | Best-effort |
 | `cursor` | `agent` | Best-effort |
+| `kimi` | `kimi` | Best-effort |
 
 ## Exit Codes
 
@@ -68,6 +69,9 @@ acw claude claude-sonnet-4-20250514 prompt.txt response.txt
 
 # Invoke Codex
 acw codex gpt-4o prompt.txt response.txt
+
+# Invoke Kimi
+acw kimi kimi-model prompt.txt response.txt
 
 # Pass additional options to the provider
 acw claude claude-sonnet-4-20250514 prompt.txt response.txt --max-tokens 4096
@@ -152,7 +156,7 @@ Use `acw --complete <topic>` to get completion values programmatically:
 
 | Topic | Description |
 |-------|-------------|
-| `providers` | List of supported providers (claude, codex, opencode, cursor) |
+| `providers` | List of supported providers (claude, codex, opencode, cursor, kimi) |
 | `cli-options` | Common CLI options (e.g., --help, --editor, --stdout, --model, --max-tokens, --yolo) |
 
 ### Setup
@@ -169,7 +173,7 @@ autoload -Uz compinit && compinit
 - The output directory is created automatically if it doesn't exist (skipped when `--stdout` is used)
 - Provider-specific options are passed through unchanged, except `--yolo` is normalized to Claude's `--dangerously-skip-permissions`
 - The wrapper returns the provider's exit code on successful execution
-- Best-effort providers (opencode, cursor) may have limited functionality
+- Best-effort providers (opencode, cursor, kimi) may have limited functionality
 - Only `acw` is the public function; all helper functions (provider invocation, completion, validation) are internal (prefixed with `_acw_`) and won't appear in tab completion
 - `acw` flags must appear before `cli-name`. Use `--` to pass provider options that collide with `acw` flags.
 - `--stdout` behavior:

--- a/docs/feat/cli/README.md
+++ b/docs/feat/cli/README.md
@@ -11,7 +11,7 @@ These documents provide comprehensive command-line interface specifications, inc
 ## Files
 
 ### acw.md
-The `acw` command for unified AI CLI invocation. See [docs/cli/acw.md](../../cli/acw.md) for interface documentation. Provides file-based input/output for claude, codex, opencode, and cursor CLIs.
+The `acw` command for unified AI CLI invocation. See [docs/cli/acw.md](../../cli/acw.md) for interface documentation. Provides file-based input/output for claude, codex, opencode, cursor, and kimi CLIs.
 
 ### install.md
 The `install` script for one-command Agentize installation. Documents installation flow (clone, worktree init, setup), command-line options (--dir, --repo, --help), post-install shell RC integration, and troubleshooting.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -11,7 +11,7 @@ Source-first libraries for Agentize CLI commands. These files are the canonical 
 - `acw.sh` - Agent CLI Wrapper library (canonical source, thin loader)
   - Sources modular files from `acw/` directory
   - Exports `acw` command for unified AI CLI invocation
-  - Handles providers: `claude`, `codex`, `opencode`, `cursor`
+  - Handles providers: `claude`, `codex`, `opencode`, `cursor`, `kimi`
   - Interface documentation: `acw.md`
 
 - `planner.sh` - Planner pipeline library (internal; used by `lol plan`)

--- a/src/cli/acw.md
+++ b/src/cli/acw.md
@@ -50,6 +50,7 @@ All helper functions are prefixed with `_acw_` to prevent tab-completion polluti
 - `_acw_invoke_codex` - Invokes Codex CLI
 - `_acw_invoke_opencode` - Invokes Opencode CLI
 - `_acw_invoke_cursor` - Invokes Cursor/Agent CLI
+- `_acw_invoke_kimi` - Invokes Kimi CLI
 
 **Completion function:**
 - `_acw_complete` - Returns completion values for shell integration

--- a/src/cli/acw/README.md
+++ b/src/cli/acw/README.md
@@ -9,7 +9,7 @@ Modular implementation of the Agent CLI Wrapper (`acw`) command.
 | File | Dependencies | Exports |
 |------|--------------|---------|
 | `helpers.sh` | None | Validation helpers (`_acw_validate_args`, `_acw_check_cli`, `_acw_ensure_output_dir`, `_acw_check_input_file`) and chat session helpers (`_acw_chat_*`) (private) |
-| `providers.sh` | `helpers.sh` | `_acw_invoke_claude`, `_acw_invoke_codex`, `_acw_invoke_opencode`, `_acw_invoke_cursor` (private) |
+| `providers.sh` | `helpers.sh` | `_acw_invoke_claude`, `_acw_invoke_codex`, `_acw_invoke_opencode`, `_acw_invoke_cursor`, `_acw_invoke_kimi` (private) |
 | `completion.sh` | None | `_acw_complete` (private) |
 | `dispatch.sh` | `helpers.sh`, `providers.sh`, `completion.sh` | `acw` (public); orchestrates chat session creation, continuation, and history prepending |
 
@@ -47,6 +47,7 @@ acw.sh (thin loader)
     |     +-- _acw_invoke_codex()
     |     +-- _acw_invoke_opencode()
     |     +-- _acw_invoke_cursor()
+    |     +-- _acw_invoke_kimi()
     |
     +-- completion.sh (private)
     |     +-- _acw_complete()
@@ -64,6 +65,7 @@ acw.sh (thin loader)
 | codex | `codex` | `< file` | `> file` | Full |
 | opencode | `opencode` | TBD | TBD | Best-effort |
 | cursor | `agent` | TBD | TBD | Best-effort |
+| kimi | `kimi` | `< file` (`--print`) | `> file` | Best-effort |
 
 ## Conventions
 

--- a/src/cli/acw/completion.md
+++ b/src/cli/acw/completion.md
@@ -10,7 +10,7 @@ completion systems.
 ### _acw_complete <topic>
 
 **Topics**:
-- `providers`: Lists supported providers (`claude`, `codex`, `opencode`, `cursor`).
+- `providers`: Lists supported providers (`claude`, `codex`, `opencode`, `cursor`, `kimi`).
 - `cli-options`: Lists common CLI options (`--help`, `--chat`, `--chat-list`,
   `--editor`, `--stdout`, `--model`, `--max-tokens`, `--yolo`).
 

--- a/src/cli/acw/completion.sh
+++ b/src/cli/acw/completion.sh
@@ -13,6 +13,7 @@ _acw_complete() {
             echo "codex"
             echo "opencode"
             echo "cursor"
+            echo "kimi"
             ;;
         cli-options)
             echo "--help"

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -14,7 +14,7 @@ acw --chat-list
 ```
 
 **Parameters**:
-- `cli-name`: Provider identifier (`claude`, `codex`, `opencode`, `cursor`)
+- `cli-name`: Provider identifier (`claude`, `codex`, `opencode`, `cursor`, `kimi`)
 - `model-name`: Model identifier passed to the provider
 - `input-file`: Prompt file path (required unless `--editor` is used)
 - `output-file`: Response file path (required unless `--stdout` is used)

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -31,7 +31,7 @@ Usage:
   acw --help
 
 Arguments:
-  cli-name      Provider: claude, codex, opencode, cursor
+  cli-name      Provider: claude, codex, opencode, cursor, kimi
   model-name    Model identifier for the provider
   input-file    Path to file containing the prompt (unless --editor is used)
   output-file   Path where response will be written (unless --stdout is used)
@@ -50,6 +50,7 @@ Providers:
   codex         OpenAI Codex CLI (full support)
   opencode      Opencode CLI (best-effort)
   cursor        Cursor Agent CLI (best-effort)
+  kimi          Kimi CLI (best-effort)
 
 Exit Codes:
   0   Success
@@ -131,7 +132,7 @@ acw() {
                 # Check if next arg looks like a session ID (not a flag, not a known provider)
                 if [ $# -gt 0 ] && [ "${1:0:1}" != "-" ]; then
                     case "$1" in
-                        claude|codex|opencode|cursor)
+                        claude|codex|opencode|cursor|kimi)
                             # This is the cli-name, not a session ID
                             ;;
                         *)
@@ -227,12 +228,12 @@ acw() {
 
     # Check if provider is known
     case "$cli_name" in
-        claude|codex|opencode|cursor)
+        claude|codex|opencode|cursor|kimi)
             # Valid provider
             ;;
         *)
             echo "Error: Unknown provider '$cli_name'" >&2
-            echo "Supported providers: claude, codex, opencode, cursor" >&2
+            echo "Supported providers: claude, codex, opencode, cursor, kimi" >&2
             return 2
             ;;
     esac
@@ -441,6 +442,20 @@ acw() {
                     _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
                 else
                     _acw_invoke_cursor "$model_name" "$input_file" "$output_file" "$@"
+                fi
+            fi
+            provider_exit=$?
+            ;;
+        kimi)
+            if [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 0 ]; then
+                _acw_invoke_kimi "$model_name" "$input_file" "$output_file" "$@" 2>&1
+            elif [ "$stdout_mode" -eq 1 ] && [ "$chat_mode" -eq 1 ]; then
+                _acw_invoke_kimi "$model_name" "$input_file" "$output_file" "$@" 2>>"$stderr_file"
+            else
+                if [ -n "$stderr_file" ]; then
+                    _acw_invoke_kimi "$model_name" "$input_file" "$output_file" "$@" 2>"$stderr_file"
+                else
+                    _acw_invoke_kimi "$model_name" "$input_file" "$output_file" "$@"
                 fi
             fi
             provider_exit=$?

--- a/src/cli/acw/helpers.sh
+++ b/src/cli/acw/helpers.sh
@@ -55,6 +55,9 @@ _acw_check_cli() {
         cursor)
             binary="agent"
             ;;
+        kimi)
+            binary="kimi"
+            ;;
         *)
             echo "Error: Unknown provider '$cli_name'" >&2
             return 2

--- a/src/cli/acw/providers.md
+++ b/src/cli/acw/providers.md
@@ -1,0 +1,38 @@
+# providers.sh
+
+## Purpose
+
+Provider-specific invocation functions for `acw`. Each function adapts the
+file-based input/output contract to a provider CLI while keeping stderr
+passthrough for progress messages.
+
+## External Interface
+
+These functions are internal to the `acw` module (prefixed with `_acw_`) but
+serve as the provider invocation surface for the dispatcher.
+
+### _acw_invoke_claude <model> <input> <output> [options...]
+- Reads the prompt from `input` and writes the response to `output`.
+- Normalizes `--yolo` to `--dangerously-skip-permissions`.
+- Returns the Claude CLI exit code.
+
+### _acw_invoke_codex <model> <input> <output> [options...]
+- Reads the prompt from `input` via stdin and writes the response to `output`.
+- Returns the Codex CLI exit code.
+
+### _acw_invoke_opencode <model> <input> <output> [options...]
+- Reads the prompt from `input` via stdin and writes the response to `output`.
+- Returns the Opencode CLI exit code.
+
+### _acw_invoke_cursor <model> <input> <output> [options...]
+- Reads the prompt from `input` via stdin and writes the response to `output`.
+- Returns the Cursor/Agent CLI exit code.
+
+### _acw_invoke_kimi <model> <input> <output> [options...]
+- Runs Kimi in print mode for non-interactive execution.
+- Reads the prompt from `input` via stdin and writes the response to `output`.
+- Returns the Kimi CLI exit code.
+
+## Internal Helpers
+
+None. Each provider function encapsulates its own CLI-specific invocation.

--- a/src/cli/acw/providers.sh
+++ b/src/cli/acw/providers.sh
@@ -78,3 +78,18 @@ _acw_invoke_cursor() {
     # stderr passes through for progress messages
     agent --model "$model" "$@" < "$input" > "$output"
 }
+
+# Invoke Kimi CLI (best-effort)
+# Usage: _acw_invoke_kimi <model> <input> <output> [options...]
+# I/O: stdout -> output file, stderr -> passthrough (progress messages visible)
+# Returns: kimi exit code
+_acw_invoke_kimi() {
+    local model="$1"
+    local input="$2"
+    local output="$3"
+    shift 3
+
+    # Kimi uses print mode for non-interactive runs; prompt is read from stdin.
+    # stderr passes through for progress messages
+    kimi --print --model "$model" "$@" < "$input" > "$output"
+}

--- a/src/completion/_acw
+++ b/src/completion/_acw
@@ -21,6 +21,7 @@ _acw() {
             'codex:OpenAI Codex CLI (full support)'
             'opencode:Opencode CLI (best-effort)'
             'cursor:Cursor Agent CLI (best-effort)'
+            'kimi:Kimi CLI (best-effort)'
         )
     else
         # Add descriptions to dynamically fetched providers
@@ -31,6 +32,7 @@ _acw() {
                 codex) providers_with_desc+=('codex:OpenAI Codex CLI (full support)') ;;
                 opencode) providers_with_desc+=('opencode:Opencode CLI (best-effort)') ;;
                 cursor) providers_with_desc+=('cursor:Cursor Agent CLI (best-effort)') ;;
+                kimi) providers_with_desc+=('kimi:Kimi CLI (best-effort)') ;;
                 *) providers_with_desc+=("$provider") ;;
             esac
         done

--- a/tests/cli/test-acw-command-functions-loaded.sh
+++ b/tests/cli/test-acw-command-functions-loaded.sh
@@ -26,6 +26,7 @@ EXPECTED_PRIVATE_FUNCTIONS=(
     "_acw_invoke_codex"
     "_acw_invoke_opencode"
     "_acw_invoke_cursor"
+    "_acw_invoke_kimi"
     "_acw_complete"
 )
 
@@ -56,6 +57,7 @@ OLD_HELPER_NAMES=(
     "acw_invoke_codex"
     "acw_invoke_opencode"
     "acw_invoke_cursor"
+    "acw_invoke_kimi"
     "acw_complete"
 )
 

--- a/tests/cli/test-acw-completion.sh
+++ b/tests/cli/test-acw-completion.sh
@@ -15,7 +15,7 @@ source "$ACW_CLI"
 test_info "Checking --complete providers"
 providers_output=$(acw --complete providers)
 
-for provider in claude codex opencode cursor; do
+for provider in claude codex opencode cursor kimi; do
     if ! echo "$providers_output" | grep -q "^${provider}$"; then
         test_fail "Provider '$provider' not found in --complete providers output"
     fi

--- a/tests/cli/test-acw-help-text.sh
+++ b/tests/cli/test-acw-help-text.sh
@@ -23,6 +23,9 @@ echo "$output" | grep -q "claude" || test_fail "Usage text missing 'claude' prov
 # Verify usage text includes codex provider
 echo "$output" | grep -q "codex" || test_fail "Usage text missing 'codex' provider"
 
+# Verify usage text includes kimi provider
+echo "$output" | grep -q "kimi" || test_fail "Usage text missing 'kimi' provider"
+
 # Verify usage text includes --help flag
 echo "$output" | grep -q "\-\-help" || test_fail "Usage text missing '--help' flag"
 

--- a/tests/cli/test-lol-impl-stubbed.sh
+++ b/tests/cli/test-lol-impl-stubbed.sh
@@ -116,6 +116,7 @@ claude
 codex
 opencode
 cursor
+kimi
 EOF
         return 0
     fi

--- a/tests/cli/test-lol-plan-github-stubbed.sh
+++ b/tests/cli/test-lol-plan-github-stubbed.sh
@@ -87,6 +87,7 @@ claude
 codex
 opencode
 cursor
+kimi
 EOF
         return 0
     fi

--- a/tests/cli/test-lol-plan-issue-mode.sh
+++ b/tests/cli/test-lol-plan-issue-mode.sh
@@ -95,6 +95,7 @@ claude
 codex
 opencode
 cursor
+kimi
 EOF
         return 0
     fi

--- a/tests/cli/test-lol-plan-pipeline-stubbed.sh
+++ b/tests/cli/test-lol-plan-pipeline-stubbed.sh
@@ -44,6 +44,7 @@ claude
 codex
 opencode
 cursor
+kimi
 EOF
         return 0
     fi


### PR DESCRIPTION
Add kimi provider support to acw

Summary:
- Add Kimi provider dispatch and invocation in acw.
- Update provider documentation and completion entries to include Kimi.
- Refresh acw-related tests and planner stubs for the new provider list.

Testing:
- bash tests/cli/test-acw-help-text.sh
- bash tests/cli/test-acw-completion.sh
- bash tests/cli/test-acw-command-functions-loaded.sh
- bash tests/cli/test-lol-impl-stubbed.sh
- bash tests/cli/test-lol-plan-issue-mode.sh
- bash tests/cli/test-lol-plan-github-stubbed.sh
- bash tests/cli/test-lol-plan-pipeline-stubbed.sh

Issue 823 resolved
closes #823
