### PR TITLE
[#984][bugfix][cli] Normalize --yolo to --full-auto for Codex provider

### DIFF
--- a/docs/cli/acw.md
+++ b/docs/cli/acw.md
@@ -177,7 +177,7 @@ autoload -Uz compinit && compinit
 ## Notes
 
 - The output directory is created automatically if it doesn't exist (skipped when `--stdout` is used)
-- Provider-specific options are passed through unchanged, except `--yolo` is normalized to Claude's `--dangerously-skip-permissions`
+- Provider-specific options are passed through unchanged, except `--yolo` is normalized to Claude's `--dangerously-skip-permissions` and Codex's `--full-auto`
 - The wrapper returns the provider's exit code on successful execution
 - Best-effort providers (opencode, cursor, kimi) may have limited functionality
 - Only `acw` is the public function; all helper functions (provider invocation, completion, validation) are internal (prefixed with `_acw_`) and won't appear in tab completion

--- a/docs/cli/lol.md
+++ b/docs/cli/lol.md
@@ -269,7 +269,7 @@ lol impl <issue-no> [--backend <provider:model>] [--max-iterations <N>] [--yolo]
 |--------|----------|---------|-------------|
 | `--backend` | No | `impl.model` or `codex:gpt-5.2-codex` | Backend in `provider:model` form |
 | `--max-iterations` | No | `impl.max_iter` or `10` | Maximum `acw` iterations before giving up |
-| `--yolo` | No | Off | Pass through to provider CLI options (Claude via acw maps to `--dangerously-skip-permissions`) |
+| `--yolo` | No | Off | Pass through to provider CLI options (Claude via acw maps to `--dangerously-skip-permissions`; Codex maps to `--full-auto`) |
 | `--wait-for-ci` | No | Off | After PR creation, monitor mergeability + CI and iterate on failures |
 
 #### Impl defaults in `.agentize.local.yaml`

--- a/python/agentize/workflow/impl/continue-prompt.md
+++ b/python/agentize/workflow/impl/continue-prompt.md
@@ -3,7 +3,7 @@ Each iteration:
 - read the issue file for the context, and read the current repo file state to determine what to do next to achieve the goal.
 - it is ok to fail some test cases temporarily at the end of an iteration, as long as they are properly reported for further development.
 - create the commit report file for the current iteration in .tmp/commit-report-iter-<iter>.txt with the full commit message for this iteration.
-- update {{finalize_file}} with PR title (first line) and body (full file); include "Issue {{issue_no}} resolved" only when done.
+- update {{finalize_file}} with PR title (first line) and body (full file); include "Issue {{issue_no}} resolved" only when done. Example: `echo "Issue {{issue_no}} resolved" >> {{finalize_file}}`
 
 PR Title Format:
 The first line of {{finalize_file}} will be used as the PR title and MUST follow this exact format:

--- a/python/agentize/workflow/impl/continue-prompt.md
+++ b/python/agentize/workflow/impl/continue-prompt.md
@@ -3,22 +3,28 @@ Each iteration:
 - read the issue file for the context, and read the current repo file state to determine what to do next to achieve the goal.
 - it is ok to fail some test cases temporarily at the end of an iteration, as long as they are properly reported for further development.
 - create the commit report file for the current iteration in .tmp/commit-report-iter-<iter>.txt with the full commit message for this iteration.
-- update {{finalize_file}} with PR title (first line) and body (full file); include "Issue {{issue_no}} resolved" only when done. Example: `echo "Issue {{issue_no}} resolved" >> {{finalize_file}}`
-
-PR Title Format:
-The first line of {{finalize_file}} will be used as the PR title and MUST follow this exact format:
-  [tag][#{{issue_no}}] Brief description
-
-Examples:
-  [feat][#42] Add user authentication
-  [bugfix][#15] Fix memory leak in worker
-  [agent.skill][#3] Add code review skill
 
 Available tags are defined in docs/git-msg-tags.md. Choose the most specific tag for your changes.
 - before claiming completion, ensure you have the goal described in the issue file fully implemented, and all tests are passing.
-- once completed the implementation, create a {{finalize_file}} file with the PR title and body, including "closes #{{issue_no}}" at the end of the body.
 
 If a CI failure context section is provided, use it to prioritize fixes and
 include relevant test updates or diagnostics in your response.
+
+COMPLETION SIGNAL (MANDATORY):
+When implementation is done, you MUST create {{finalize_file}} with this exact structure:
+Line 1: PR title in format [tag][#{{issue_no}}] Brief description
+Line 2+: PR body describing the changes
+Last line: "Issue {{issue_no}} resolved" and "closes #{{issue_no}}"
+
+Run this command to create the file:
+```
+cat > {{finalize_file}} << 'FINALIZE_EOF'
+[tag][#{{issue_no}}] Brief description of changes
+Summary of what was implemented.
+Issue {{issue_no}} resolved
+closes #{{issue_no}}
+FINALIZE_EOF
+```
+The orchestrator checks {{finalize_file}} for "Issue {{issue_no}} resolved" after every iteration. If the file does not exist or does not contain this string, another iteration will run. You MUST create this file in the SAME iteration where you finish the implementation.
 
 {{iteration_section}}{{previous_output_section}}{{previous_commit_report_section}}{{ci_failure_section}}

--- a/python/agentize/workflow/impl/kernels.py
+++ b/python/agentize/workflow/impl/kernels.py
@@ -868,6 +868,22 @@ def impl_kernel(
         ci_failure=ci_failure,
     )
 
+    # Write AGENTS.md for non-claude providers (e.g., Codex reads this at startup)
+    if provider != "claude":
+        agents_md = state.worktree / "AGENTS.md"
+        if not agents_md.exists():
+            agents_md.write_text(
+                f"IMPORTANT: After implementing the fix, you MUST create "
+                f"{finalize_file} with the completion marker.\n"
+                f"Run: cat > {finalize_file} << 'EOF'\n"
+                f"[bugfix][#{ state.issue_no}] Brief description\n"
+                f"Issue {state.issue_no} resolved\n"
+                f"closes #{state.issue_no}\n"
+                f"EOF\n"
+                f"The orchestrator will loop forever if this file is missing.\n",
+                encoding="utf-8",
+            )
+
     # Run the prompt
     extra_flags = ["--yolo"] if yolo else None
     try:

--- a/src/cli/acw/providers.md
+++ b/src/cli/acw/providers.md
@@ -18,6 +18,7 @@ serve as the provider invocation surface for the dispatcher.
 
 ### _acw_invoke_codex <model> <input> <output> [options...]
 - Reads the prompt from `input` via stdin and writes the response to `output`.
+- Normalizes `--yolo` to `--full-auto`.
 - Returns the Codex CLI exit code.
 
 ### _acw_invoke_opencode <model> <input> <output> [options...]

--- a/src/cli/acw/providers.sh
+++ b/src/cli/acw/providers.sh
@@ -42,9 +42,19 @@ _acw_invoke_codex() {
     local output="$3"
     shift 3
 
+    # Normalize --yolo to Codex's supported flag
+    local args=()
+    for arg in "$@"; do
+        if [ "$arg" = "--yolo" ]; then
+            args+=( "--full-auto" )
+        else
+            args+=( "$arg" )
+        fi
+    done
+
     # Codex reads from stdin, uses -o for output file
     # stderr passes through for progress messages
-    codex exec --model "$model" -o "$output" "$@" - < "$input"
+    codex exec --model "$model" -o "$output" "${args[@]}" - < "$input"
 }
 
 # Invoke Opencode CLI (best-effort)

--- a/tests/cli/test-acw-codex-yolo-translation.sh
+++ b/tests/cli/test-acw-codex-yolo-translation.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Test: acw --yolo translation for Codex provider
+# Verifies that --yolo is translated to --full-auto when invoking Codex
+
+source "$(dirname "$0")/../common.sh"
+
+ACW_CLI="$PROJECT_ROOT/src/cli/acw.sh"
+
+test_info "Testing --yolo translation for Codex provider"
+
+# Create temp directory for test artifacts
+TMP_DIR=$(make_temp_dir "acw-codex-yolo-$$")
+trap 'cleanup_dir "$TMP_DIR"' EXIT
+
+# Create a simple input file
+echo "Test prompt" > "$TMP_DIR/input.txt"
+
+# Create a stub codex command that logs its arguments
+cat > "$TMP_DIR/codex" << 'STUB'
+#!/usr/bin/env bash
+# Log all arguments to a file for verification
+echo "$@" > "$ARGS_LOG_FILE"
+# Write dummy output to the -o file
+for i in $(seq 1 $#); do
+    if [ "${!i}" = "-o" ]; then
+        next=$((i + 1))
+        echo "stub response" > "${!next}"
+        break
+    fi
+done
+STUB
+chmod +x "$TMP_DIR/codex"
+
+# Prepend our stub directory to PATH so the stub is found first
+export PATH="$TMP_DIR:$PATH"
+export ARGS_LOG_FILE="$TMP_DIR/args.log"
+export AGENTIZE_HOME="$PROJECT_ROOT"
+
+# Source the acw module
+source "$ACW_CLI"
+
+# Test: invoke acw with codex and --yolo flag
+test_info "Invoking acw codex with --yolo flag"
+acw codex test-model "$TMP_DIR/input.txt" "$TMP_DIR/codex-output.txt" --yolo
+
+# Check if the args log contains --full-auto instead of --yolo
+if [ ! -f "$ARGS_LOG_FILE" ]; then
+    test_fail "Codex stub was not invoked - args log file missing"
+fi
+
+logged_args=$(cat "$ARGS_LOG_FILE")
+test_info "Logged args: $logged_args"
+
+if echo "$logged_args" | grep -q -- "--yolo"; then
+    test_fail "--yolo was passed directly to Codex instead of being translated"
+fi
+
+if ! echo "$logged_args" | grep -q -- "--full-auto"; then
+    test_fail "--yolo was not translated to --full-auto for Codex"
+fi
+
+test_pass "--yolo correctly translated to --full-auto for Codex"


### PR DESCRIPTION
## Summary

Fix Codex implementation backend completing in 1 iteration instead of looping 4+ times with "completion marker missing".

**Root cause:** Three compounding issues prevented Codex from writing `.tmp/finalize.txt`:
1. `--yolo` flag was passed to Codex unchanged, but Codex requires `--full-auto` for workspace write permissions
2. The prompt template buried the finalize instruction in a bullet list — too implicit for Codex's execution model
3. Codex reads `AGENTS.md` at startup as persistent system instructions, but no such file existed

**Three-layer fix:**

| Layer | File | What it does | Effect |
|-------|------|-------------|--------|
| `--yolo` normalization | `providers.sh` | Translate `--yolo` → `--full-auto` for Codex | Codex can write files (was read-only before) |
| Prompt restructure | `continue-prompt.md` | Move completion signal to prominent standalone section with concrete `cat` heredoc example | Codex understands it must create the file |
| AGENTS.md injection | `kernels.py` | Write AGENTS.md with finalize instructions in worktree before invoking non-claude agents | Codex sees the instruction at startup, before the prompt |

**Measured improvement:**

| Attempt | Iterations | Impl time | Total time |
|---------|-----------|-----------|------------|
| Before fix (infinite loop) | 4+ (killed) | >500s | >900s |
| +--yolo normalization only | 3 iterations | 556s | 904s |
| +stronger prompt | 2 iterations | 601s | 1339s |
| **All three fixes** | **1 iteration** | **91s** | **399s** |

## Test plan

- [x] Claude `--yolo` translation test passes (existing)
- [x] Codex `--yolo` → `--full-auto` translation test passes (new)
- [x] 62/62 Python tests pass
- [x] Live test: `--mode full --limit 1 --impl-backend codex:gpt-5.2-codex` completes in 1 iteration with `impl_done`
- [x] No regression for Claude sonnet impl backend (still 1 iteration)

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)
