### PR TITLE
Simp report gate and issue publish for lol simp

### DIFF
--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -199,16 +199,21 @@ See [planner pipeline module](planner.md) for pipeline stage details and artifac
 Simplify code without changing semantics.
 
 ```bash
-lol simp [file]
+lol simp [file] [--issue <issue-no>]
 ```
 
 If `file` is provided, the workflow focuses on that file. When omitted, the
 workflow selects a small random set of tracked files (`git ls-files`) and
 records the selection in `.tmp/simp-targets.txt` for reproducibility.
 
+The simplification report must start with `Yes.` or `No.`. The report is always
+written to `.tmp/simp-output.md` and the local path is logged. When the report
+starts with `Yes.` and `--issue` is provided, the report is published to the
+specified issue.
+
 Artifacts are written under `.tmp/`:
 - `.tmp/simp-input.md` - Rendered prompt with selected file contents
-- `.tmp/simp-output.md` - Simplification output
+- `.tmp/simp-output.md` - Simplification report (starts with `Yes.` or `No.`)
 - `.tmp/simp-targets.txt` - Selected file list
 
 ### lol impl

--- a/python/agentize/cli.md
+++ b/python/agentize/cli.md
@@ -21,7 +21,7 @@ The Python CLI supports the same commands as the shell implementation:
 | `claude-clean` | Remove stale project entries from `~/.claude.json` |
 | `version` | Display version information |
 | `impl` | Issue-to-implementation loop (Python workflow) |
-| `simp` | Simplify code without changing semantics |
+| `simp` | Simplify code without changing semantics (optional issue publish) |
 
 ## Top-level Flags
 
@@ -72,6 +72,10 @@ python -m agentize.cli claude-clean
 python -m agentize.cli usage --cache
 python -m agentize.cli usage --cost
 python -m agentize.cli usage --week --cache --cost
+
+# Simplify and publish to an issue when the report starts with Yes.
+python -m agentize.cli simp --issue 123
+python -m agentize.cli simp README.md --issue 123
 ```
 
 ## Related Documentation

--- a/python/agentize/cli.py
+++ b/python/agentize/cli.py
@@ -99,7 +99,7 @@ def handle_impl(args: argparse.Namespace) -> int:
 def handle_simp(args: argparse.Namespace) -> int:
     """Handle simp command."""
     try:
-        run_simp_workflow(args.file)
+        run_simp_workflow(args.file, issue_number=args.issue)
         return 0
     except (SimpError, ValueError) as e:
         print(str(e), file=sys.stderr)
@@ -237,6 +237,11 @@ def main() -> int:
         "simp", help="Simplify code without changing semantics"
     )
     simp_parser.add_argument("file", nargs="?", help="Optional file to simplify")
+    simp_parser.add_argument(
+        "--issue",
+        type=int,
+        help="Issue number to publish the report when approved",
+    )
 
     # version command
     subparsers.add_parser("version", help="Display version information")

--- a/python/agentize/workflow/__init__.md
+++ b/python/agentize/workflow/__init__.md
@@ -145,21 +145,25 @@ def run_simp_workflow(
     backend: str = "codex:gpt-5.2-codex",
     max_files: int = 3,
     seed: int | None = None,
+    issue_number: int | None = None,
 ) -> None
 ```
 
 Run the semantic-preserving simplifier workflow. The workflow renders a prompt
 from `workflow/simp/prompt.md`, selects target files (explicit or random), and
-executes a single `acw` run via `Session.run_prompt`.
+executes a single `acw` run via `Session.run_prompt`. Reports must start with
+`Yes.` or `No.`; when the report starts with `Yes.` and an issue number is
+provided, the report is published to the issue.
 
 **Parameters:**
 - `file_path`: Optional path to a specific file to simplify.
 - `backend`: Backend in `provider:model` form.
 - `max_files`: Maximum number of files to pick when no file is provided.
 - `seed`: Optional random seed for file selection.
+- `issue_number`: Optional issue number to publish the report when approved.
 
 **Raises:**
-- `ValueError`: Invalid arguments (backend format, max files, seed).
+- `ValueError`: Invalid arguments (backend format, max files, seed, issue number).
 - `SimpError`: Missing files, git listing failures, or prompt execution errors.
 
 #### `SimpError`

--- a/python/agentize/workflow/simp/__init__.md
+++ b/python/agentize/workflow/simp/__init__.md
@@ -13,6 +13,7 @@ def run_simp_workflow(
     backend: str = "codex:gpt-5.2-codex",
     max_files: int = 3,
     seed: int | None = None,
+    issue_number: int | None = None,
 ) -> None
 ```
 

--- a/python/agentize/workflow/simp/prompt.md
+++ b/python/agentize/workflow/simp/prompt.md
@@ -21,6 +21,10 @@ File contents:
 {{file_contents}}
 
 Output format:
-- Start with a short summary of safe simplifications.
+- The very first token must be `Yes.` or `No.`.
+- Use `Yes.` only if you provide at least one safe simplification.
+- Use `No.` if no safe simplifications exist.
+- After the leading token, add a short summary of safe simplifications (or explain
+  why none are safe).
 - For each file, provide a unified diff in a fenced code block with `diff`.
 - If no safe simplifications exist, say "No safe simplifications found" and explain.

--- a/python/agentize/workflow/simp/simp.md
+++ b/python/agentize/workflow/simp/simp.md
@@ -13,6 +13,7 @@ def run_simp_workflow(
     backend: str = "codex:gpt-5.2-codex",
     max_files: int = 3,
     seed: int | None = None,
+    issue_number: int | None = None,
 ) -> None
 ```
 
@@ -24,6 +25,7 @@ files using a prompt-driven workflow.
 - `backend`: Backend in `provider:model` form.
 - `max_files`: Maximum number of files to pick when `file_path` is omitted.
 - `seed`: Optional random seed for file selection.
+- `issue_number`: Optional issue number to publish the report when approved.
 
 **Behavior**:
 - Resolves the repo root and `.tmp/` output directory.
@@ -33,9 +35,13 @@ files using a prompt-driven workflow.
 - Writes the selected file list to `.tmp/simp-targets.txt`.
 - Renders `prompt.md` with the selected file list and file contents.
 - Executes a single `Session.run_prompt()` call to produce `.tmp/simp-output.md`.
+- Validates the report starts with `Yes.` or `No.` and logs the local report path.
+- When the report starts with `Yes.` and `issue_number` is provided, publishes
+  the report body to the matching GitHub issue.
 
 **Errors**:
-- Raises `ValueError` for invalid backend format, max file count, or seed values.
+- Raises `ValueError` for invalid backend format, max file count, seed values,
+  or issue number.
 - Raises `SimpError` for missing files, git listing failures, or prompt execution errors.
 
 ## Prompt Template
@@ -47,7 +53,7 @@ files using a prompt-driven workflow.
 ## Outputs
 
 - `.tmp/simp-input.md`: Rendered prompt input
-- `.tmp/simp-output.md`: Simplification output
+- `.tmp/simp-output.md`: Simplification report (starts with `Yes.` or `No.`)
 - `.tmp/simp-targets.txt`: Selected file list for reproducibility
 
 ## Internal Helpers

--- a/src/cli/lol/commands/simp.md
+++ b/src/cli/lol/commands/simp.md
@@ -8,17 +8,21 @@ Delegates `lol simp` to the Python simplifier workflow in
 ### Command
 
 ```bash
-lol simp [file]
+lol simp [file] [--issue <issue-no>]
 ```
 
 **Parameters**:
 - `file`: Optional path to a file to simplify.
+- `--issue <issue-no>`: Optional issue number to publish the report when approved.
 
 **Behavior**:
 - Delegates to the Python workflow via `python -m agentize.cli simp`.
 - When `file` is omitted, the workflow selects a small random set of tracked
   files and records the selection in `.tmp/simp-targets.txt`.
 - Writes prompt and output artifacts under `.tmp/`.
+- Requires the simplification report to start with `Yes.` or `No.`.
+- When `--issue` is provided and the report starts with `Yes.`, the report is
+  published to the target issue.
 
 **Failure conditions**:
 - Invalid file path (missing, non-file, or outside the repo) reported by the

--- a/src/cli/lol/commands/simp.sh
+++ b/src/cli/lol/commands/simp.sh
@@ -5,10 +5,16 @@
 # Main _lol_cmd_simp function
 # Arguments:
 #   $1 - file_path: Optional file path to simplify
+#   $2 - issue_number: Optional issue number to publish the report
 _lol_cmd_simp() {
     local file_path="$1"
+    local issue_number="$2"
 
-    if [ -n "$file_path" ]; then
+    if [ -n "$issue_number" ] && [ -n "$file_path" ]; then
+        python -m agentize.cli simp "$file_path" --issue "$issue_number"
+    elif [ -n "$issue_number" ]; then
+        python -m agentize.cli simp --issue "$issue_number"
+    elif [ -n "$file_path" ]; then
         python -m agentize.cli simp "$file_path"
     else
         python -m agentize.cli simp

--- a/src/cli/lol/parsers.md
+++ b/src/cli/lol/parsers.md
@@ -41,4 +41,4 @@ and `refine_instructions` are present, they are concatenated with a blank line
 Validates positional arguments and flags for `lol impl`, then calls `_lol_cmd_impl`.
 
 ### _lol_parse_simp()
-Accepts zero or one positional file path and delegates to `_lol_cmd_simp`.
+Accepts an optional file path plus `--issue <issue-no>` and delegates to `_lol_cmd_simp`.

--- a/tests/cli/test-lol-simp-args.sh
+++ b/tests/cli/test-lol-simp-args.sh
@@ -53,14 +53,58 @@ if ! grep -q "python -m agentize.cli simp README.md" "$PYTHON_LOG"; then
   test_fail "Expected file path to be forwarded to python -m agentize.cli simp"
 fi
 
-# Test 3: lol simp rejects extra args
+# Test 3: lol simp with issue only
+: > "$PYTHON_LOG"
+output=$(lol simp --issue 123 2>&1) || {
+  echo "Output: $output" >&2
+  test_fail "lol simp should accept --issue without a file"
+}
+
+if ! grep -q "python -m agentize.cli simp --issue 123" "$PYTHON_LOG"; then
+  echo "Python log:" >&2
+  cat "$PYTHON_LOG" >&2
+  test_fail "Expected --issue to be forwarded to python -m agentize.cli simp"
+fi
+
+# Test 4: lol simp with file and issue
+: > "$PYTHON_LOG"
+output=$(lol simp README.md --issue 123 2>&1) || {
+  echo "Output: $output" >&2
+  test_fail "lol simp should accept file path with --issue"
+}
+
+if ! grep -q "python -m agentize.cli simp README.md --issue 123" "$PYTHON_LOG"; then
+  echo "Python log:" >&2
+  cat "$PYTHON_LOG" >&2
+  test_fail "Expected file path and --issue to be forwarded to python -m agentize.cli simp"
+fi
+
+# Test 5: lol simp rejects missing issue value
+: > "$PYTHON_LOG"
+output=$(lol simp --issue 2>&1) && {
+  echo "Output: $output" >&2
+  test_fail "lol simp should fail when --issue has no value"
+}
+
+echo "$output" | grep -q "Usage: lol simp \[file\] \[--issue <issue-no>\]" || {
+  echo "Output: $output" >&2
+  test_fail "Expected usage message for lol simp"
+}
+
+if [ -s "$PYTHON_LOG" ]; then
+  echo "Python log:" >&2
+  cat "$PYTHON_LOG" >&2
+  test_fail "lol simp should not invoke python when args are invalid"
+fi
+
+# Test 6: lol simp rejects extra args
 : > "$PYTHON_LOG"
 output=$(lol simp README.md docs/cli/lol.md 2>&1) && {
   echo "Output: $output" >&2
   test_fail "lol simp should fail with more than one argument"
 }
 
-echo "$output" | grep -q "Usage: lol simp \[file\]" || {
+echo "$output" | grep -q "Usage: lol simp \[file\] \[--issue <issue-no>\]" || {
   echo "Output: $output" >&2
   test_fail "Expected usage message for lol simp"
 }


### PR DESCRIPTION
Simp report gate and issue publish for lol simp

## Summary
- enforce Yes./No. leading token in simp reports and log the local report path
- publish simp reports to issues only when --issue is provided and the report starts with Yes.
- add --issue parsing/forwarding plus updated docs and tests

## Testing
- make test-fast TEST_SHELLS="bash zsh"

Issue 834 resolved

closes #834
