### PR TITLE
[agent.workflow][#861] Replace if/elif dispatch with table-driven FSM orchestrator

### DIFF
--- a/python/agentize/workflow/impl/orchestrator.md
+++ b/python/agentize/workflow/impl/orchestrator.md
@@ -10,9 +10,12 @@ table, and exits only at terminal states.
 
 ## Core API
 
-- `run_fsm_orchestrator(context, kernels, logger=print, max_steps=200)`
+- `run_fsm_orchestrator(context, kernels, logger=print, max_steps=200, pre_step_hook=None)`
 - `OrchestratorError` (reserved for explicit orchestration runtime failures)
 - `StageHandler` / `KernelRegistry` type aliases
+
+The optional `pre_step_hook` callback is invoked before each stage dispatch,
+receiving the current `WorkflowContext`. Primary use case: checkpoint saves.
 
 ## Runtime Behavior
 
@@ -30,4 +33,10 @@ On each loop iteration:
 - Invalid transition/event resolution causes deterministic transition to
   `fatal` with diagnostic `fatal_reason`.
 - `max_steps` guard prevents accidental infinite loops.
+
+## Production Usage
+
+`run_fsm_orchestrator()` is the production runtime loop for `impl.py`.
+Stage kernels are registered in `KERNELS` (kernels.py) and dispatch is
+governed by `TRANSITIONS` (transition.py).
 

--- a/python/agentize/workflow/impl/orchestrator.py
+++ b/python/agentize/workflow/impl/orchestrator.py
@@ -34,6 +34,7 @@ def run_fsm_orchestrator(
     kernels: KernelRegistry,
     logger: Callable[[str], None] = print,
     max_steps: int = 200,
+    pre_step_hook: Callable[[WorkflowContext], None] | None = None,
 ) -> WorkflowContext:
     """Run a flat FSM loop until `finish` or `fatal` stage is reached."""
     step = 0
@@ -45,6 +46,9 @@ def run_fsm_orchestrator(
             context.final_status = "fatal"
             context.fatal_reason = f"Max FSM steps exceeded: {max_steps}"
             break
+
+        if pre_step_hook is not None:
+            pre_step_hook(context)
 
         handler = kernels.get(context.current_stage)
         if handler is None:


### PR DESCRIPTION
[agent.workflow][#861] Replace if/elif dispatch with table-driven FSM orchestrator

## Summary

Replace the 260-line if/elif dispatch chain in `impl.py` with a table-driven FSM
orchestrator (`run_fsm_orchestrator`), real stage kernels in `kernels.py`, and a
`pre_step_hook` for checkpoint saves. Delete `_run_impl_workflow_legacy` (~190 lines).

## Changes

- **orchestrator.py**: Add `pre_step_hook` callback parameter invoked before each
  stage dispatch for checkpoint persistence.
- **kernels.py**: Implement 4 real stage kernels (`impl_stage_kernel`,
  `review_stage_kernel`, `pr_stage_kernel`, `rebase_stage_kernel`) that extract
  dependencies from `WorkflowContext.data`, call production kernels, track convergence
  counters, and emit structured events.
- **impl.py**: Replace if/elif chain with `WorkflowContext` construction +
  `run_fsm_orchestrator()` dispatch. Delete legacy `_run_impl_workflow_legacy`.
  Add post-FSM terminal state handling.
- **test_impl_fsm.py**: Add 15 new tests across 5 test classes covering all stage
  kernel paths and convergence guards.
- **Documentation**: Update README.md, impl.md, kernels.md, orchestrator.md to
  reflect FSM dispatch architecture.

## Test Results

All 400 Python tests pass (32 FSM + 368 others). All 58 shell tests pass (bash + zsh).

Issue 861 resolved

closes #861
