### PR TITLE
[feat][#889] Add Worktree and Settings sidebar tabs

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,12 +1,13 @@
 # VS Code Agentize Extension
 
 This directory contains a VS Code Activity Bar extension that wraps the Agentize CLI
-planning workflow and surfaces it in a webview.
+planning workflow and surfaces it alongside Worktree and Settings placeholders.
 
 ## Organization
 
 - `src/` contains extension backend code (state, runner, and view wiring).
-- `webview/` contains the Plan tab UI assets rendered in the Activity Bar webview.
+- `webview/` contains the Plan, Worktree, and Settings tab UI assets rendered in the Activity Bar webviews.
+- `resources/` contains icons for the Activity Bar container and each tab.
 - `bin/` contains helper executables used by the extension runtime.
 
 ## Plan to Implementation Flow

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -13,7 +13,9 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "onView:agentize.planView"
+    "onView:agentize.planView",
+    "onView:agentize.worktreeView",
+    "onView:agentize.settingsView"
   ],
   "contributes": {
     "viewsContainers": {
@@ -30,13 +32,26 @@
         {
           "id": "agentize.planView",
           "name": "Agentize",
-          "type": "webview"
+          "type": "webview",
+          "icon": "resources/plan.svg"
+        },
+        {
+          "id": "agentize.worktreeView",
+          "name": "Worktree",
+          "type": "webview",
+          "icon": "resources/worktree.svg"
+        },
+        {
+          "id": "agentize.settingsView",
+          "name": "Settings",
+          "type": "webview",
+          "icon": "resources/settings.svg"
         }
       ]
     }
   },
   "scripts": {
-    "compile": "tsc -p . && tsc -p webview/plan/tsconfig.json",
+    "compile": "tsc -p . && tsc -p webview/plan/tsconfig.json && tsc -p webview/worktree/tsconfig.json && tsc -p webview/settings/tsconfig.json",
     "watch": "tsc -watch -p .",
     "vscode:prepublish": "npm run compile"
   },

--- a/vscode/resources/README.md
+++ b/vscode/resources/README.md
@@ -4,4 +4,6 @@ Static assets for the VS Code extension.
 
 ## Organization
 
-- `plan.svg` is the Activity Bar icon for the Plan view.
+- `plan.svg` is the Activity Bar icon for the Agentize container.
+- `worktree.svg` is the icon for the Worktree tab.
+- `settings.svg` is the icon for the Settings tab.

--- a/vscode/resources/settings.svg
+++ b/vscode/resources/settings.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M3 4h10v1H3V4z"/>
+  <circle cx="6" cy="4.5" r="1" fill="currentColor"/>
+  <path fill="currentColor" d="M3 8h10v1H3V8z"/>
+  <circle cx="10" cy="8.5" r="1" fill="currentColor"/>
+  <path fill="currentColor" d="M3 12h10v1H3v-1z"/>
+  <circle cx="5" cy="12.5" r="1" fill="currentColor"/>
+</svg>

--- a/vscode/resources/worktree.svg
+++ b/vscode/resources/worktree.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="3.5" r="1.5" fill="currentColor"/>
+  <circle cx="4" cy="12.5" r="1.5" fill="currentColor"/>
+  <circle cx="12" cy="12.5" r="1.5" fill="currentColor"/>
+  <path fill="currentColor" d="M7.5 5h1v4h-1V5z"/>
+  <path fill="currentColor" d="M3.5 9h9v1h-9V9z"/>
+  <path fill="currentColor" d="M3.5 10h1v1.5h-1V10zm8 0h1v1.5h-1V10z"/>
+</svg>

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { PlanRunner } from './runner/planRunner';
 import { SessionStore } from './state/sessionStore';
 import { PlanViewProvider } from './view/planViewProvider';
+import { SettingsViewProvider } from './view/settingsViewProvider';
+import { WorktreeViewProvider } from './view/worktreeViewProvider';
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('Agentize Plan');
@@ -9,10 +11,14 @@ export function activate(context: vscode.ExtensionContext): void {
   const store = new SessionStore(context.workspaceState);
   const runner = new PlanRunner();
   const provider = new PlanViewProvider(context.extensionUri, store, runner, output);
+  const worktreeProvider = new WorktreeViewProvider(context.extensionUri);
+  const settingsProvider = new SettingsViewProvider(context.extensionUri);
 
   context.subscriptions.push(
     output,
     vscode.window.registerWebviewViewProvider(PlanViewProvider.viewType, provider),
+    vscode.window.registerWebviewViewProvider(WorktreeViewProvider.viewType, worktreeProvider),
+    vscode.window.registerWebviewViewProvider(SettingsViewProvider.viewType, settingsProvider),
   );
 }
 

--- a/vscode/src/view/README.md
+++ b/vscode/src/view/README.md
@@ -1,7 +1,9 @@
 # Webview Provider
 
-This folder implements the webview provider that renders the Plan Activity Bar UI.
+This folder implements the webview providers that render the Activity Bar tabs.
 
 ## Organization
 
 - `planViewProvider.ts` builds the webview HTML, injects initial state, and routes messages.
+- `worktreeViewProvider.ts` renders the Worktree placeholder tab.
+- `settingsViewProvider.ts` renders the Settings placeholder tab.

--- a/vscode/src/view/settingsViewProvider.md
+++ b/vscode/src/view/settingsViewProvider.md
@@ -1,0 +1,21 @@
+# settingsViewProvider.ts
+
+Webview view provider that renders the Settings Activity Bar panel with a static
+placeholder layout.
+
+## External Interface
+
+### SettingsViewProvider
+- `resolveWebviewView(view: vscode.WebviewView)`: configures the webview options,
+  injects the Settings HTML shell, and loads the compiled webview assets.
+
+## Internal Helpers
+
+### buildHtml(webview: vscode.Webview)
+Builds the CSP-safe HTML shell, including the Settings CSS and compiled script.
+The HTML includes a small skeleton card that keeps the view readable while assets
+load or when they are missing.
+
+### getNonce()
+Generates a random nonce for the CSP `script-src` directive so the inline
+bootstrap script can safely load the Settings module.

--- a/vscode/src/view/settingsViewProvider.ts
+++ b/vscode/src/view/settingsViewProvider.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class SettingsViewProvider implements vscode.WebviewViewProvider {
+  static readonly viewType = 'agentize.settingsView';
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'webview')],
+    };
+
+    view.webview.html = this.buildHtml(view.webview);
+  }
+
+  private buildHtml(webview: vscode.Webview): string {
+    const scriptPath = vscode.Uri.joinPath(this.extensionUri, 'webview', 'settings', 'out', 'index.js');
+    const stylePath = vscode.Uri.joinPath(this.extensionUri, 'webview', 'settings', 'styles.css');
+    const scriptUri = webview.asWebviewUri(scriptPath);
+    const styleUri = webview.asWebviewUri(stylePath);
+    const nonce = this.getNonce();
+    const scriptFsPath = path.join(this.extensionUri.fsPath, 'webview', 'settings', 'out', 'index.js');
+    const styleFsPath = path.join(this.extensionUri.fsPath, 'webview', 'settings', 'styles.css');
+    const hasScript = fs.existsSync(scriptFsPath);
+    const hasStyle = fs.existsSync(styleFsPath);
+
+    if (!hasScript || !hasStyle) {
+      console.warn(
+        `[settingsView] missing webview assets: script=${hasScript ? 'ok' : scriptFsPath} style=${hasStyle ? 'ok' : styleFsPath}`,
+      );
+    }
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} https: data:; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource} 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="${styleUri}" rel="stylesheet" />
+  <title>Agentize Settings</title>
+</head>
+<body>
+  <div id="settings-root" class="settings-root">
+    <div class="plan-skeleton">
+      <div class="plan-skeleton-title">Settings</div>
+      <div id="settings-skeleton-status" class="plan-skeleton-subtitle">Loading webview UI...</div>
+      ${hasScript && hasStyle ? '' : '<div class="plan-skeleton-error">Webview assets missing. Run <code>make vscode-plugin</code> and reload VS Code.</div>'}
+    </div>
+  </div>
+  <script nonce="${nonce}">
+    (function() {
+      const statusEl = document.getElementById('settings-skeleton-status');
+      const initialStatus = statusEl ? statusEl.textContent : '';
+      const setStatus = (text) => {
+        if (statusEl) statusEl.textContent = text;
+      };
+      const setStatusIfUnchanged = (text) => {
+        if (!statusEl) return;
+        if (statusEl.textContent === initialStatus) {
+          statusEl.textContent = text;
+        }
+      };
+
+      window.addEventListener('error', (event) => {
+        const message = event && event.message ? event.message : 'Unknown error';
+        setStatus('Webview error: ' + message);
+      });
+
+      window.addEventListener('unhandledrejection', (event) => {
+        let reason = 'Unknown rejection';
+        if (event && event.reason) {
+          try { reason = String(event.reason); } catch (_) {}
+        }
+        setStatus('Webview rejection: ' + reason);
+      });
+
+      const script = document.createElement('script');
+      script.src = "${scriptUri}";
+      script.type = "module";
+      script.nonce = "${nonce}";
+      script.onload = () => {
+        setStatusIfUnchanged('Webview script loaded; waiting for init...');
+        setTimeout(() => {
+          setStatusIfUnchanged('Webview script loaded but did not initialize.');
+        }, 2000);
+      };
+      script.onerror = () => setStatus('Failed to load webview script.');
+      document.body.appendChild(script);
+    })();
+  </script>
+</body>
+</html>`;
+  }
+
+  private getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let value = '';
+    for (let i = 0; i < 32; i += 1) {
+      value += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return value;
+  }
+}

--- a/vscode/src/view/worktreeViewProvider.md
+++ b/vscode/src/view/worktreeViewProvider.md
@@ -1,0 +1,21 @@
+# worktreeViewProvider.ts
+
+Webview view provider that renders the Worktree Activity Bar panel with a static
+placeholder layout.
+
+## External Interface
+
+### WorktreeViewProvider
+- `resolveWebviewView(view: vscode.WebviewView)`: configures the webview options,
+  injects the Worktree HTML shell, and loads the compiled webview assets.
+
+## Internal Helpers
+
+### buildHtml(webview: vscode.Webview)
+Builds the CSP-safe HTML shell, including the Worktree CSS and compiled script.
+The HTML includes a small skeleton card that keeps the view readable while assets
+load or when they are missing.
+
+### getNonce()
+Generates a random nonce for the CSP `script-src` directive so the inline
+bootstrap script can safely load the Worktree module.

--- a/vscode/src/view/worktreeViewProvider.ts
+++ b/vscode/src/view/worktreeViewProvider.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class WorktreeViewProvider implements vscode.WebviewViewProvider {
+  static readonly viewType = 'agentize.worktreeView';
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'webview')],
+    };
+
+    view.webview.html = this.buildHtml(view.webview);
+  }
+
+  private buildHtml(webview: vscode.Webview): string {
+    const scriptPath = vscode.Uri.joinPath(this.extensionUri, 'webview', 'worktree', 'out', 'index.js');
+    const stylePath = vscode.Uri.joinPath(this.extensionUri, 'webview', 'worktree', 'styles.css');
+    const scriptUri = webview.asWebviewUri(scriptPath);
+    const styleUri = webview.asWebviewUri(stylePath);
+    const nonce = this.getNonce();
+    const scriptFsPath = path.join(this.extensionUri.fsPath, 'webview', 'worktree', 'out', 'index.js');
+    const styleFsPath = path.join(this.extensionUri.fsPath, 'webview', 'worktree', 'styles.css');
+    const hasScript = fs.existsSync(scriptFsPath);
+    const hasStyle = fs.existsSync(styleFsPath);
+
+    if (!hasScript || !hasStyle) {
+      console.warn(
+        `[worktreeView] missing webview assets: script=${hasScript ? 'ok' : scriptFsPath} style=${hasStyle ? 'ok' : styleFsPath}`,
+      );
+    }
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} https: data:; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource} 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="${styleUri}" rel="stylesheet" />
+  <title>Agentize Worktree</title>
+</head>
+<body>
+  <div id="worktree-root" class="worktree-root">
+    <div class="plan-skeleton">
+      <div class="plan-skeleton-title">Worktree</div>
+      <div id="worktree-skeleton-status" class="plan-skeleton-subtitle">Loading webview UI...</div>
+      ${hasScript && hasStyle ? '' : '<div class="plan-skeleton-error">Webview assets missing. Run <code>make vscode-plugin</code> and reload VS Code.</div>'}
+    </div>
+  </div>
+  <script nonce="${nonce}">
+    (function() {
+      const statusEl = document.getElementById('worktree-skeleton-status');
+      const initialStatus = statusEl ? statusEl.textContent : '';
+      const setStatus = (text) => {
+        if (statusEl) statusEl.textContent = text;
+      };
+      const setStatusIfUnchanged = (text) => {
+        if (!statusEl) return;
+        if (statusEl.textContent === initialStatus) {
+          statusEl.textContent = text;
+        }
+      };
+
+      window.addEventListener('error', (event) => {
+        const message = event && event.message ? event.message : 'Unknown error';
+        setStatus('Webview error: ' + message);
+      });
+
+      window.addEventListener('unhandledrejection', (event) => {
+        let reason = 'Unknown rejection';
+        if (event && event.reason) {
+          try { reason = String(event.reason); } catch (_) {}
+        }
+        setStatus('Webview rejection: ' + reason);
+      });
+
+      const script = document.createElement('script');
+      script.src = "${scriptUri}";
+      script.type = "module";
+      script.nonce = "${nonce}";
+      script.onload = () => {
+        setStatusIfUnchanged('Webview script loaded; waiting for init...');
+        setTimeout(() => {
+          setStatusIfUnchanged('Webview script loaded but did not initialize.');
+        }, 2000);
+      };
+      script.onerror = () => setStatus('Failed to load webview script.');
+      document.body.appendChild(script);
+    })();
+  </script>
+</body>
+</html>`;
+  }
+
+  private getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let value = '';
+    for (let i = 0; i < 32; i += 1) {
+      value += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return value;
+  }
+}

--- a/vscode/webview/README.md
+++ b/vscode/webview/README.md
@@ -1,7 +1,9 @@
 # Plan Webview Assets
 
-This folder contains webview assets for the VS Code Plan Activity Bar view.
+This folder contains webview assets for the VS Code Activity Bar views.
 
 ## Organization
 
 - `plan/` holds the Plan tab UI script and styles.
+- `worktree/` holds the Worktree placeholder UI script and styles.
+- `settings/` holds the Settings placeholder UI script and styles.

--- a/vscode/webview/settings/README.md
+++ b/vscode/webview/settings/README.md
@@ -1,0 +1,9 @@
+# Settings Webview
+
+UI assets for the Settings Activity Bar tab.
+
+## Organization
+
+- `index.ts` renders the placeholder UI.
+- `styles.css` provides the Settings tab styling.
+- `tsconfig.json` compiles the webview script to `out/`.

--- a/vscode/webview/settings/index.md
+++ b/vscode/webview/settings/index.md
@@ -1,0 +1,13 @@
+# index.ts
+
+Webview script that renders the Settings placeholder experience.
+
+## External Interface
+
+### UI Rendering
+- Replaces the `#settings-root` contents with a centered "Under Construction" card.
+- Updates the skeleton status line once rendering succeeds.
+
+## Internal Helpers
+
+No internal helpers; this script only renders static markup.

--- a/vscode/webview/settings/index.ts
+++ b/vscode/webview/settings/index.ts
@@ -1,0 +1,30 @@
+(() => {
+  const statusEl = document.getElementById('settings-skeleton-status');
+  if (statusEl) {
+    statusEl.textContent = 'Rendering Settings placeholder...';
+  }
+
+  const root = document.getElementById('settings-root');
+  if (!root) {
+    if (statusEl) {
+      statusEl.textContent = 'Missing #settings-root element in webview HTML.';
+    }
+    return;
+  }
+
+  root.innerHTML = `
+    <main class="settings-placeholder" role="status" aria-live="polite">
+      <div class="settings-placeholder-icon" aria-hidden="true">&#x1F6A7;</div>
+      <div class="settings-placeholder-title">Settings</div>
+      <div class="settings-placeholder-subtitle">Under Construction</div>
+      <p class="settings-placeholder-body">
+        Settings controls will live here. Expect configuration, defaults, and
+        quality-of-life toggles for Agentize workflows.
+      </p>
+    </main>
+  `;
+
+  if (statusEl) {
+    statusEl.textContent = 'Settings placeholder ready.';
+  }
+})();

--- a/vscode/webview/settings/styles.css
+++ b/vscode/webview/settings/styles.css
@@ -1,0 +1,47 @@
+@import url('../plan/styles.css');
+
+.settings-root {
+  padding: 24px 18px;
+  min-height: calc(100vh - 48px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-placeholder {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  max-width: 320px;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.settings-placeholder-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+}
+
+.settings-placeholder-title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-size: 18px;
+}
+
+.settings-placeholder-subtitle {
+  margin-top: 4px;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.settings-placeholder-body {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}

--- a/vscode/webview/settings/styles.md
+++ b/vscode/webview/settings/styles.md
@@ -1,0 +1,17 @@
+# styles.css
+
+Styles for the Settings placeholder UI, layered on the shared warm-cream theme.
+
+## External Interface
+
+### Layout Classes
+- `.settings-root`: top-level layout container.
+- `.settings-placeholder`: card container for the placeholder content.
+- `.settings-placeholder-icon`: emoji icon styling.
+- `.settings-placeholder-title`: primary title text.
+- `.settings-placeholder-subtitle`: short status line.
+- `.settings-placeholder-body`: descriptive text.
+
+## Internal Helpers
+
+No internal helpers; this file only provides static styles.

--- a/vscode/webview/settings/tsconfig.json
+++ b/vscode/webview/settings/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "types": [],
+    "rootDir": ".",
+    "outDir": "out",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["out"]
+}

--- a/vscode/webview/worktree/README.md
+++ b/vscode/webview/worktree/README.md
@@ -1,0 +1,9 @@
+# Worktree Webview
+
+UI assets for the Worktree Activity Bar tab.
+
+## Organization
+
+- `index.ts` renders the placeholder UI.
+- `styles.css` provides the Worktree tab styling.
+- `tsconfig.json` compiles the webview script to `out/`.

--- a/vscode/webview/worktree/index.md
+++ b/vscode/webview/worktree/index.md
@@ -1,0 +1,13 @@
+# index.ts
+
+Webview script that renders the Worktree placeholder experience.
+
+## External Interface
+
+### UI Rendering
+- Replaces the `#worktree-root` contents with a centered "Under Construction" card.
+- Updates the skeleton status line once rendering succeeds.
+
+## Internal Helpers
+
+No internal helpers; this script only renders static markup.

--- a/vscode/webview/worktree/index.ts
+++ b/vscode/webview/worktree/index.ts
@@ -1,0 +1,30 @@
+(() => {
+  const statusEl = document.getElementById('worktree-skeleton-status');
+  if (statusEl) {
+    statusEl.textContent = 'Rendering Worktree placeholder...';
+  }
+
+  const root = document.getElementById('worktree-root');
+  if (!root) {
+    if (statusEl) {
+      statusEl.textContent = 'Missing #worktree-root element in webview HTML.';
+    }
+    return;
+  }
+
+  root.innerHTML = `
+    <main class="worktree-placeholder" role="status" aria-live="polite">
+      <div class="worktree-placeholder-icon" aria-hidden="true">&#x1F6A7;</div>
+      <div class="worktree-placeholder-title">Worktree</div>
+      <div class="worktree-placeholder-subtitle">Under Construction</div>
+      <p class="worktree-placeholder-body">
+        Worktree visibility is on the way. This tab will focus on repository
+        context, branches, and activity snapshots.
+      </p>
+    </main>
+  `;
+
+  if (statusEl) {
+    statusEl.textContent = 'Worktree placeholder ready.';
+  }
+})();

--- a/vscode/webview/worktree/styles.css
+++ b/vscode/webview/worktree/styles.css
@@ -1,0 +1,47 @@
+@import url('../plan/styles.css');
+
+.worktree-root {
+  padding: 24px 18px;
+  min-height: calc(100vh - 48px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.worktree-placeholder {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  max-width: 320px;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.worktree-placeholder-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+}
+
+.worktree-placeholder-title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-size: 18px;
+}
+
+.worktree-placeholder-subtitle {
+  margin-top: 4px;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.worktree-placeholder-body {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}

--- a/vscode/webview/worktree/styles.md
+++ b/vscode/webview/worktree/styles.md
@@ -1,0 +1,17 @@
+# styles.css
+
+Styles for the Worktree placeholder UI, layered on the shared warm-cream theme.
+
+## External Interface
+
+### Layout Classes
+- `.worktree-root`: top-level layout container.
+- `.worktree-placeholder`: card container for the placeholder content.
+- `.worktree-placeholder-icon`: emoji icon styling.
+- `.worktree-placeholder-title`: primary title text.
+- `.worktree-placeholder-subtitle`: short status line.
+- `.worktree-placeholder-body`: descriptive text.
+
+## Internal Helpers
+
+No internal helpers; this file only provides static styles.

--- a/vscode/webview/worktree/tsconfig.json
+++ b/vscode/webview/worktree/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "types": [],
+    "rootDir": ".",
+    "outDir": "out",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["out"]
+}


### PR DESCRIPTION
[feat][#889] Add Worktree and Settings sidebar tabs

## Summary
- Add Worktree and Settings webview providers with under-construction placeholders.
- Share the warm-cream theme and add tab icons for the new views.
- Update extension manifests and documentation for the multi-tab sidebar.

## Testing
- make vscode-plugin

Issue 889 resolved
closes #889
