### PR TITLE
[feat][#869] Move Plan view to Activity Bar

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,12 +1,12 @@
 # VS Code Plan Extension
 
-This directory contains a VS Code sidebar extension that wraps the Agentize CLI
+This directory contains a VS Code Activity Bar extension that wraps the Agentize CLI
 planning workflow and surfaces it in a webview.
 
 ## Organization
 
 - `src/` contains extension backend code (state, runner, and view wiring).
-- `webview/` contains the Plan tab UI assets rendered in the sidebar webview.
+- `webview/` contains the Plan tab UI assets rendered in the Activity Bar webview.
 - `bin/` contains helper executables used by the extension runtime.
 
 ## Prerequisites

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentize-plan-extension",
   "displayName": "Agentize Plan",
-  "description": "Plan sidebar extension for the Agentize CLI.",
+  "description": "Plan Activity Bar extension for the Agentize CLI.",
   "version": "0.0.1",
   "publisher": "agentize",
   "private": true,
@@ -16,8 +16,17 @@
     "onView:agentize.planView"
   ],
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "agentize-plan",
+          "title": "Plan",
+          "icon": "resources/plan.svg"
+        }
+      ]
+    },
     "views": {
-      "explorer": [
+      "agentize-plan": [
         {
           "id": "agentize.planView",
           "name": "Plan",

--- a/vscode/resources/README.md
+++ b/vscode/resources/README.md
@@ -1,0 +1,7 @@
+# Resources
+
+Static assets for the VS Code extension.
+
+## Organization
+
+- `plan.svg` is the Activity Bar icon for the Plan view.

--- a/vscode/resources/plan.svg
+++ b/vscode/resources/plan.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M4 3h8v1H4V3zm0 3h8v1H4V6zm0 3h5v1H4V9z"/>
+  <path fill="currentColor" fill-rule="evenodd" d="M1 2a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2zm1 0v12h12V2H2z"/>
+</svg>

--- a/vscode/src/README.md
+++ b/vscode/src/README.md
@@ -1,6 +1,6 @@
 # Extension Backend
 
-This folder hosts the VS Code extension backend modules for the Plan sidebar.
+This folder hosts the VS Code extension backend modules for the Plan Activity Bar view.
 
 ## Organization
 

--- a/vscode/src/extension.md
+++ b/vscode/src/extension.md
@@ -1,12 +1,12 @@
 # extension.ts
 
-Extension entry point that wires the Plan sidebar webview provider into VS Code.
+Extension entry point that wires the Plan Activity Bar webview provider into VS Code.
 
 ## External Interface
 
 ### activate(context: vscode.ExtensionContext)
 Registers the Plan webview view provider, instantiates state and runner services, and
-exposes the sidebar view to the user.
+exposes the Activity Bar view to the user.
 
 ### deactivate()
 Reserved for cleanup when the extension is deactivated.

--- a/vscode/src/state/README.md
+++ b/vscode/src/state/README.md
@@ -1,6 +1,6 @@
 # Plan State
 
-This folder defines the Plan sidebar state models and persistence helpers.
+This folder defines the Plan Activity Bar state models and persistence helpers.
 
 ## Organization
 

--- a/vscode/src/state/types.md
+++ b/vscode/src/state/types.md
@@ -1,11 +1,11 @@
 # types.ts
 
-Shared state contracts for the Plan sidebar and related tabs.
+Shared state contracts for the Plan Activity Bar view and related tabs.
 
 ## External Interface
 
 ### AppState
-- `activeTab`: which sidebar tab is active (`plan`, `repo`, `impl`, `settings`).
+- `activeTab`: which Plan view tab is active (`plan`, `repo`, `impl`, `settings`).
 - `plan`: PlanState payload.
 - `repo`, `impl`, `settings`: placeholders for future tabs.
 

--- a/vscode/src/view/README.md
+++ b/vscode/src/view/README.md
@@ -1,6 +1,6 @@
 # Webview Provider
 
-This folder implements the webview provider that renders the Plan sidebar UI.
+This folder implements the webview provider that renders the Plan Activity Bar UI.
 
 ## Organization
 

--- a/vscode/src/view/planViewProvider.md
+++ b/vscode/src/view/planViewProvider.md
@@ -1,6 +1,6 @@
 # planViewProvider.ts
 
-Webview view provider that renders the Plan sidebar and routes messages between the
+Webview view provider that renders the Plan Activity Bar panel and routes messages between the
 webview UI, session state, and runner.
 
 ## External Interface

--- a/vscode/webview/README.md
+++ b/vscode/webview/README.md
@@ -1,6 +1,6 @@
 # Plan Webview Assets
 
-This folder contains webview assets for the VS Code Plan sidebar.
+This folder contains webview assets for the VS Code Plan Activity Bar view.
 
 ## Organization
 

--- a/vscode/webview/plan/README.md
+++ b/vscode/webview/plan/README.md
@@ -1,6 +1,6 @@
 # Plan Tab UI
 
-This folder provides the Plan sidebar UI implementation for the webview.
+This folder provides the Plan Activity Bar UI implementation for the webview.
 
 ## Organization
 


### PR DESCRIPTION
[feat][#869] Move Plan view to Activity Bar

Summary:
- add the Plan Activity Bar container with a themed icon asset
- migrate the Plan view registration into the Activity Bar container
- update VS Code extension documentation to reference the Activity Bar location
- Issue 869 resolved

Tests:
- make test-fast TEST_SHELLS="bash zsh" (passed)
- Not run: Manual VS Code UI validation (Light/Dark/High Contrast themes)

closes #869
