### PR TITLE
[feat][#945] Unify planner input shortcuts

### DIFF
--- a/vscode/test/playwright/test-session-append.js
+++ b/vscode/test/playwright/test-session-append.js
@@ -155,6 +155,26 @@ const run = async () => {
     await page.waitForSelector('#plan-textarea', { timeout: 10000 });
     await page.screenshot({ path: nextScreenshotPath(), fullPage: true });
 
+    const hintText = await page.locator('.input-hint').textContent();
+    if (!hintText || !hintText.includes('Esc to cancel')) {
+      throw new Error(`Plan input hint text missing Esc guidance: ${hintText || 'empty'}`);
+    }
+
+    const planButtonCount = await page.locator('#plan-input button').count();
+    if (planButtonCount !== 0) {
+      throw new Error(`Plan input should not include buttons; found ${planButtonCount}`);
+    }
+
+    await page.press('#plan-textarea', 'Escape');
+    await page.waitForFunction(() => {
+      const panel = document.getElementById('plan-input');
+      return Boolean(panel && panel.classList.contains('hidden'));
+    }, { timeout: 10000 });
+    await page.screenshot({ path: nextScreenshotPath(), fullPage: true });
+
+    await page.click('#new-plan');
+    await page.waitForSelector('#plan-textarea', { timeout: 10000 });
+
     await page.fill('#plan-textarea', PLAN_PROMPT);
     const submitShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter';
     await page.press('#plan-textarea', submitShortcut);

--- a/vscode/webview/plan/index.ts
+++ b/vscode/webview/plan/index.ts
@@ -52,11 +52,7 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
     <div id="plan-input" class="plan-input hidden">
       <label class="input-label" for="plan-textarea">Plan prompt</label>
       <textarea id="plan-textarea" rows="6" placeholder="Describe the plan you want to run..."></textarea>
-      <div class="input-actions">
-        <button id="plan-run" class="primary">Run Plan</button>
-        <button id="plan-cancel">Cancel</button>
-        <span class="hint">Cmd+Enter / Ctrl+Enter to run</span>
-      </div>
+      <div class="input-hint">Cmd+Enter / Ctrl+Enter to run, Esc to cancel.</div>
     </div>
     <div id="session-list" class="session-list"></div>
   `;
@@ -66,8 +62,6 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
   const newPlanButton = document.getElementById('new-plan');
   const inputPanel = document.getElementById('plan-input');
   const textarea = document.getElementById('plan-textarea') as HTMLTextAreaElement;
-  const runButton = document.getElementById('plan-run');
-  const cancelButton = document.getElementById('plan-cancel');
   const sessionList = document.getElementById('session-list');
 
   type SessionNode = {
@@ -150,18 +144,14 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
     showInputPanel();
   });
 
-  runButton?.addEventListener('click', () => {
-    submitPlan();
-  });
-
-  cancelButton?.addEventListener('click', () => {
-    hideInputPanel();
-  });
-
   textarea?.addEventListener('keydown', (event) => {
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       submitPlan();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      hideInputPanel();
     }
   });
 

--- a/vscode/webview/plan/styles.css
+++ b/vscode/webview/plan/styles.css
@@ -125,16 +125,9 @@ button:disabled {
   resize: vertical;
 }
 
-.input-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.hint {
+.input-hint {
   font-size: 12px;
   color: var(--muted);
-  margin-left: auto;
 }
 
 .session-list {
@@ -491,9 +484,5 @@ button:disabled {
 
   .session-header {
     flex-wrap: wrap;
-  }
-
-  .hint {
-    margin-left: 0;
   }
 }


### PR DESCRIPTION
[feat][#945] Unify planner input shortcuts
Summary:
- Remove planner run/cancel buttons and add Esc cancellation handling.
- Update planner hint text to match the refine shortcut pattern.
- Extend the Playwright plan session test to cover hint text and Escape behavior.
Files:
- vscode/webview/plan/index.ts: simplify plan input markup and key handling.
- vscode/webview/plan/styles.css: replace input action styles with input hint styling.
- vscode/test/playwright/test-session-append.js: assert hint text, no buttons, and Escape hides the panel.
Tests:
- make vscode-plugin
- TEST_SHELLS="bash zsh" make test-fast

Issue 945 resolved
closes #945
