### PR TITLE
[feat][#888] Gate Implement on issue state

### DIFF
--- a/tests/vscode/test-plan-view-ui.sh
+++ b/tests/vscode/test-plan-view-ui.sh
@@ -8,6 +8,7 @@ test_info "Testing plan view UI structure and components"
 # Check that the webview files exist and have the expected content
 WEBVIEW_DIR="$PROJECT_ROOT/vscode/webview/plan"
 PROVIDER_FILE="$PROJECT_ROOT/vscode/src/view/planViewProvider.ts"
+STATE_TYPES_FILE="$PROJECT_ROOT/vscode/src/state/types.ts"
 
 # Test 1: Check CSS has step indicator styles
 if ! grep -q "step-indicator" "$WEBVIEW_DIR/styles.css"; then
@@ -74,6 +75,31 @@ fi
 
 if ! grep -q "Interactive Links" "$WEBVIEW_DIR/index.md"; then
   test_fail "index.md missing Interactive Links documentation"
+fi
+
+# Test 12: Check documentation mentions closed issue behavior
+if ! grep -q "Closed" "$WEBVIEW_DIR/index.md"; then
+  test_fail "index.md missing closed issue button documentation"
+fi
+
+# Test 13: Check session type includes issueState
+if ! grep -q "issueState" "$STATE_TYPES_FILE"; then
+  test_fail "types.ts missing issueState field"
+fi
+
+# Test 14: Check plan view provider handles issue state validation
+if ! grep -q "checkIssueState" "$PROVIDER_FILE"; then
+  test_fail "planViewProvider.ts missing checkIssueState handler"
+fi
+
+# Test 15: Check webview handles closed issue state
+if ! grep -q "Closed" "$WEBVIEW_DIR/index.ts"; then
+  test_fail "index.ts missing Closed button state"
+fi
+
+# Test 16: Check CSS has closed issue styling
+if ! grep -q "impl-button.closed" "$WEBVIEW_DIR/styles.css"; then
+  test_fail "styles.css missing impl-button.closed styles"
 fi
 
 test_info "All UI structure tests passed"

--- a/vscode/src/state/sessionStore.ts
+++ b/vscode/src/state/sessionStore.ts
@@ -48,6 +48,7 @@ export class SessionStore {
       status: 'idle',
       prompt: trimmed,
       issueNumber: undefined,
+      issueState: undefined,
       implStatus: 'idle',
       implLogs: [],
       implCollapsed: false,

--- a/vscode/src/state/types.md
+++ b/vscode/src/state/types.md
@@ -21,6 +21,8 @@ Shared state contracts for the Plan Activity Bar view and related tabs.
 - `prompt`: raw planning prompt.
 - `command`: resolved CLI command string (optional).
 - `issueNumber`: GitHub issue number captured from plan output (optional).
+- `issueState`: last known GitHub issue state (`open`, `closed`, `unknown`) used to gate implementation runs (optional).
+  - `unknown` means the state could not be verified (missing `gh`, auth, or network).
 - `implStatus`: implementation run status (`idle`, `running`, `success`, `error`).
 - `implLogs`: implementation log lines captured for this session (optional).
 - `implCollapsed`: whether the implementation log panel is collapsed (optional).

--- a/vscode/src/state/types.ts
+++ b/vscode/src/state/types.ts
@@ -18,6 +18,7 @@ export interface PlanSession {
   prompt: string;
   command?: string;
   issueNumber?: string;
+  issueState?: 'open' | 'closed' | 'unknown';
   implStatus?: SessionStatus;
   implLogs?: string[];
   implCollapsed?: boolean;

--- a/vscode/src/view/planViewProvider.md
+++ b/vscode/src/view/planViewProvider.md
@@ -28,7 +28,8 @@ Consumes UI messages:
 
 `plan/delete` stops an in-flight session before removing it from storage.
 `plan/impl` starts an implementation run for the captured issue number and stores output in a
-separate implementation log buffer.
+separate implementation log buffer. Before starting implementation, the provider validates
+the GitHub issue state and blocks the run if the issue is closed.
 
 Emits UI messages:
 - `state/replace`
@@ -84,3 +85,11 @@ Plan stdout/stderr lines are scanned for:
 - `https://github.com/<owner>/<repo>/issues/N`
 
 When a match is found, `issueNumber` is stored on the session and pushed to the webview.
+
+### Issue State Validation
+
+When the Plan view becomes visible, the provider checks the GitHub issue state (via `gh issue view`)
+for sessions with an issue number and stores the resulting `issueState` on the session. The same check
+runs immediately before starting an implementation run. A closed issue blocks implementation and keeps
+the button disabled in the UI. If the `gh` CLI check fails, the provider records `unknown` and allows
+implementation to proceed.

--- a/vscode/webview/plan/index.md
+++ b/vscode/webview/plan/index.md
@@ -67,6 +67,8 @@ The raw console log box can be collapsed/expanded independently of the session c
 When a plan finishes successfully and an issue number has been captured, the session header shows an Implement button.
 Clicking it triggers `plan/impl` with the issue number, and a separate "Implementation Log" panel streams the output.
 The button is disabled while the implementation run is active.
+If the session `issueState` is `closed`, the button text changes to "Closed" and stays disabled to prevent
+implementation runs on closed issues.
 
 ### Issue Number Extraction (UI)
 

--- a/vscode/webview/plan/index.ts
+++ b/vscode/webview/plan/index.ts
@@ -198,8 +198,22 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
     const showButton = current.status === 'success' && Boolean(issueNumber);
     if (node.implButton) {
       node.implButton.classList.toggle('hidden', !showButton);
-      node.implButton.disabled = current.implStatus === 'running';
       node.implButton.dataset.issueNumber = issueNumber ?? '';
+      const isRunning = current.implStatus === 'running';
+      const isClosed = current.issueState === 'closed';
+      if (isRunning) {
+        node.implButton.disabled = true;
+        node.implButton.textContent = 'Running...';
+        node.implButton.classList.remove('closed');
+      } else if (isClosed) {
+        node.implButton.disabled = true;
+        node.implButton.textContent = 'Closed';
+        node.implButton.classList.add('closed');
+      } else {
+        node.implButton.disabled = false;
+        node.implButton.textContent = 'Implement';
+        node.implButton.classList.remove('closed');
+      }
     }
 
     const hasImplLogs = Array.isArray(current.implLogs) && current.implLogs.length > 0;
@@ -829,6 +843,7 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
     logs?: string[];
     collapsed?: boolean;
     issueNumber?: string;
+    issueState?: 'open' | 'closed' | 'unknown';
     implStatus?: string;
     implLogs?: string[];
     implCollapsed?: boolean;

--- a/vscode/webview/plan/styles.css
+++ b/vscode/webview/plan/styles.css
@@ -217,6 +217,13 @@ button:disabled {
   border-color: var(--border);
 }
 
+.impl-button.closed {
+  background-color: #6e7681;
+  color: #c9d1d9;
+  border-color: #6e7681;
+  cursor: not-allowed;
+}
+
 .refine {
   border-color: var(--accent);
   color: var(--accent);

--- a/vscode/webview/plan/styles.md
+++ b/vscode/webview/plan/styles.md
@@ -14,6 +14,7 @@ Minimal readable styles for the Plan webview UI.
 - `.logs`: monospace log display.
 - `.hidden`: utility class to hide optional UI elements.
 - `.impl-button`: primary action for starting implementation runs.
+- `.impl-button.closed`: disabled styling when the linked issue is closed.
 - `.impl-logs-box`: container for implementation logs and header.
 - `.impl-logs-header`, `.impl-logs-toggle`, `.impl-logs-title`, `.impl-logs-body`: implementation log panel chrome.
 - `#plan-textarea`: uses border-box sizing to keep padding within the panel.


### PR DESCRIPTION
[feat][#888] Gate Implement on issue state
Summary:
- check GitHub issue state on plan view visibility and before implementation, fail open on gh errors
- propagate issueState to the webview and render a Closed button state with styling
- extend plan view UI tests and docs for issue state behavior

Tests:
- make vscode-plugin
- bash tests/vscode/test-plan-view-ui.sh
- TEST_SHELLS="bash zsh" make test-fast

Issue 888 resolved
closes #888
