### PR TITLE
Force Kimi stream-json output and strip assistant text

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -183,6 +183,7 @@ autoload -Uz compinit && compinit
   - With `--chat`: provider stderr is appended to `.tmp/acw-sessions/<session-id>.stderr` to keep stdout clean for piping. Empty sidecar files created by `acw` are automatically removed.
   - With `--chat --editor`: when stdout is a TTY, the user prompt is echoed immediately before provider invocation, followed by a `Response:` header before assistant output.
 - In file mode (no `--stdout`), provider stderr is written to `<output-file>.stderr`. Empty sidecar files are removed after the provider exits.
+- Kimi output is forced to `--output-format stream-json` and stripped to plain assistant text. In non-chat `--stdout` mode, merged stderr lines that are not JSON may be dropped during stripping.
 
 ## See Also
 

--- a/src/cli/acw/README.md
+++ b/src/cli/acw/README.md
@@ -65,7 +65,11 @@ acw.sh (thin loader)
 | codex | `codex` | `< file` | `> file` | Full |
 | opencode | `opencode` | TBD | TBD | Best-effort |
 | cursor | `agent` | TBD | TBD | Best-effort |
-| kimi | `kimi` | `< file` (`--print`) | `> file` | Best-effort |
+| kimi | `kimi` | `< file` (`--print`) | `> file` (stream-json stripped) | Best-effort |
+
+## Runtime Dependencies
+
+- Kimi output normalization uses `python` (stdlib JSON) to strip stream-json into plain text.
 
 ## Conventions
 

--- a/src/cli/acw/dispatch.md
+++ b/src/cli/acw/dispatch.md
@@ -43,6 +43,21 @@ acw --chat-list
 - Emits argument or validation errors to stderr with non-zero exit codes as
   documented in `acw.md`.
 
+## Kimi Output Normalization
+
+Kimi is forced to stream JSON. The dispatcher captures raw output, extracts
+`content[].type == "text"` segments, and writes clean assistant text to the
+final output destination (file or stdout).
+
+Normalization flow:
+1. Attempt to parse the full payload as JSON.
+2. If that fails, parse each line as NDJSON.
+3. Concatenate all `text` fragments in order.
+4. If nothing parses, fall back to the raw payload.
+
+In non-chat `--stdout` mode, stderr is merged into the stream before stripping,
+so non-JSON stderr lines may be dropped when Kimi output is normalized.
+
 ## Internal Helpers
 
 ### _acw_usage()
@@ -60,6 +75,11 @@ when git metadata is unavailable.
 ### _acw_validate_no_positional_args()
 Ensures editor/stdout modes do not accept extra positional arguments. Allows
 values following flags and allows positional values after `--`.
+
+### _acw_kimi_strip_output()
+Strips Kimi stream-json output into plain assistant text. Uses Python to parse
+either a full JSON payload or NDJSON and falls back to raw output when parsing
+fails or yields no text segments.
 
 ## Chat Mode
 

--- a/src/cli/acw/providers.md
+++ b/src/cli/acw/providers.md
@@ -30,6 +30,7 @@ serve as the provider invocation surface for the dispatcher.
 
 ### _acw_invoke_kimi <model> <input> <output> [options...]
 - Runs Kimi in print mode for non-interactive execution.
+- Forces `--output-format stream-json` to normalize streaming output.
 - Reads the prompt from `input` via stdin and writes the response to `output`.
 - Ignores the `model` argument and lets Kimi select its default model.
 - Returns the Kimi CLI exit code.

--- a/src/cli/acw/providers.sh
+++ b/src/cli/acw/providers.sh
@@ -92,5 +92,5 @@ _acw_invoke_kimi() {
     # Kimi uses print mode for non-interactive runs; prompt is read from stdin.
     # The model argument is ignored so Kimi uses its default model.
     # stderr passes through for progress messages
-    kimi --print "$@" < "$input" > "$output"
+    kimi --print --output-format stream-json "$@" < "$input" > "$output"
 }

--- a/tests/cli/test-acw-flags.md
+++ b/tests/cli/test-acw-flags.md
@@ -30,6 +30,10 @@ Validate `acw` flag behavior for `--editor`, `--stdout`, and file-mode stderr ca
 **Purpose**: Empty stderr does not leave a sidecar file.
 **Expected**: `<output-file>.stderr` is removed when provider writes no stderr.
 
+### kimi_forces_stream_json
+**Purpose**: Kimi invocation always forces stream-json output format.
+**Expected**: Stub captures `--output-format stream-json` in the Kimi arguments.
+
 ### stdout_output_file_rejected
 **Purpose**: `--stdout` rejects an output-file positional argument.
 **Expected**: Non-zero exit mentioning stdout.

--- a/tests/cli/test-acw-kimi-stripper.md
+++ b/tests/cli/test-acw-kimi-stripper.md
@@ -1,0 +1,23 @@
+# test-acw-kimi-stripper.sh
+
+## Purpose
+
+Validate Kimi stream-json output is stripped into plain assistant text for file and chat modes.
+
+## Test Cases
+
+### ndjson_stripping
+**Purpose**: NDJSON output is concatenated into plain text.
+**Expected**: Output file contains combined text fragments.
+
+### json_payload_stripping
+**Purpose**: Single JSON payload yields plain text.
+**Expected**: Output file contains the extracted text content.
+
+### mixed_line_stripping
+**Purpose**: Mixed non-JSON lines do not break stripping.
+**Expected**: Output ignores non-JSON lines and keeps extracted text.
+
+### chat_session_stripping
+**Purpose**: Chat sessions store stripped assistant text for Kimi turns.
+**Expected**: Session file and output file contain plain text without raw JSON.

--- a/tests/cli/test-acw-kimi-stripper.sh
+++ b/tests/cli/test-acw-kimi-stripper.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Test: acw Kimi stream-json stripping
+# Test 1: NDJSON input yields concatenated text
+# Test 2: JSON payload yields text
+# Test 3: Mixed non-JSON line is ignored
+# Test 4: Chat mode stores stripped assistant text
+
+source "$(dirname "$0")/../common.sh"
+
+ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
+
+test_info "acw Kimi stream-json stripping"
+
+export AGENTIZE_HOME="$PROJECT_ROOT"
+source "$ACW_CLI"
+
+TEST_HOME=$(make_temp_dir "test-acw-kimi-stripper-$$")
+TEST_BIN="$TEST_HOME/bin"
+mkdir -p "$TEST_BIN"
+
+cat > "$TEST_BIN/kimi" << 'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+case "$KIMI_MODE" in
+  ndjson)
+    printf '%s\n' '{"content":[{"type":"text","text":"Hello "}]}'
+    printf '%s\n' '{"content":[{"type":"text","text":"World"}]}'
+    ;;
+  json)
+    printf '%s\n' '{"content":[{"type":"text","text":"Solo"}]}'
+    ;;
+  mixed)
+    echo "progress line"
+    printf '%s\n' '{"content":[{"type":"text","text":"Mixed"}]}'
+    ;;
+  chat)
+    printf '%s\n' '{"content":[{"type":"text","text":"Chat reply"}]}'
+    ;;
+  *)
+    printf '%s\n' '{"content":[{"type":"text","text":"Default"}]}'
+    ;;
+esac
+STUB
+chmod +x "$TEST_BIN/kimi"
+
+export PATH="$TEST_BIN:$PATH"
+
+input_file="$TEST_HOME/input.txt"
+echo "Prompt" > "$input_file"
+
+# Test 1: NDJSON input yields concatenated text
+export KIMI_MODE="ndjson"
+output_file="$TEST_HOME/ndjson.txt"
+set +e
+acw kimi default "$input_file" "$output_file" >/dev/null 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  test_fail "Kimi NDJSON stripping should succeed"
+fi
+
+output=$(cat "$output_file")
+if [ "$output" != "Hello World" ]; then
+  test_fail "NDJSON output should be concatenated into plain text"
+fi
+
+# Test 2: JSON payload yields text
+export KIMI_MODE="json"
+output_file="$TEST_HOME/json.txt"
+set +e
+acw kimi default "$input_file" "$output_file" >/dev/null 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  test_fail "Kimi JSON stripping should succeed"
+fi
+
+output=$(cat "$output_file")
+if [ "$output" != "Solo" ]; then
+  test_fail "JSON output should be stripped to plain text"
+fi
+
+# Test 3: Mixed non-JSON line is ignored
+export KIMI_MODE="mixed"
+output_file="$TEST_HOME/mixed.txt"
+set +e
+acw kimi default "$input_file" "$output_file" >/dev/null 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  test_fail "Kimi mixed output stripping should succeed"
+fi
+
+output=$(cat "$output_file")
+if [ "$output" != "Mixed" ]; then
+  test_fail "Mixed output should ignore non-JSON lines"
+fi
+
+# Test 4: Chat mode stores stripped assistant text
+CHAT_HOME="$TEST_HOME/chat-home"
+mkdir -p "$CHAT_HOME"
+ORIGINAL_AGENTIZE_HOME="$AGENTIZE_HOME"
+export AGENTIZE_HOME="$CHAT_HOME"
+export KIMI_MODE="chat"
+chat_output="$TEST_HOME/chat-output.txt"
+chat_stderr="$TEST_HOME/chat-stderr.txt"
+set +e
+acw --chat kimi default "$input_file" "$chat_output" 2>"$chat_stderr"
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  test_fail "Kimi chat mode should succeed"
+fi
+
+session_id=$(sed -n 's/^Session: //p' "$chat_stderr" | head -n1)
+if [ -z "$session_id" ]; then
+  test_fail "Kimi chat mode should emit a session ID"
+fi
+
+session_file="$CHAT_HOME/.tmp/acw-sessions/${session_id}.md"
+if [ ! -f "$session_file" ]; then
+  test_fail "Kimi chat session file should exist"
+fi
+
+if ! grep -q "Chat reply" "$session_file"; then
+  test_fail "Kimi chat session should store stripped assistant text"
+fi
+
+if grep -q '"content"' "$session_file"; then
+  test_fail "Kimi chat session should not store raw JSON content"
+fi
+
+if ! grep -q "Chat reply" "$chat_output"; then
+  test_fail "Kimi chat output file should contain stripped text"
+fi
+
+export AGENTIZE_HOME="$ORIGINAL_AGENTIZE_HOME"
+
+test_pass "acw Kimi stream-json stripping works correctly"

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -131,8 +131,8 @@ for shell in $TEST_SHELLS; do
     FAILED_TESTS=0
 
     # Auto-discover and run tests in categorical subdirectories
-    # Notable CLI additions: test-acw-logging.sh, test-lol-use-branch.sh,
-    # test-lol-upgrade.sh, test-lol-plan-github-stubbed.sh,
+    # Notable CLI additions: test-acw-logging.sh, test-acw-kimi-stripper.sh,
+    # test-lol-use-branch.sh, test-lol-upgrade.sh, test-lol-plan-github-stubbed.sh,
     # test-lol-simp-args.sh
     for category in $CATEGORIES; do
         category_dir="$SCRIPT_DIR/$category"


### PR DESCRIPTION
Force Kimi stream-json output and strip assistant text

## Summary
- Force Kimi to emit stream-json and strip assistant text for stdout/file outputs.
- Normalize Kimi output parsing for JSON/NDJSON with safe fallback.
- Add Kimi stripping tests plus updated CLI documentation.

## Tests
- TEST_SHELLS="bash zsh" make test-fast

Issue 830 resolved
closes #830
