### PR TITLE
[feat][#956] Equal-width plan action buttons

### DIFF
--- a/vscode/webview/plan/styles.css
+++ b/vscode/webview/plan/styles.css
@@ -321,7 +321,9 @@ button:disabled {
   color: var(--text);
   cursor: pointer;
   white-space: nowrap;
-  flex: 0 0 auto;
+  /* Equal-width buttons: flex distributes space evenly, min-width prevents truncation. */
+  flex: 1 1 0;
+  min-width: 70px;
 }
 
 .widget-button-primary {


### PR DESCRIPTION
[feat][#956] Equal-width plan action buttons

Summary:
- Make plan action buttons equal-width with a minimum size for dynamic labels.
- Document the layout intent directly in the button styles.
- Issue 956 resolved.

Tests:
- `make vscode-plugin`
- `node vscode/test/playwright/test-session-append.js`

closes #956
