### PR TITLE
Ignore Kimi model-name in acw

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -20,7 +20,7 @@ acw --help
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `cli-name` | Yes | Provider name: `claude`, `codex`, `opencode`, `cursor`, `kimi` |
-| `model-name` | Yes | Model identifier passed to the provider |
+| `model-name` | Yes | Model identifier passed to the provider (Kimi ignores this and uses its default model) |
 | `input-file` | Conditional | Path to file containing the prompt (required unless `--editor` is used) |
 | `output-file` | Conditional | Path where response will be written (required unless `--stdout` is used) |
 | `cli-options` | No | Additional options passed to the provider CLI |
@@ -70,8 +70,8 @@ acw claude claude-sonnet-4-20250514 prompt.txt response.txt
 # Invoke Codex
 acw codex gpt-4o prompt.txt response.txt
 
-# Invoke Kimi
-acw kimi kimi-model prompt.txt response.txt
+# Invoke Kimi (model-name is ignored; Kimi uses its default)
+acw kimi default prompt.txt response.txt
 
 # Pass additional options to the provider
 acw claude claude-sonnet-4-20250514 prompt.txt response.txt --max-tokens 4096
@@ -137,7 +137,7 @@ The capital of France is Paris.
 
 1. **New session**: `acw --chat` creates a session file, prints its ID, and runs the first turn.
 2. **Continue session**: `acw --chat <id>` prepends the session history to the current input and appends the new turn after the provider responds.
-3. **List sessions**: `acw --chat-list` lists session IDs with provider, model, and creation date.
+3. **List sessions**: `acw --chat-list` lists session IDs with provider, model label, and creation date. Kimi sessions store `model: default` to reflect provider defaults.
 
 ## Environment Variables
 
@@ -158,6 +158,8 @@ Use `acw --complete <topic>` to get completion values programmatically:
 |-------|-------------|
 | `providers` | List of supported providers (claude, codex, opencode, cursor, kimi) |
 | `cli-options` | Common CLI options (e.g., --help, --editor, --stdout, --model, --max-tokens, --yolo) |
+
+Kimi ignores `<model-name>`, so provider completions still include `--model` for other CLIs while Kimi uses its default model.
 
 ### Setup
 

--- a/src/cli/acw/completion.md
+++ b/src/cli/acw/completion.md
@@ -12,7 +12,8 @@ completion systems.
 **Topics**:
 - `providers`: Lists supported providers (`claude`, `codex`, `opencode`, `cursor`, `kimi`).
 - `cli-options`: Lists common CLI options (`--help`, `--chat`, `--chat-list`,
-  `--editor`, `--stdout`, `--model`, `--max-tokens`, `--yolo`).
+  `--editor`, `--stdout`, `--model`, `--max-tokens`, `--yolo`). Kimi ignores the
+  model name and does not receive `--model` during invocation.
 
 **Output**:
 - Prints one value per line to stdout.

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -15,7 +15,8 @@ acw --chat-list
 
 **Parameters**:
 - `cli-name`: Provider identifier (`claude`, `codex`, `opencode`, `cursor`, `kimi`)
-- `model-name`: Model identifier passed to the provider
+- `model-name`: Model identifier passed to the provider (Kimi ignores this and
+  uses its default model)
 - `input-file`: Prompt file path (required unless `--editor` is used)
 - `output-file`: Response file path (required unless `--stdout` is used)
 - `options...`: Provider-specific options passed through unchanged
@@ -65,8 +66,9 @@ values following flags and allows positional values after `--`.
 In chat mode, the dispatcher orchestrates session creation, history prepending,
 and turn appending:
 
-1. **New session**: Creates a session file with YAML front matter, prepends an
-   empty history, runs the provider, and appends the first turn.
+1. **New session**: Creates a session file with YAML front matter (Kimi stores
+   `model: default`), prepends an empty history, runs the provider, and appends
+   the first turn.
 2. **Continue session**: Validates the session file, prepends existing history
    to a combined temp file, runs the provider, and appends the new turn.
 

--- a/src/cli/acw/dispatch.sh
+++ b/src/cli/acw/dispatch.sh
@@ -351,7 +351,11 @@ acw() {
             fi
 
             session_file=$(_acw_chat_session_path "$chat_session_id")
-            _acw_chat_create_session "$session_file" "$cli_name" "$model_name"
+            local session_model="$model_name"
+            if [ "$cli_name" = "kimi" ]; then
+                session_model="default"
+            fi
+            _acw_chat_create_session "$session_file" "$cli_name" "$session_model"
 
             # Print session ID to stderr
             echo "Session: $chat_session_id" >&2

--- a/src/cli/acw/helpers.md
+++ b/src/cli/acw/helpers.md
@@ -36,7 +36,9 @@ Validates base62 characters (a-z, A-Z, 0-9) and length 8-12. Returns non-zero
 on failure.
 
 ### _acw_chat_create_session <path> <provider> <model>
-Writes YAML front matter with `provider`, `model`, and `created` (UTC ISO-8601).
+Writes YAML front matter with `provider`, a model label, and `created` (UTC
+ISO-8601). For Kimi sessions, the model label should be `default` because the
+provider ignores the user-supplied model name.
 
 ### _acw_chat_validate_session_file <path>
 Checks that file exists, begins with `---`, ends header with `---`, and contains
@@ -58,5 +60,5 @@ Appends a turn to the session file:
 5. Ensure trailing newline.
 
 ### _acw_chat_list_sessions()
-Lists `*.md` files in session dir and prints `id`, `provider`, `model`, `created`
-(best-effort from header).
+Lists `*.md` files in session dir and prints `id`, `provider`, model label, and
+`created` (best-effort from header).

--- a/src/cli/acw/providers.md
+++ b/src/cli/acw/providers.md
@@ -31,6 +31,7 @@ serve as the provider invocation surface for the dispatcher.
 ### _acw_invoke_kimi <model> <input> <output> [options...]
 - Runs Kimi in print mode for non-interactive execution.
 - Reads the prompt from `input` via stdin and writes the response to `output`.
+- Ignores the `model` argument and lets Kimi select its default model.
 - Returns the Kimi CLI exit code.
 
 ## Internal Helpers

--- a/src/cli/acw/providers.sh
+++ b/src/cli/acw/providers.sh
@@ -90,6 +90,7 @@ _acw_invoke_kimi() {
     shift 3
 
     # Kimi uses print mode for non-interactive runs; prompt is read from stdin.
+    # The model argument is ignored so Kimi uses its default model.
     # stderr passes through for progress messages
-    kimi --print --model "$model" "$@" < "$input" > "$output"
+    kimi --print "$@" < "$input" > "$output"
 }

--- a/tests/cli/test-acw-completion.sh
+++ b/tests/cli/test-acw-completion.sh
@@ -25,6 +25,7 @@ done
 test_info "Checking --complete cli-options"
 options_output=$(acw --complete cli-options)
 
+# --model remains in completions for providers that accept it; Kimi ignores the model name.
 for option in "--help" "--chat" "--chat-list" "--editor" "--stdout" "--model" "--max-tokens" "--yolo"; do
     if ! echo "$options_output" | grep -q "^${option}$"; then
         test_fail "Option '$option' not found in --complete cli-options output"


### PR DESCRIPTION
Ignore Kimi model-name in acw

## Summary
- stop forwarding --model to Kimi and store a default model label for Kimi chat sessions
- document Kimi model-name ignore behavior across acw docs and completion guidance
- clarify completion test rationale for --model in Kimi context

## Testing
- make test-fast TEST_SHELLS="bash zsh"

Issue 825 resolved.

closes #825
