### PR TITLE
[docs][#853] Add CLI quickstart onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Agentize is an AI-powered SDK that helps you build your software projects
 using Claude Code powerfully. It is splitted into two main components:
 
 1. **Claude Code Plugin**: Automatically registered during installation when `claude` CLI is available.
-   See [Tutorial 00: Initialize Your Project](./docs/tutorial/00-initialize.md) for details.
+   See [Tutorial 00a: Claude UI Setup](./docs/tutorial/00a-claude-ui-setup.md) for details.
 2. **CLI Tool**: A source-first CLI tool to help you manage your projects using Agentize.
-   See the commands below to install.
+   See [Tutorial 00: CLI Quickstart](./docs/tutorial/00-cli-quickstart.md) for the CLI workflow.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SyntheSys-Lab/agentize/main/scripts/install | bash
@@ -54,6 +54,39 @@ source $HOME/.agentize/setup.sh
 See [docs/feat/cli/install.md](./docs/feat/cli/install.md) for installation options and troubleshooting.
 
 **Upgrade:** Run `lol upgrade` to pull the latest changes.
+
+## Your First 15 Minutes
+
+After installation, the installer creates `~/.agentize.local.yaml` in your home folder. This file controls which AI backends are used for planning and implementation.
+
+### The 5-Step Agentize CLI Workflow
+
+1. **Configure** (already done) - confirm `~/.agentize.local.yaml` exists and adjust backends if needed
+
+2. **Clone** with worktrees:
+   ```bash
+   wt clone https://github.com/org/repo.git myproject.git
+   ```
+   `wt clone` sets up a bare repository and leaves you in `trees/main`.
+
+3. **Plan** your first feature:
+   ```bash
+   lol plan --editor
+   ```
+   Review the GitHub issue it creates.
+
+4. **Implement** the plan:
+   ```bash
+   lol impl <issue-number>
+   ```
+
+5. **Navigate** between worktrees:
+   ```bash
+   wt goto <issue-number>
+   wt goto main
+   ```
+
+See [Tutorial 00: CLI Quickstart](./docs/tutorial/00-cli-quickstart.md) for a full walkthrough.
 
 ## Troubleshoot
 
@@ -110,11 +143,11 @@ See our detailed workflow diagrams:
 
 Learn Agentize in 15 minutes with our step-by-step tutorials (3-5 min each):
 
-1. **[Initialize Your Project](./docs/tutorial/00-initialize.md)** - Set up Agentize in new or existing projects
-   - You already did this if you followed the Quick Start!
-2. **[Ultra Planner](./docs/tutorial/01-ultra-planner.md)** - Primary planning tutorial (recommended)
-3. **[Issue to Implementation](./docs/tutorial/02-issue-to-impl.md)** - Complete development cycle with `/issue-to-impl` and `/code-review`
-4. **[Advanced Usage](./docs/tutorial/03-advanced-usage.md)** - Scale up with parallel development workflows
+1. **[CLI Quickstart](./docs/tutorial/00-cli-quickstart.md)** - Learn the core CLI workflow in 15 minutes
+2. **[Claude UI Setup](./docs/tutorial/00a-claude-ui-setup.md)** - Set up the Claude Code plugin and slash commands
+3. **[Ultra Planner](./docs/tutorial/01-ultra-planner.md)** - Primary planning tutorial (recommended)
+4. **[Issue to Implementation](./docs/tutorial/02-issue-to-impl.md)** - Complete development cycle with `/issue-to-impl` and `/code-review`
+5. **[Advanced Usage](./docs/tutorial/03-advanced-usage.md)** - Scale up with parallel development workflows
 
 ## Project Organization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,12 @@ This directory contains all user-facing and developer documentation for the Agen
 Learn Agentize step-by-step in 15 minutes total (3-5 min per tutorial):
 
 See [`tutorial/README.md`](tutorial/README.md) for the complete tutorial series:
-- `tutorial/00-initialize.md` - Project initialization and setup
-- `tutorial/01-ultra-planner.md` - Primary planning tutorial (recommended)
+- `tutorial/00-cli-quickstart.md` - CLI workflow from config to implementation (recommended)
+- `tutorial/00a-claude-ui-setup.md` - Claude UI setup for slash commands
+- `tutorial/01-ultra-planner.md` - Primary planning tutorial
 - `tutorial/02-issue-to-impl.md` - Complete development cycle
 - `tutorial/03-advanced-usage.md` - Parallel development workflows
+- `tutorial/04-project.md` - Project board automation with PAT
 
 ### CLI Reference
 
@@ -60,10 +62,12 @@ Testing framework, validation, and agent testing:
 
 New to Agentize? Start with the tutorial series in order:
 
-1. Tutorial 00: Initialize your project
-2. Tutorial 01: Learn to plan features
-3. Tutorial 02: Implement your first issue
-4. Tutorial 03: Scale up with parallel development
+1. Tutorial 00: CLI Quickstart
+2. Tutorial 00a: Claude UI Setup (optional for UI users)
+3. Tutorial 01: Learn to plan features
+4. Tutorial 02: Implement your first issue
+5. Tutorial 03: Scale up with parallel development
+6. Tutorial 04: Configure project automation
 
 ## Maintenance Note
 

--- a/docs/tutorial/00-cli-quickstart.md
+++ b/docs/tutorial/00-cli-quickstart.md
@@ -1,0 +1,82 @@
+# Tutorial 00: CLI Quickstart
+
+**Read time: 5 minutes**
+
+Learn the core Agentize CLI workflow in about 15 minutes: configure -> clone -> plan -> implement -> navigate.
+
+## What You Will Do
+
+- Confirm your local Agentize configuration exists
+- Clone a repository with the bare + worktree layout
+- Create a plan with `lol plan --editor`
+- Implement the plan with `lol impl <issue-number>`
+- Move between worktrees with `wt goto`
+
+## Step 1: Confirm Local Configuration
+
+The installer creates `~/.agentize.local.yaml` in your home folder. This file controls which AI backends the planner and implementation workflow use.
+
+Check that it exists:
+
+```bash
+ls ~/.agentize.local.yaml
+```
+
+If you want to change models or backends, open the file and edit the planner/impl settings. See `docs/cli/lol.md` for the full schema.
+
+## Step 2: Clone With Worktrees
+
+Agentize uses bare repositories with worktrees so each issue can live in its own working directory without branch conflicts.
+
+Clone your project as a bare repo and initialize worktrees:
+
+```bash
+wt clone https://github.com/org/repo.git myproject.git
+```
+
+`wt clone` sets up the bare repository and puts you in `trees/main`, so you are ready to plan immediately.
+See `docs/feat/cli/wt.md` for the full `wt` command reference.
+
+## Step 3: Plan Your First Feature
+
+Use the planner to create a GitHub issue with a consensus implementation plan:
+
+```bash
+lol plan --editor
+```
+
+If you do not have `$EDITOR` configured, pass the description directly:
+
+```bash
+lol plan "Add user authentication"
+```
+
+Review the newly created issue and make sure the plan matches what you want to build.
+See `docs/cli/lol.md` for the full `lol` command reference.
+
+## Step 4: Implement the Plan
+
+Start the automated implementation loop for the issue:
+
+```bash
+lol impl <issue-number>
+```
+
+`lol impl` will create the issue worktree (if needed), enter it, and run the implementation workflow.
+
+## Step 5: Navigate Between Worktrees
+
+Jump between worktrees as you iterate:
+
+```bash
+wt goto <issue-number>
+wt goto main
+```
+
+Use `wt list` to see all available worktrees at any time.
+
+## Next Steps
+
+- [Tutorial 01: Ultra Planner](./01-ultra-planner.md) for a deep dive on planning
+- [Tutorial 02: Issue to Implementation](./02-issue-to-impl.md) for the full CLI loop
+- [Tutorial 03: Advanced Usage](./03-advanced-usage.md) for parallel workflows and scaling up

--- a/docs/tutorial/00a-claude-ui-setup.md
+++ b/docs/tutorial/00a-claude-ui-setup.md
@@ -1,10 +1,13 @@
-# Tutorial 00: Initialize Your Project
+> **Looking for the CLI quickstart?** See [Tutorial 00: CLI Quickstart](./00-cli-quickstart.md) for the `wt clone` -> `lol plan` -> `lol impl` workflow.
+>
+> This tutorial covers Claude UI setup for users who prefer the `/ultra-planner` and `/issue-to-impl` slash commands.
+
+# Tutorial 00a: Claude UI Setup
 
 **Read time: 3-5 minutes**
 
-This tutorial shows you how to set up the Agentize framework in your project.
-Currently, this framework is stuck to Claude Code CLI.
-~~I am not sure how long it will take to support other Coding agents.~~
+This tutorial shows you how to set up the Agentize framework and Claude Code plugin in your project.
+Use this path if you prefer the Claude UI slash commands for planning and implementation.
 
 ## Getting Started
 
@@ -38,7 +41,7 @@ claude plugin install agentize@agentize
 
 ## Verify Installation
 
-After setup, verify the CLI entrypoints are available:
+After setup, verify the CLI entrypoints are available (the installer sets up both CLI and UI tooling):
 
 ```bash
 lol plan --help
@@ -71,6 +74,7 @@ For example, you might add project-specific tags like:
 ## Next Steps
 
 Once initialized:
+- **Tutorial 00**: If you prefer CLI onboarding, start with [Tutorial 00: CLI Quickstart](./00-cli-quickstart.md)
 - **Tutorial 01**: Learn CLI planning with `lol plan --editor` (uses the git tags you just customized)
 - **Tutorial 02**: Learn the CLI implementation loop with `lol impl <issue-no>`
 - **Tutorial 03**: Scale up with parallel development workflows

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -6,11 +6,12 @@ This directory contains step-by-step tutorials for learning Agentize.
 
 Complete all tutorials in 15-25 minutes (3-5 minutes each):
 
-1. `00-initialize.md` - Project initialization and setup
-2. `01-ultra-planner.md` - CLI planning with `lol plan --editor` (recommended)
-3. `02-issue-to-impl.md` - Implementation; together with 01 this forms the end-to-end flow
-4. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
-5. `04-project.md` - Configuring project board automation with PAT
+1. `00-cli-quickstart.md` - CLI workflow from config to implementation (recommended)
+2. `00a-claude-ui-setup.md` - Claude UI setup for slash commands
+3. `01-ultra-planner.md` - CLI planning with `lol plan --editor`
+4. `02-issue-to-impl.md` - Implementation; together with 01 this forms the end-to-end flow
+5. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
+6. `04-project.md` - Configuring project board automation with PAT
 
 ## Tutorial Format
 
@@ -22,4 +23,5 @@ Each tutorial includes:
 
 ## Getting Started
 
-New users should start with `00-initialize.md` and proceed sequentially through the series.
+New CLI users should start with `00-cli-quickstart.md` and proceed sequentially through the series.
+Claude UI users can start with `00a-claude-ui-setup.md` instead.


### PR DESCRIPTION
[docs][#853] Add CLI quickstart onboarding

## Summary
- add a CLI-first quickstart tutorial and surface the 15-minute workflow in the README
- preserve Claude UI setup with a redirect notice for CLI users

## Changes
- README.md: add the 5-step CLI workflow section and refresh tutorial links
- docs/tutorial/00-cli-quickstart.md: introduce the CLI onboarding walkthrough
- docs/tutorial/00a-claude-ui-setup.md: rename and add CLI redirect notice
- docs/tutorial/README.md: update tutorial index and entry guidance
- docs/README.md: update tutorial index and getting started order

## Tests
- make test-fast TEST_SHELLS="bash zsh"

Issue 853 resolved
closes #853
