### PR TITLE
[bugfix][#954] Preserve terminal collapse state on session updates

### DIFF
--- a/vscode/webview/plan/index.md
+++ b/vscode/webview/plan/index.md
@@ -47,6 +47,9 @@ state and live updates aligned without legacy duplicated UI sections.
 For progress widgets, hydration now prefers persisted `metadata.progressEvents` timestamps
 over raw log replay, so elapsed stage timings remain stable across reloads.
 
+Terminal widgets only apply collapsed state when `metadata.collapsed` is explicitly defined.
+This preserves user-toggled collapse state during session updates.
+
 ## Process Control
 
 Terminal headers include stop controls that post `plan/stop`. The stop button is surfaced

--- a/vscode/webview/plan/index.ts
+++ b/vscode/webview/plan/index.ts
@@ -474,7 +474,10 @@ declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
       if (Array.isArray(widget.content)) {
         terminal.setLines(widget.content);
       }
-      terminal.setCollapsed(Boolean(widget.metadata?.collapsed));
+      // Only apply persisted collapsed state when explicitly defined.
+      if (typeof widget.metadata?.collapsed === 'boolean') {
+        terminal.setCollapsed(widget.metadata.collapsed);
+      }
       return;
     }
 


### PR DESCRIPTION
[bugfix][#954] Preserve terminal collapse state on session updates

Summary:
- Preserve terminal widget collapse state during session refreshes by honoring explicit metadata only.
- Document terminal hydration behavior for collapse state preservation.

Tests:
- make vscode-plugin

Issue 954 resolved
closes #954
