### PR TITLE
Planner: log acw command and dump paths

### DIFF
--- a/docs/cli/planner.md
+++ b/docs/cli/planner.md
@@ -109,7 +109,11 @@ Planner progress is printed to stderr as plain text:
 - Pipeline completion and artifact locations
 - Issue publish status and URLs (when issue publishing is enabled)
 
-When the default `acw` runner is used, the `ACW` class also emits start/finish timing logs for each stage.
+When the default `acw` runner is used, the planner logs the exact `acw` command (per
+`docs/cli/acw.md`) before each stage run, followed by the ACW timing logs. After output
+validation, the planner logs `<stage> dumped to <output-path>` using the actual `.txt`
+or `.md` artifact path. For the consensus stage, the dump log is emitted after the
+provenance footer is appended so the path reflects the final output.
 
 ## Exit Codes
 

--- a/python/agentize/workflow/api/acw.md
+++ b/python/agentize/workflow/api/acw.md
@@ -67,6 +67,7 @@ class ACW:
         permission_mode: str | None = None,
         extra_flags: list[str] | None = None,
         log_writer: Callable[[str], None] | None = None,
+        log_command: bool = False,
         runner: Callable[..., subprocess.CompletedProcess] | None = None,
     ) -> None: ...
     def run(self, input_file: str | Path, output_file: str | Path) -> subprocess.CompletedProcess: ...
@@ -74,6 +75,7 @@ class ACW:
 
 Class-based runner that validates providers (unless a custom runner is supplied) and
 emits start/finish timing logs in the format:
+- `Command: acw <provider> <model> <input> <output> [cli-options...]` (when `log_command` is enabled)
 - `agent <name> (<provider>:<model>) is running...`
 - `agent <name> (<provider>:<model>) runs <seconds>s`
 
@@ -94,10 +96,13 @@ def run(
     cwd: str | Path | None = None,
     env: dict[str, str] | None = None,
     log_writer: Callable[[str], None] | None = None,
+    log_command: bool = False,
 ) -> subprocess.CompletedProcess
 ```
 
 Convenience helper that wraps `ACW` to execute a single stage with timing logs.
+When `log_command` is enabled, the `Command: acw ...` line is logged before the
+timing messages.
 
 ## Internal Helpers
 

--- a/python/agentize/workflow/api/session.md
+++ b/python/agentize/workflow/api/session.md
@@ -15,6 +15,8 @@ def __init__(
     runner: Callable[..., subprocess.CompletedProcess] = run_acw,
     input_suffix: str = "-input.md",
     output_suffix: str = "-output.md",
+    log_acw_command: bool = False,
+    log_output_dump: bool = False,
 ) -> None
 ```
 
@@ -26,6 +28,8 @@ def __init__(
 - `runner`: ACW-compatible callable (defaults to `run_acw`).
 - `input_suffix`: Default suffix for generated input filenames.
 - `output_suffix`: Default suffix for generated output filenames.
+- `log_acw_command`: When enabled, logs `Command: acw ...` before each stage run.
+- `log_output_dump`: When enabled, logs `<stage> dumped to <output-path>` after validation.
 
 ### `Session.run_prompt()`
 
@@ -54,6 +58,7 @@ Runs a single stage with retries and output validation.
 - Writes the prompt to the input path (string content or a writer callable).
 - Executes the runner with stage-level tools and permission mode.
 - Validates output (non-zero exit, missing output, or empty output triggers retry).
+- When `log_output_dump` is enabled, logs `<stage> dumped to <output-path>` after validation.
 - Retries up to `1 + retry` attempts; raises `PipelineError` on failure.
 
 ### `Session.stage()`

--- a/python/agentize/workflow/api/session.py
+++ b/python/agentize/workflow/api/session.py
@@ -61,6 +61,8 @@ class Session:
         runner: Callable[..., subprocess.CompletedProcess] = run_acw,
         input_suffix: str = "-input.md",
         output_suffix: str = "-output.md",
+        log_acw_command: bool = False,
+        log_output_dump: bool = False,
     ) -> None:
         self._output_dir = Path(output_dir)
         self._output_dir.mkdir(parents=True, exist_ok=True)
@@ -68,6 +70,8 @@ class Session:
         self._runner = runner
         self._input_suffix = input_suffix
         self._output_suffix = output_suffix
+        self._log_acw_command = log_acw_command
+        self._log_output_dump = log_output_dump
         self._log_lock = threading.Lock()
 
     def _log(self, message: str) -> None:
@@ -134,6 +138,7 @@ class Session:
             permission_mode=permission_mode,
             extra_flags=extra_flags,
             log_writer=self._log,
+            log_command=self._log_acw_command,
             runner=self._runner,
         )
         return acw_runner.run(input_path, output_path)
@@ -183,6 +188,8 @@ class Session:
                     extra_flags=extra_flags,
                 )
                 self._validate_output(name, output_path_resolved, process)
+                if self._log_output_dump:
+                    self._log(f"{name} dumped to {output_path_resolved}")
                 return StageResult(
                     stage=name,
                     input_path=input_path_resolved,

--- a/python/agentize/workflow/planner/__main__.py
+++ b/python/agentize/workflow/planner/__main__.py
@@ -326,6 +326,7 @@ def main(argv: list[str]) -> int:
             prefix=prefix_name,
             stage_backends=stage_backends,
             runner=run_acw,
+            log_output_dump=False,
         )
     except (FileNotFoundError, RuntimeError, subprocess.TimeoutExpired) as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -351,6 +352,7 @@ def main(argv: list[str]) -> int:
     consensus_path = consensus_result.output_path
     commit_hash = _resolve_commit_hash(repo_root)
     _append_plan_footer(consensus_path, commit_hash)
+    _log(f"consensus dumped to {consensus_path}")
 
     _log_verbose("")
     _log("Pipeline complete!")

--- a/python/agentize/workflow/planner/pipeline.md
+++ b/python/agentize/workflow/planner/pipeline.md
@@ -1,6 +1,7 @@
 # pipeline.py
 
-Planner pipeline implementation built on the Session DSL. Provides the canonical example of the imperative workflow API.
+Planner pipeline implementation built on the Session DSL. Provides the canonical example of the imperative workflow API,
+including planner-specific command/dump logging.
 
 ## External Interfaces
 
@@ -36,11 +37,13 @@ def run_consensus_stage(
     prefix: str,
     stage_backends: dict[str, tuple[str, str]],
     runner: Callable[..., subprocess.CompletedProcess] = run_acw,
+    log_output_dump: bool = True,
 ) -> StageResult
 ```
 
 Runs the consensus stage independently, writing the consensus prompt and output
-artifacts (`*-consensus-input.md`, `*-consensus.md`).
+artifacts (`*-consensus-input.md`, `*-consensus.md`). Dump logging can be
+coordinated by callers that append a footer after the stage completes.
 
 ### `StageResult`
 

--- a/python/agentize/workflow/planner/pipeline.py
+++ b/python/agentize/workflow/planner/pipeline.py
@@ -165,6 +165,8 @@ def run_planner_pipeline(
         prefix=prefix,
         runner=runner,
         output_suffix=output_suffix,
+        log_acw_command=True,
+        log_output_dump=True,
     )
 
     def _log_stage(message: str) -> None:
@@ -274,6 +276,7 @@ def run_consensus_stage(
     prefix: str,
     stage_backends: dict[str, tuple[str, str]],
     runner: Callable[..., subprocess.CompletedProcess] = run_acw,
+    log_output_dump: bool = True,
 ) -> StageResult:
     """Run the consensus stage independently."""
     bold_output = bold_path.read_text()
@@ -298,7 +301,13 @@ def run_consensus_stage(
             path,
         )
 
-    session = Session(output_dir=output_dir, prefix=prefix, runner=runner)
+    session = Session(
+        output_dir=output_dir,
+        prefix=prefix,
+        runner=runner,
+        log_acw_command=True,
+        log_output_dump=log_output_dump,
+    )
     return session.run_prompt(
         "consensus",
         _write_consensus_prompt,


### PR DESCRIPTION
Planner: log acw command and dump paths

## Summary
- Log canonical acw command lines for planner stages and dump paths after validation.
- Gate command/dump logging to planner workflows, with consensus dump logged after footer append.
- Update planner/session/ACW documentation and tests.

## Testing
- python -m pytest python/tests/test_planner_workflow.py python/tests/test_workflow_session.py

Issue 836 resolved
closes #836
