### PR TITLE
[feat][#963] VSCode Plugin Equal-Width Tabs with Overflow Protection

### DIFF
--- a/tests/vscode/test-tab-styling.sh
+++ b/tests/vscode/test-tab-styling.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Test: Tab styling CSS properties for equal-width tabs with overflow protection
+
+source "$(dirname "$0")/../common.sh"
+
+test_info "Testing tab styling CSS properties"
+
+PROVIDER_FILE="vscode/src/view/unifiedViewProvider.ts"
+
+# Check that the required CSS properties are present in .unified-tab
+if ! grep -q "flex: 1;" "$PROVIDER_FILE"; then
+  test_fail "Missing 'flex: 1' CSS property in .unified-tab"
+fi
+
+if ! grep -q "text-align: center;" "$PROVIDER_FILE"; then
+  test_fail "Missing 'text-align: center' CSS property in .unified-tab"
+fi
+
+if ! grep -q "white-space: nowrap;" "$PROVIDER_FILE"; then
+  test_fail "Missing 'white-space: nowrap' CSS property in .unified-tab"
+fi
+
+if ! grep -q "overflow: hidden;" "$PROVIDER_FILE"; then
+  test_fail "Missing 'overflow: hidden' CSS property in .unified-tab"
+fi
+
+if ! grep -q "text-overflow: ellipsis;" "$PROVIDER_FILE"; then
+  test_fail "Missing 'text-overflow: ellipsis' CSS property in .unified-tab"
+fi
+
+# Verify properties are within .unified-tab context (not in other classes)
+# Extract the .unified-tab CSS block and verify all properties are present
+TAB_BLOCK=$(sed -n '/\.unified-tab {/,/^    }$/p' "$PROVIDER_FILE" | head -n 20)
+
+if ! echo "$TAB_BLOCK" | grep -q "flex: 1"; then
+  test_fail "'flex: 1' not found within .unified-tab CSS block"
+fi
+
+if ! echo "$TAB_BLOCK" | grep -q "text-align: center"; then
+  test_fail "'text-align: center' not found within .unified-tab CSS block"
+fi
+
+if ! echo "$TAB_BLOCK" | grep -q "white-space: nowrap"; then
+  test_fail "'white-space: nowrap' not found within .unified-tab CSS block"
+fi
+
+if ! echo "$TAB_BLOCK" | grep -q "overflow: hidden"; then
+  test_fail "'overflow: hidden' not found within .unified-tab CSS block"
+fi
+
+if ! echo "$TAB_BLOCK" | grep -q "text-overflow: ellipsis"; then
+  test_fail "'text-overflow: ellipsis' not found within .unified-tab CSS block"
+fi
+
+test_pass "Tab styling CSS properties verified"

--- a/vscode/src/view/unifiedViewProvider.md
+++ b/vscode/src/view/unifiedViewProvider.md
@@ -61,6 +61,14 @@ while scrolling.
 Inactive tabs intentionally use a lighter muted label color to keep focus emphasis on
 the active tab.
 
+Tab Styling:
+The `.unified-tab` class uses flexbox with `flex: 1` to distribute equal width to all tabs,
+ensuring the Plan, Worktree, and Settings tabs maintain consistent proportions regardless
+of label text length. Tab labels are centered via `text-align: center`. To prevent layout
+issues in narrow sidebars, overflow protection is applied: `white-space: nowrap` prevents
+text wrapping, `overflow: hidden` clips excess content, and `text-overflow: ellipsis`
+displays an ellipsis ("...") when labels are truncated due to insufficient space.
+
 ### buildPlanSkeleton(hasAssets: boolean)
 Loads `webview/plan/skeleton.html` and injects an asset-missing banner when compiled
 assets are not present on disk.

--- a/vscode/src/view/unifiedViewProvider.ts
+++ b/vscode/src/view/unifiedViewProvider.ts
@@ -2047,6 +2047,11 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
       letter-spacing: 0.12em;
       text-transform: uppercase;
       box-shadow: none;
+      flex: 1;
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .unified-tab.is-active {


### PR DESCRIPTION
[feat][#963] VSCode Plugin Equal-Width Tabs with Overflow Protection

Implement equal-width tabs for the VSCode plugin's unified view to improve
visual harmony and professional appearance.

## Changes

**vscode/src/view/unifiedViewProvider.ts:**
- Add `flex: 1` to distribute equal width to all three tabs (Plan, Worktree, Settings)
- Add `text-align: center` to center tab labels
- Add `white-space: nowrap` to prevent text wrapping
- Add `overflow: hidden` and `text-overflow: ellipsis` for graceful overflow handling

**vscode/src/view/unifiedViewProvider.md:**
- Document tab styling behavior including flexbox equal-width distribution
- Document overflow protection strategy for narrow sidebars

**tests/vscode/test-tab-styling.sh:**
- New visual regression test to verify all required CSS properties are present

## Success Criteria

- ✅ `flex: 1` distributes equal width to all three tabs
- ✅ `text-align: center` centers tab labels
- ✅ `white-space: nowrap` prevents text wrapping
- ✅ `text-overflow: ellipsis` truncates with "..." when space is insufficient
- ✅ All new CSS properties are documented in interface docs
- ✅ Visual regression tests pass

## Test Results

- tests/vscode/test-link-detection.sh: 14 passed, 0 failed
- tests/vscode/test-step-progress-parser.sh: 7 passed, 0 failed
- tests/vscode/test-tab-styling.sh: passed

Build verified: `make vscode-plugin` compiles successfully with no errors.

Issue 963 resolved

closes #963
