### PR TITLE
[bugfix][#839] Fix lol plan failing when run from different project

### DIFF
--- a/python/agentize/workflow/planner/__main__.py
+++ b/python/agentize/workflow/planner/__main__.py
@@ -98,7 +98,9 @@ def _strip_plan_footer(text: str) -> str:
 
 def _load_planner_backend_config(repo_root: Path, start_dir: Path) -> dict[str, str]:
     """Load planner backend overrides from .agentize.local.yaml."""
-    plugin_dir = repo_root / ".claude-plugin"
+    from agentize.shell import get_agentize_home
+
+    plugin_dir = Path(get_agentize_home()) / ".claude-plugin"
     if str(plugin_dir) not in sys.path:
         sys.path.insert(0, str(plugin_dir))
 
@@ -231,7 +233,7 @@ def main(argv: list[str]) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    os.environ["AGENTIZE_HOME"] = str(repo_root)
+    # Use current repo for output, NOT for AGENTIZE_HOME (which should be set by setup.sh)
     output_dir = repo_root / ".tmp"
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary

Fixed `lol plan` command to work correctly when run from a project directory other than the agentize installation. The command was failing because `AGENTIZE_HOME` was incorrectly overwritten with the current project's git root.

## Changes

- Modified `python/agentize/workflow/planner/__main__.py:233` to remove the line that overwrote `AGENTIZE_HOME` with current repo root
- Modified `python/agentize/workflow/planner/__main__.py:99-102` to use `get_agentize_home()` instead of `repo_root` parameter for finding the `.claude-plugin` directory

## Testing

- Manually tested by simulating running from a different project:
  1. Set `AGENTIZE_HOME=/home/cakin/agentize`
  2. Verified prompt files resolve to correct paths in agentize installation
  3. Confirmed all agent prompts (understander, bold, critique, reducer) are found

## Related Issue

Fixes #839
