### PR TITLE
[bugfix][#883] Rename VS Code extension labels to Agentize

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,4 +1,4 @@
-# VS Code Plan Extension
+# VS Code Agentize Extension
 
 This directory contains a VS Code Activity Bar extension that wraps the Agentize CLI
 planning workflow and surfaces it in a webview.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentize-plan-extension",
   "displayName": "Agentize Plan",
-  "description": "Plan Activity Bar extension for the Agentize CLI.",
+  "description": "Agentize Activity Bar extension for the Agentize CLI.",
   "version": "0.0.1",
   "publisher": "agentize",
   "private": true,
@@ -20,7 +20,7 @@
       "activitybar": [
         {
           "id": "agentize-plan",
-          "title": "Plan",
+          "title": "Agentize",
           "icon": "resources/plan.svg"
         }
       ]
@@ -29,7 +29,7 @@
       "agentize-plan": [
         {
           "id": "agentize.planView",
-          "name": "Plan",
+          "name": "Agentize",
           "type": "webview"
         }
       ]

--- a/vscode/src/view/planViewProvider.ts
+++ b/vscode/src/view/planViewProvider.ts
@@ -348,7 +348,7 @@ export class PlanViewProvider implements vscode.WebviewViewProvider {
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="${styleUri}" rel="stylesheet" />
-  <title>Plan</title>
+  <title>Agentize</title>
 </head>
 <body>
   <div id="plan-root" class="plan-root"></div>


### PR DESCRIPTION
[bugfix][#883] Rename VS Code extension labels to Agentize

**Summary**
- update VS Code extension activity bar/view labels and webview title to Agentize
- align extension description and README title with Agentize branding

**Testing**
- make vscode-plugin
- TEST_SHELLS="bash zsh" make test-fast

Issue 883 resolved
closes #883
