### PR TITLE
[feat][#879] Add plan-to-impl flow in VS Code plan view

### DIFF
--- a/docs/tutorial/03-vscode-planning.md
+++ b/docs/tutorial/03-vscode-planning.md
@@ -1,0 +1,56 @@
+# Tutorial 03: VS Code Planning
+
+**Read time: 4 minutes**
+
+Use the VS Code Plan Activity Bar view to create a plan and launch implementation with a
+single click.
+
+## What You Will Do
+
+- Load the Agentize Plan extension in VS Code
+- Run a plan in the Plan Activity Bar panel
+- Launch implementation from the Implement button
+- Review plan and implementation logs separately
+
+## Step 1: Load the Extension
+
+From the repository root, install dependencies and compile the extension:
+
+```bash
+npm --prefix vscode install
+npm --prefix vscode run compile
+```
+
+Then open the extension in VS Code:
+
+```bash
+code --extensionDevelopmentPath ./vscode
+```
+
+## Step 2: Open a Workspace
+
+Open a workspace that contains an Agentize worktree. The extension looks for
+`trees/main` first and falls back to the workspace root when it already contains the
+Agentize CLI.
+
+## Step 3: Run a Plan
+
+1. Open the Plan view in the Activity Bar.
+2. Click **New Plan**.
+3. Enter a short prompt and click **Run Plan**.
+
+The plan output streams into the Raw Console Log panel. When the planner creates a
+placeholder issue, the extension captures the issue number from the output.
+
+## Step 4: Implement the Plan
+
+After the plan finishes successfully, the session header shows an **Implement** button.
+Click it to run `lol impl <issue-number>`.
+
+The implementation output appears in a separate **Implementation Log** panel, and the
+button is disabled while the implementation run is active.
+
+## Next Steps
+
+- [Tutorial 02: Issue to Implementation](./02-issue-to-impl.md) for the CLI flow
+- [Tutorial 03: Advanced Usage](./03-advanced-usage.md) for parallel workflows

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -10,8 +10,9 @@ Complete all tutorials in 15-25 minutes (3-5 minutes each):
 2. `00a-claude-ui-setup.md` - Claude UI setup for slash commands
 3. `01-ultra-planner.md` - CLI planning with `lol plan --editor`
 4. `02-issue-to-impl.md` - Implementation; together with 01 this forms the end-to-end flow
-5. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
-6. `04-project.md` - Configuring project board automation with PAT
+5. `03-vscode-planning.md` - Planning and implementation from the VS Code Activity Bar
+6. `03-advanced-usage.md` - Parallel development workflows with clones or worktrees
+7. `04a-project.md` - Configuring project board automation with PAT
 
 ## Tutorial Format
 

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,8 @@
+# Workflows
+
+This directory contains workflow documentation that describes how Agentize features are
+used across interfaces and tools.
+
+## Organization
+
+- `vscode-extension.md` describes the Plan-to-Implement flow in the VS Code extension.

--- a/docs/workflows/vscode-extension.md
+++ b/docs/workflows/vscode-extension.md
@@ -1,0 +1,38 @@
+# VS Code Extension Workflow
+
+This document describes the Plan-to-Implement workflow exposed by the VS Code extension.
+It focuses on the rationale behind the UI and state flow so the behavior stays consistent
+across future updates.
+
+## Goals
+
+- Provide a single-click transition from planning to implementation.
+- Capture the GitHub issue number as soon as the planner emits it.
+- Keep plan and implementation logs visually separate to reduce confusion.
+
+## Plan Session Lifecycle
+
+1. The user creates a Plan session in the Activity Bar panel.
+2. The extension launches `lol plan` via the CLI wrapper and streams stdout/stderr into
+   the session log buffer.
+3. The session status transitions through `running` to `success` or `error`.
+
+## Issue Number Capture
+
+The planner emits lines such as `Created placeholder issue #N` or a GitHub issue URL.
+The extension scans stdout/stderr lines in real time and stores the first matching issue
+number on the session. Capturing the issue number during execution ensures the UI can
+surface the Implement action immediately after the plan completes.
+
+## Implementation Launch
+
+When a plan succeeds and an issue number exists, the UI displays an Implement button in
+that session header. Clicking it launches `lol impl <issue-number>` and tracks the run
+status separately from the plan. The UI disables the button while the implementation run
+is active to prevent overlapping runs.
+
+## Log Separation
+
+Implementation output is streamed into a dedicated Implementation Log panel. Keeping the
+plan and implementation logs separate avoids mixing the planner transcript with code
+changes, which makes it easier to scan each phase independently.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -9,6 +9,12 @@ planning workflow and surfaces it in a webview.
 - `webview/` contains the Plan tab UI assets rendered in the Activity Bar webview.
 - `bin/` contains helper executables used by the extension runtime.
 
+## Plan to Implementation Flow
+
+When a plan finishes successfully and the planner creates a placeholder GitHub issue, the
+Plan tab surfaces an Implement button. Clicking it launches `lol impl <issue-number>` in a
+separate Implementation Log panel so plan and implementation output stay distinct.
+
 ## Prerequisites
 
 - Node.js + npm (for compiling the extension TypeScript).

--- a/vscode/src/runner/planRunner.md
+++ b/vscode/src/runner/planRunner.md
@@ -1,6 +1,7 @@
 # planRunner.ts
 
 Command runner for Plan sessions that spawns the CLI process and emits run events.
+It supports both `plan` and `impl` CLI subcommands.
 
 ## External Interface
 
@@ -9,15 +10,17 @@ Command runner for Plan sessions that spawns the CLI process and emits run event
   streams events to the callback.
 - Spawn failures emit stderr lines with user-friendly guidance (including missing command hints).
 - `stop(sessionId: string)`: terminates a running session.
-- `isRunning(sessionId: string)`: reports whether a session is currently running.
+- `isRunning(sessionId: string, commandType?: RunCommandType)`: reports whether a session is currently running (optionally scoped to `plan` or `impl`).
 - CLI execution is routed through `vscode/bin/lol-wrapper.js` so the shell-based
   `lol` function can be invoked from a subprocess.
+- Each emitted event includes `commandType` so callers can route plan and implementation logs separately.
 
 ## Internal Helpers
 
-### buildCommand(prompt: string)
-Returns the executable and arguments used to invoke the planning CLI, using `node`
-to run the wrapper script while preserving the user-facing display string.
+### buildCommand(input: RunPlanInput)
+Returns the executable and arguments used to invoke the CLI (either `lol plan` or
+`lol impl`), using `node` to run the wrapper script while preserving the user-facing
+display string.
 
 ### attachLineReaders()
 Converts stdout/stderr streams into line-based run events.

--- a/vscode/src/runner/types.md
+++ b/vscode/src/runner/types.md
@@ -6,8 +6,13 @@ Contracts for Plan command execution events.
 
 ### RunPlanInput
 - `sessionId`: session identifier to associate with the run.
-- `prompt`: prompt text passed to the CLI.
+- `command`: which CLI subcommand to execute (`plan` or `impl`).
+- `prompt`: prompt text passed to the CLI (required for `plan`).
+- `issueNumber`: issue number passed to the CLI (required for `impl`).
 - `cwd`: working directory for the command.
+
+### RunCommandType
+Union of `plan` and `impl` command identifiers used by the runner and webview routing.
 
 ### RunEvent
 Union of events emitted during execution:
@@ -15,6 +20,7 @@ Union of events emitted during execution:
 - `stdout`: stdout line emitted.
 - `stderr`: stderr line emitted.
 - `exit`: process exit with code and signal.
+Each event includes `commandType` so consumers can route plan vs. implementation output.
 
 ## Internal Helpers
 

--- a/vscode/src/runner/types.ts
+++ b/vscode/src/runner/types.ts
@@ -1,6 +1,10 @@
+export type RunCommandType = 'plan' | 'impl';
+
 export interface RunPlanInput {
   sessionId: string;
-  prompt: string;
+  command: RunCommandType;
+  prompt?: string;
+  issueNumber?: string;
   cwd: string;
 }
 
@@ -9,24 +13,28 @@ export type RunEvent =
       type: 'start';
       sessionId: string;
       command: string;
+      commandType: RunCommandType;
       cwd: string;
       timestamp: number;
     }
   | {
       type: 'stdout';
       sessionId: string;
+      commandType: RunCommandType;
       line: string;
       timestamp: number;
     }
   | {
       type: 'stderr';
       sessionId: string;
+      commandType: RunCommandType;
       line: string;
       timestamp: number;
     }
   | {
       type: 'exit';
       sessionId: string;
+      commandType: RunCommandType;
       code: number | null;
       signal: NodeJS.Signals | null;
       timestamp: number;

--- a/vscode/src/state/sessionStore.md
+++ b/vscode/src/state/sessionStore.md
@@ -10,7 +10,9 @@ Plan session persistence and CRUD helper used by the extension backend.
 - `createSession(prompt: string)`: creates a new session and persists it.
 - `updateSession(id: string, update: Partial<PlanSession>)`: updates a session and persists it.
 - `appendSessionLogs(id: string, lines: string[])`: appends log lines with trimming.
+- `appendImplLogs(id: string, lines: string[])`: appends implementation log lines with trimming.
 - `toggleSessionCollapse(id: string)`: flips the collapsed flag.
+- `toggleImplCollapse(id: string)`: flips the implementation log collapse flag.
 - `deleteSession(id: string)`: removes a session.
 - `updateDraftInput(value: string)`: persists the draft input text.
 - `getSession(id: string)`: returns a single session by id.

--- a/vscode/src/state/sessionStore.ts
+++ b/vscode/src/state/sessionStore.ts
@@ -47,6 +47,10 @@ export class SessionStore {
       collapsed: false,
       status: 'idle',
       prompt: trimmed,
+      issueNumber: undefined,
+      implStatus: 'idle',
+      implLogs: [],
+      implCollapsed: false,
       logs: [],
       createdAt: now,
       updatedAt: now,
@@ -80,6 +84,19 @@ export class SessionStore {
     return this.cloneSession(session);
   }
 
+  appendImplLogs(id: string, lines: string[]): PlanSession | undefined {
+    const session = this.state.sessions.find((item) => item.id === id);
+    if (!session) {
+      return undefined;
+    }
+
+    const existing = session.implLogs ?? [];
+    session.implLogs = this.trimLogs([...existing, ...lines]);
+    session.updatedAt = Date.now();
+    this.persist();
+    return this.cloneSession(session);
+  }
+
   toggleSessionCollapse(id: string): PlanSession | undefined {
     const session = this.state.sessions.find((item) => item.id === id);
     if (!session) {
@@ -87,6 +104,18 @@ export class SessionStore {
     }
 
     session.collapsed = !session.collapsed;
+    session.updatedAt = Date.now();
+    this.persist();
+    return this.cloneSession(session);
+  }
+
+  toggleImplCollapse(id: string): PlanSession | undefined {
+    const session = this.state.sessions.find((item) => item.id === id);
+    if (!session) {
+      return undefined;
+    }
+
+    session.implCollapsed = !session.implCollapsed;
     session.updatedAt = Date.now();
     this.persist();
     return this.cloneSession(session);
@@ -143,6 +172,9 @@ export class SessionStore {
     return {
       ...session,
       logs: [...session.logs],
+      implStatus: session.implStatus ?? 'idle',
+      implLogs: session.implLogs ? [...session.implLogs] : [],
+      implCollapsed: session.implCollapsed ?? false,
     };
   }
 }

--- a/vscode/src/state/types.md
+++ b/vscode/src/state/types.md
@@ -20,6 +20,10 @@ Shared state contracts for the Plan Activity Bar view and related tabs.
 - `status`: session status.
 - `prompt`: raw planning prompt.
 - `command`: resolved CLI command string (optional).
+- `issueNumber`: GitHub issue number captured from plan output (optional).
+- `implStatus`: implementation run status (`idle`, `running`, `success`, `error`).
+- `implLogs`: implementation log lines captured for this session (optional).
+- `implCollapsed`: whether the implementation log panel is collapsed (optional).
 - `logs`: log lines captured for this session.
 - `createdAt`, `updatedAt`: timestamps.
 

--- a/vscode/src/state/types.ts
+++ b/vscode/src/state/types.ts
@@ -7,6 +7,10 @@ export interface PlanSession {
   status: SessionStatus;
   prompt: string;
   command?: string;
+  issueNumber?: string;
+  implStatus?: SessionStatus;
+  implLogs?: string[];
+  implCollapsed?: boolean;
   logs: string[];
   createdAt: number;
   updatedAt: number;

--- a/vscode/src/view/planViewProvider.md
+++ b/vscode/src/view/planViewProvider.md
@@ -15,13 +15,17 @@ webview UI, session state, and runner.
 Consumes UI messages:
 - `plan/new`
 - `plan/run`
+- `plan/impl`
 - `plan/toggleCollapse`
+- `plan/toggleImplCollapse`
 - `plan/delete`
 - `plan/updateDraft`
 - `link/openExternal` - Opens GitHub issue URLs in default browser
 - `link/openFile` - Opens local markdown files in VSCode editor
 
 `plan/delete` stops an in-flight session before removing it from storage.
+`plan/impl` starts an implementation run for the captured issue number and stores output in a
+separate implementation log buffer.
 
 Emits UI messages:
 - `state/replace`
@@ -38,6 +42,8 @@ The provider loads the compiled webview script `webview/plan/out/index.js` (buil
 
 ### handleRunEvent(event: RunEvent)
 Transforms runner events into state updates and UI updates (status changes and log lines).
+Plan events update `status` and `logs`; implementation events update `implStatus` and `implLogs`.
+Issue numbers are extracted in real time from stdout/stderr lines and persisted on the session.
 
 ### resolvePlanCwd()
 Resolves the planning working directory.
@@ -54,3 +60,10 @@ Validates GitHub issue URLs using the pattern `^https://github\.com/[^/]+/[^/]+/
 
 **`openLocalFile(filePath: string): Promise<void>`**
 Resolves local file paths relative to the workspace root and opens them in the VSCode editor using `vscode.workspace.openTextDocument()` and `vscode.window.showTextDocument()`.
+
+### Issue Extraction
+Plan stdout/stderr lines are scanned for:
+- `Created placeholder issue #N`
+- `https://github.com/<owner>/<repo>/issues/N`
+
+When a match is found, `issueNumber` is stored on the session and pushed to the webview.

--- a/vscode/webview/plan/README.md
+++ b/vscode/webview/plan/README.md
@@ -6,4 +6,5 @@ This folder provides the Plan Activity Bar UI implementation for the webview.
 
 - `index.ts` renders sessions, handles input, and posts messages. It is compiled to `out/index.js`
   for the webview runtime.
+- `types.ts` defines message shapes used by the plan webview.
 - `styles.css` defines the minimal readable styling for the Plan tab.

--- a/vscode/webview/plan/index.md
+++ b/vscode/webview/plan/index.md
@@ -7,6 +7,8 @@ Webview script that renders the Plan session list and handles user input.
 ### UI Actions
 - Creates new Plan sessions and posts `plan/new` to the extension.
 - Sends `plan/toggleCollapse`, `plan/delete`, and `plan/updateDraft` messages.
+- Sends `plan/impl` when the Implement button is pressed for a completed plan.
+- Sends `plan/toggleImplCollapse` when the implementation log panel is collapsed or expanded.
 - Sends `link/openExternal` and `link/openFile` for clickable links in logs.
 - Deletes are immediate; running sessions are stopped by the extension host.
 
@@ -24,6 +26,9 @@ Updates a single session row without re-rendering the full list.
 ### appendLogLine(sessionId, line, stream)
 Appends a log line with a per-session buffer limit. Parses stderr lines for stage progress and updates step indicators.
 
+### appendImplLogLine(sessionId, line, stream)
+Appends a log line to the implementation log buffer and keeps the implementation log panel scrolled.
+
 ### Step Progress Indicators
 
 Step indicators are rendered above the raw logs box by parsing stderr lines matching the pattern:
@@ -37,6 +42,21 @@ Running steps display animated dots cycling from 1 to 3 using CSS `@keyframes`. 
 ### Collapsible Raw Console Log
 
 The raw console log box can be collapsed/expanded independently of the session collapse. Clicking the toggle button updates the local state; the collapse state is maintained in the webview and persists across state updates.
+
+### Implement Button + Implementation Logs
+
+When a plan finishes successfully and an issue number has been captured, the session header shows an Implement button.
+Clicking it triggers `plan/impl` with the issue number, and a separate "Implementation Log" panel streams the output.
+The button is disabled while the implementation run is active.
+
+### Issue Number Extraction (UI)
+
+The webview parses incoming log lines for:
+- `Created placeholder issue #N`
+- `https://github.com/<owner>/<repo>/issues/N`
+
+This acts as a UI-side fallback to surface the Implement button even if the extension state has
+not yet persisted the issue number.
 
 ### Interactive Links
 

--- a/vscode/webview/plan/styles.css
+++ b/vscode/webview/plan/styles.css
@@ -53,6 +53,10 @@ button:disabled {
   opacity: 0.6;
 }
 
+.hidden {
+  display: none;
+}
+
 .plan-input {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -158,6 +162,22 @@ button:disabled {
 .delete {
   border-color: var(--error);
   color: var(--error);
+}
+
+.impl-button {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.impl-button:hover {
+  filter: brightness(0.95);
+}
+
+.impl-button:disabled {
+  background: var(--border);
+  color: var(--muted);
+  border-color: var(--border);
 }
 
 .session-body {
@@ -323,6 +343,55 @@ button:disabled {
 }
 
 .raw-logs-body .logs {
+  border-radius: 0;
+  max-height: none;
+  margin: 0;
+}
+
+/* Implementation Logs Box */
+.impl-logs-box {
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.impl-logs-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: rgba(15, 110, 110, 0.08);
+  border-bottom: 1px solid var(--accent);
+}
+
+.impl-logs-toggle {
+  border: none;
+  background: none;
+  font-weight: 700;
+  color: var(--accent);
+  padding: 0 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.impl-logs-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  flex: 1;
+}
+
+.impl-logs-body {
+  max-height: 220px;
+  overflow-y: auto;
+  transition: max-height 0.25s ease-out;
+}
+
+.impl-logs-body.collapsed {
+  max-height: 0;
+}
+
+.impl-logs-body .logs {
   border-radius: 0;
   max-height: none;
   margin: 0;

--- a/vscode/webview/plan/styles.md
+++ b/vscode/webview/plan/styles.md
@@ -11,6 +11,10 @@ Minimal readable styles for the Plan webview UI.
 - `.session-header`: row with title, status, and actions.
 - `.session-body`: contains prompt and logs.
 - `.logs`: monospace log display.
+- `.hidden`: utility class to hide optional UI elements.
+- `.impl-button`: primary action for starting implementation runs.
+- `.impl-logs-box`: container for implementation logs and header.
+- `.impl-logs-header`, `.impl-logs-toggle`, `.impl-logs-title`, `.impl-logs-body`: implementation log panel chrome.
 - `#plan-textarea`: uses border-box sizing to keep padding within the panel.
 
 ### Status Modifiers

--- a/vscode/webview/plan/types.md
+++ b/vscode/webview/plan/types.md
@@ -1,0 +1,18 @@
+# types.ts
+
+Message payload definitions for the Plan webview.
+
+## External Interface
+
+### PlanImplMessage
+- `type`: `plan/impl`.
+- `sessionId`: Plan session identifier.
+- `issueNumber`: issue number to pass to `lol impl`.
+
+### PlanToggleImplCollapseMessage
+- `type`: `plan/toggleImplCollapse`.
+- `sessionId`: Plan session identifier.
+
+## Internal Helpers
+
+No internal helpers; this module only exports types.

--- a/vscode/webview/plan/types.ts
+++ b/vscode/webview/plan/types.ts
@@ -1,0 +1,10 @@
+export interface PlanImplMessage {
+  type: 'plan/impl';
+  sessionId: string;
+  issueNumber: string;
+}
+
+export interface PlanToggleImplCollapseMessage {
+  type: 'plan/toggleImplCollapse';
+  sessionId: string;
+}


### PR DESCRIPTION
[feat][#879] Add plan-to-impl flow in VS Code plan view

## Summary
- capture issue numbers during plan runs and persist them for UI actions
- add Implement button with separate implementation logs in the Plan webview
- extend runner/provider/session store to execute and track impl runs
- document the Plan-to-Implement workflow and tutorial steps
- Issue 879 resolved

## Tests
- make vscode-plugin
- bash tests/vscode/test-plan-view-ui.sh
- TEST_SHELLS="bash zsh" make test-fast

closes #879
