### PR TITLE
[#985][feat][eval] Add per-phase time tracking and planning timeout

### DIFF
--- a/python/agentize/eval/README.md
+++ b/python/agentize/eval/README.md
@@ -1,0 +1,10 @@
+# eval/
+
+Evaluation harness and benchmark artifacts for agentize.
+
+## Contents
+
+- `eval_harness.py` — CLI + evaluation pipeline (single-file design)
+- `eval_harness.md` — Design rationale and usage documentation
+- `nginx_tasks.json` — Nginx benchmark task data
+- `eval-report-*.md` — Recorded run summaries and analysis

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -82,13 +82,25 @@ Raw mode has no planning phase — all time is implementation (single `claude -p
 | astropy-13453 | 600s | 47s | 647s | 93% | Yes (600s cap) |
 | **Mean** | **514s** | **190s** | **704s** | **73%** | **2/5 (40%)** |
 
-#### cc.nl (nlcmd — TBD, run pending)
+#### cc.nl (nlcmd — `claude -p "/ultra-planner"` + sonnet impl, --planning-timeout 600)
 
-*To be added after `--mode nlcmd --limit 5 --planning-timeout 600` run.*
+| Task | Planning | Impl | Total | Planning % | Timed out? |
+|------|----------|------|-------|------------|------------|
+| astropy-12907 | 600s | 37s | 637s | 94% | Yes (600s cap, partial plan found) |
+| astropy-13033 | 600s | 64s | 664s | 90% | Yes (600s cap, partial plan found) |
+| **Mean (2/5)** | **600s** | **51s** | **651s** | **92%** | **2/2 (100%)** |
 
-#### cc.script + codex impl (full — opus planning + codex impl, TBD)
+nlcmd planning **always** times out at 600s. The `claude -p "/ultra-planner"` NL dispatch adds ~200-300s overhead compared to direct agent invocation in full mode. However, partial consensus plans are still found and used for implementation. Full 5-task run pending.
 
-*To be added after `--mode full --limit 5 --impl-backend codex:gpt-5.2-codex --planning-timeout 600` run.*
+#### cc.script + codex impl (full — opus planning + codex:gpt-5.2-codex impl, --planning-timeout 600)
+
+| Task | Planning | Impl | Iters | Total | Planning % | Plan T/O? |
+|------|----------|------|-------|-------|------------|-----------|
+| astropy-12907 | 397s | 80s | 1 | 477s | 83% | No |
+| astropy-13033 | 365s | 466s | 2 | 831s | 44% | No |
+| **Mean (2/5)** | **381s** | **273s** | **1.5** | **654s** | **58%** | **0/2** |
+
+Codex impl completes in 1-2 iterations (down from 4+ before #984 fix). Task 2 needed 2 iterations because Codex wrote the code fix but missed the completion marker on iter 1 — a known probabilistic behavior where ~60-70% of tasks complete in 1 iteration. Full 5-task run in progress.
 
 #### Key observations
 

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -56,7 +56,22 @@ We scaled the SWE-bench evaluation from 5 to 20 tasks across three orchestration
 | **cc.nl** | ~123,763* | ~6,188* | ~3,134s* (~52 min) | ~157s* |
 | **cc.script** | 152,796 | 7,640 | 14,241s (3.9 hrs) | 712s |
 
-### Phase Timing Breakdown (5-task sample, 2026-04-07)
+### Phase Timing Breakdown (5-task samples, 2026-04-07)
+
+#### cc.r opus (raw — no planning phase)
+
+| Task | Planning | Impl | Total | Planning % | Timed out? |
+|------|----------|------|-------|------------|------------|
+| astropy-12907 | 0s | 68s | 68s | 0% | N/A |
+| astropy-13033 | 0s | 82s | 82s | 0% | N/A |
+| astropy-13236 | 0s | 68s | 68s | 0% | N/A |
+| astropy-13398 | 0s | 58s | 58s | 0% | N/A |
+| astropy-13453 | 0s | 197s | 197s | 0% | N/A |
+| **Mean** | **0s** | **95s** | **95s** | **0%** | **N/A** |
+
+Raw mode has no planning phase — all time is implementation (single `claude -p` call).
+
+#### cc.script (full — opus planning + sonnet impl, --planning-timeout 600)
 
 | Task | Planning | Impl | Total | Planning % | Timed out? |
 |------|----------|------|-------|------------|------------|
@@ -67,10 +82,20 @@ We scaled the SWE-bench evaluation from 5 to 20 tasks across three orchestration
 | astropy-13453 | 600s | 47s | 647s | 93% | Yes (600s cap) |
 | **Mean** | **514s** | **190s** | **704s** | **73%** | **2/5 (40%)** |
 
-Key observations:
-- Planning accounts for **51-93%** of total task time (mean 73%)
-- Implementation is fast: mean 190s (3.2 min) per task
-- 2/5 tasks hit the 600s planning timeout — typically when understander or bold-proposer runs long
+#### cc.nl (nlcmd — TBD, run pending)
+
+*To be added after `--mode nlcmd --limit 5 --planning-timeout 600` run.*
+
+#### cc.script + codex impl (full — opus planning + codex impl, TBD)
+
+*To be added after `--mode full --limit 5 --impl-backend codex:gpt-5.2-codex --planning-timeout 600` run.*
+
+#### Key observations
+
+- **Raw mode**: All time is implementation — mean 95s/task with opus
+- **Full mode**: Planning accounts for **51-93%** of total task time (mean 73%)
+- Implementation is fast: mean 190s (3.2 min) per task with sonnet
+- 2/5 full-mode tasks hit the 600s planning timeout — typically when understander (48-292s) or bold-proposer (72-347s) runs long
 - Per-agent timing: understander 48-292s, bold 72-347s, critique+reducer 62-108s (parallel), consensus 89-253s
 
 ## Analysis

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -15,7 +15,8 @@ We scaled the SWE-bench evaluation from 5 to 20 tasks across three orchestration
 
 | Mode |  name | Resolved | Rate | Cost | Time |
 |------|-------------|----------|------|------|------|
-| `--mode raw` | **cc.r** | 10/20 | 50% | $4.64 | 34 min |
+| `--mode raw` (sonnet) | **cc.r** | 10/20 | 50% | $4.64 | 34 min |
+| `--mode raw` (opus) | **cc.r.opus** | 10/20 | 50% | $16.77 | 23 min |
 | `--mode nlcmd` | **cc.nl** | 11/20 | 55% | ~$8.94* | ~52 min* |
 | `--mode full` | **cc.script** | 12/20 | 60% | $70.62 | 3.9 hrs |
 

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -95,13 +95,17 @@ nlcmd planning **always** times out at 600s. The `claude -p "/ultra-planner"` NL
 
 #### cc.script + codex impl (full — opus planning + codex:gpt-5.2-codex impl, --planning-timeout 600)
 
-| Task | Planning | Impl | Iters | Total | Planning % | Plan T/O? |
-|------|----------|------|-------|-------|------------|-----------|
-| astropy-12907 | 397s | 80s | 1 | 477s | 83% | No |
-| astropy-13033 | 365s | 466s | 2 | 831s | 44% | No |
-| **Mean (2/5)** | **381s** | **273s** | **1.5** | **654s** | **58%** | **0/2** |
+20-task run: **8/20 completed, 12/20 failed** (Codex exit code 1 — API crashes, not completion marker issue).
 
-Codex impl completes in 1-2 iterations (down from 4+ before #984 fix). Task 2 needed 2 iterations because Codex wrote the code fix but missed the completion marker on iter 1 — a known probabilistic behavior where ~60-70% of tasks complete in 1 iteration. Full 5-task run in progress.
+| Metric | Value |
+|--------|-------|
+| Completed | 8/20 (40%) |
+| Failed (Codex crash) | 12/20 (60%) |
+| Cost total | $99.37 |
+| Planning time | 4939s (mean 247s) |
+| Impl time | 3234s (mean 162s) |
+
+The 12 failed tasks show Codex returning exit code 1 within 1-2s on every iteration — not the completion marker issue but a Codex API failure (likely rate limiting or auth). Tasks 1-8 ran normally (planning 250-600s, impl 80-466s, 1-2 iterations). Tasks 9-20 crashed immediately with `Planning error: Stage failed with exit code 1` followed by 10 instant-fail impl iterations.
 
 #### Key observations
 

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -56,6 +56,23 @@ We scaled the SWE-bench evaluation from 5 to 20 tasks across three orchestration
 | **cc.nl** | ~123,763* | ~6,188* | ~3,134s* (~52 min) | ~157s* |
 | **cc.script** | 152,796 | 7,640 | 14,241s (3.9 hrs) | 712s |
 
+### Phase Timing Breakdown (5-task sample, 2026-04-07)
+
+| Task | Planning | Impl | Total | Planning % | Timed out? |
+|------|----------|------|-------|------------|------------|
+| astropy-12907 | 600s | 55s | 655s | 92% | Yes (600s cap) |
+| astropy-13033 | 488s | 83s | 570s | 86% | No |
+| astropy-13236 | 369s | 280s | 649s | 57% | No |
+| astropy-13398 | 513s | 484s | 998s | 51% | No |
+| astropy-13453 | 600s | 47s | 647s | 93% | Yes (600s cap) |
+| **Mean** | **514s** | **190s** | **704s** | **73%** | **2/5 (40%)** |
+
+Key observations:
+- Planning accounts for **51-93%** of total task time (mean 73%)
+- Implementation is fast: mean 190s (3.2 min) per task
+- 2/5 tasks hit the 600s planning timeout — typically when understander or bold-proposer runs long
+- Per-agent timing: understander 48-292s, bold 72-347s, critique+reducer 62-108s (parallel), consensus 89-253s
+
 ## Analysis
 
 ### Finding 1: cc.r < cc.nl < cc.script confirmed (barely)

--- a/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
+++ b/python/agentize/eval/eval-report-2026-03-16-swebench-20.md
@@ -16,7 +16,7 @@ We scaled the SWE-bench evaluation from 5 to 20 tasks across three orchestration
 | Mode |  name | Resolved | Rate | Cost | Time |
 |------|-------------|----------|------|------|------|
 | `--mode raw` (sonnet) | **cc.r** | 10/20 | 50% | $4.64 | 34 min |
-| `--mode raw` (opus) | **cc.r.opus** | 10/20 | 50% | $16.77 | 23 min |
+| `--mode raw` (opus) | **cc.r.opus** | 11/20 | 55% | $16.77 | 23 min |
 | `--mode nlcmd` | **cc.nl** | 11/20 | 55% | ~$8.94* | ~52 min* |
 | `--mode full` | **cc.script** | 12/20 | 60% | $70.62 | 3.9 hrs |
 

--- a/python/agentize/eval/eval_harness.md
+++ b/python/agentize/eval/eval_harness.md
@@ -67,7 +67,9 @@ instantly.
 
 ### Timeout Enforcement
 
-Both modes enforce the `--timeout` flag. Raw mode uses `subprocess.run(timeout=...)`
+Both modes enforce the `--timeout` flag. Planning in `full`/`nlcmd` also respects
+`--planning-timeout` (default: 600) and reports `planning_timeout` status if the limit
+is exceeded before a plan is available. Raw mode uses `subprocess.run(timeout=...)`
 natively. Full mode runs the planning + FSM body in a daemon thread and joins
 with a deadline — if the thread is still alive after `timeout` seconds, the task
 is marked as `"timeout"` and the main loop moves to the next task. The daemon

--- a/python/agentize/eval/eval_harness.py
+++ b/python/agentize/eval/eval_harness.py
@@ -51,11 +51,13 @@ _MODEL_ID_MAP = {
 
 
 def _make_result(instance_id: str) -> dict:
-    """Create a blank per-task result dict with cost fields."""
+    """Create a blank per-task result dict with cost and timing fields."""
     return {
         "instance_id": instance_id,
         "status": "error",
         "wall_time": 0.0,
+        "planning_time": 0.0,
+        "impl_time": 0.0,
         "tokens": 0,
         "input_tokens": 0,
         "output_tokens": 0,
@@ -722,6 +724,7 @@ def run_full_impl(
     skip_planning: bool = False,
     planner_backend: str | None = None,
     impl_backend: str | None = None,
+    planning_timeout: int = 600,
 ) -> dict:
     """Run the agentize pipeline against a task.
 
@@ -744,6 +747,9 @@ def run_full_impl(
     if not skip_planning:
         result["cost_note"] = "cost estimated from new JSONL session files"
 
+    # Shared timing bucket for phase timing from daemon thread
+    timing_bucket: list[dict] = []
+
     # Run the pipeline body in a daemon thread so we can enforce a timeout.
     # A daemon thread is killed when the main thread moves on; this is
     # acceptable because each task runs in its own isolated worktree.
@@ -752,6 +758,7 @@ def run_full_impl(
 
     def _run_pipeline():
         try:
+            planning_start = time.time()
             status = _run_full_impl_body(
                 wt_path, overrides_path, instance_id,
                 problem_statement, model,
@@ -760,6 +767,10 @@ def run_full_impl(
                 planner_backend=planner_backend,
                 impl_backend=impl_backend,
             )
+            # Record phase timing — planning ends when FSM starts (approximated
+            # by total time minus impl time; the split point is inside
+            # _run_full_impl_body which we can't instrument without changing its
+            # return type, so we use wall_time as the authoritative total)
             status_bucket.append(status)
         except Exception as exc:
             exc_bucket.append(exc)
@@ -954,6 +965,7 @@ def run_nlcmd_impl(
     enable_simp: bool = False,
     max_iterations: int = 10,
     impl_backend: str | None = None,
+    planning_timeout: int = 600,
 ) -> dict:
     """Run multi-agent NL planning command + FSM implementation.
 
@@ -1000,12 +1012,13 @@ def run_nlcmd_impl(
         return result
 
     cmd_str = template.format(problem_statement=problem_statement)
-    planning_timeout = timeout // 2  # reserve half the budget for impl
+    effective_planning_timeout = min(planning_timeout, timeout // 2)
 
-    print(f"  Phase 1: NL planning via '{planner_cmd}' (timeout={planning_timeout}s)",
+    print(f"  Phase 1: NL planning via '{planner_cmd}' (timeout={effective_planning_timeout}s)",
           file=sys.stderr)
 
     plan_text = ""
+    planning_start = time.time()
     try:
         plan_proc = subprocess.run(
             ["claude", "-p", "--output-format", "json",
@@ -1015,7 +1028,7 @@ def run_nlcmd_impl(
             env=env,
             capture_output=True,
             text=True,
-            timeout=planning_timeout,
+            timeout=effective_planning_timeout,
         )
 
         if plan_proc.returncode != 0:
@@ -1050,14 +1063,17 @@ def run_nlcmd_impl(
             print("  No plan produced — falling back to raw problem statement",
                   file=sys.stderr)
 
+        result["planning_time"] = time.time() - planning_start
+
     except subprocess.TimeoutExpired:
+        result["planning_time"] = time.time() - planning_start
         # Even on timeout, check if a partial consensus was written
         plan_text = _find_consensus_plan(tmp_dir)
         if plan_text:
             print(f"  Planning timed out but partial consensus found ({len(plan_text)} chars)",
                   file=sys.stderr)
         else:
-            result["status"] = "timeout"
+            result["status"] = "planning_timeout"
             result["wall_time"] = time.time() - start_time
             # Capture any JSONL files written before the timeout
             files_after = _list_jsonl_files()
@@ -1073,6 +1089,7 @@ def run_nlcmd_impl(
             return result
 
     # --- Phase 2: FSM impl with plan ---
+    impl_start = time.time()
     remaining_timeout = max(60, timeout - int(time.time() - start_time))
     print(f"  Phase 2: FSM impl (timeout={remaining_timeout}s)", file=sys.stderr)
 
@@ -1096,6 +1113,8 @@ def run_nlcmd_impl(
     worker = threading.Thread(target=_run_impl, daemon=True)
     worker.start()
     worker.join(timeout=remaining_timeout)
+
+    result["impl_time"] = time.time() - impl_start
 
     if worker.is_alive():
         print(f"  Impl timeout after {remaining_timeout}s", file=sys.stderr)
@@ -1192,11 +1211,14 @@ def aggregate_metrics(results: list[dict]) -> dict:
     costs = [r["cost_usd"] for r in results if r.get("cost_usd", 0) > 0]
     input_tokens = [r["input_tokens"] for r in completed if r.get("input_tokens", 0) > 0]
     output_tokens = [r["output_tokens"] for r in completed if r.get("output_tokens", 0) > 0]
+    planning_times = [r["planning_time"] for r in results if r.get("planning_time", 0) > 0]
+    impl_times = [r["impl_time"] for r in results if r.get("impl_time", 0) > 0]
 
     return {
         "total_tasks": len(results),
         "completed": len(completed),
         "timeouts": sum(1 for r in results if r["status"] == "timeout"),
+        "planning_timeouts": sum(1 for r in results if r["status"] == "planning_timeout"),
         "errors": sum(1 for r in results if r["status"] == "error"),
         "compile_failed": sum(1 for r in results if r["status"] == "compile_failed"),
         "failed": sum(1 for r in results if r["status"] == "failed"),
@@ -1207,6 +1229,10 @@ def aggregate_metrics(results: list[dict]) -> dict:
         "output_tokens_total": sum(output_tokens),
         "time_mean": sum(times) / len(times) if times else 0.0,
         "time_total": sum(times),
+        "planning_time_total": sum(planning_times),
+        "planning_time_mean": sum(planning_times) / len(planning_times) if planning_times else 0.0,
+        "impl_time_total": sum(impl_times),
+        "impl_time_mean": sum(impl_times) / len(impl_times) if impl_times else 0.0,
         "cost_total_usd": sum(costs),
         "cost_mean_usd": sum(costs) / len(costs) if costs else 0.0,
     }
@@ -1238,6 +1264,10 @@ def main(argv: list[str] | None = None) -> int:
     run_p.add_argument(
         "--timeout", type=int, default=1800,
         help="Per-task timeout in seconds (default: 1800)",
+    )
+    run_p.add_argument(
+        "--planning-timeout", type=int, default=600,
+        help="Planning-phase timeout in seconds for full/nlcmd (default: 600)",
     )
     run_p.add_argument(
         "--output-dir", default=".tmp/eval",
@@ -1412,6 +1442,7 @@ def _cmd_run(args) -> int:
                 enable_simp=args.enable_simp,
                 max_iterations=args.max_iterations,
                 impl_backend=args.impl_backend or None,
+                planning_timeout=args.planning_timeout,
             )
         elif args.mode in ("full", "impl"):
             result = run_full_impl(
@@ -1424,6 +1455,7 @@ def _cmd_run(args) -> int:
                 skip_planning=(args.mode == "impl"),
                 planner_backend=args.planner_backend or None,
                 impl_backend=args.impl_backend or None,
+                planning_timeout=args.planning_timeout,
             )
         else:
             result = run_impl(
@@ -1513,6 +1545,8 @@ def _print_summary(metrics: dict) -> None:
     print(f"Completed:    {metrics['completed']}")
     print(f"Failed:       {metrics['failed']}")
     print(f"Timeouts:     {metrics['timeouts']}")
+    if metrics.get("planning_timeouts", 0) > 0:
+        print(f"Plan T/O:     {metrics['planning_timeouts']}")
     print(f"Errors:       {metrics['errors']}")
     if metrics.get("compile_failed", 0) > 0:
         print(f"Compile fail: {metrics['compile_failed']}")
@@ -1525,6 +1559,10 @@ def _print_summary(metrics: dict) -> None:
     if metrics["time_total"] > 0:
         print(f"Time total:   {metrics['time_total']:.1f}s")
         print(f"Time mean:    {metrics['time_mean']:.1f}s")
+    if metrics.get("planning_time_total", 0) > 0:
+        print(f"Planning time:{metrics['planning_time_total']:.1f}s (mean {metrics['planning_time_mean']:.1f}s)")
+    if metrics.get("impl_time_total", 0) > 0:
+        print(f"Impl time:    {metrics['impl_time_total']:.1f}s (mean {metrics['impl_time_mean']:.1f}s)")
     if metrics.get("cost_total_usd", 0) > 0:
         print(f"Cost total:   ${metrics['cost_total_usd']:.4f}")
         print(f"Cost mean:    ${metrics['cost_mean_usd']:.4f}")

--- a/python/agentize/eval/eval_harness.py
+++ b/python/agentize/eval/eval_harness.py
@@ -766,6 +766,7 @@ def run_full_impl(
                 planner_backend=planner_backend,
                 impl_backend=impl_backend,
                 timing_bucket=timing_bucket,
+                planning_timeout=planning_timeout,
             )
             status_bucket.append(status)
         except Exception as exc:
@@ -790,7 +791,7 @@ def run_full_impl(
     # Extract phase timing from daemon thread
     if timing_bucket:
         result["planning_time"] = timing_bucket[0].get("planning_time", 0.0)
-        result["impl_time"] = result["wall_time"] - result["planning_time"]
+        result["impl_time"] = max(0.0, result["wall_time"] - result["planning_time"])
 
     # Compute cost from NEW JSONL files only (created during this run)
     files_after = _list_jsonl_files()
@@ -821,6 +822,7 @@ def _run_full_impl_body(
     planner_backend: str | None = None,
     impl_backend: str | None = None,
     timing_bucket: list[dict] | None = None,
+    planning_timeout: int = 600,
 ) -> str:
     """Inner body of run_full_impl — runs planning + FSM, returns status string.
 
@@ -861,15 +863,51 @@ def _run_full_impl_body(
         )
     else:
         _planning_start = time.time()
-        issue_content = run_planning_phase(
-            problem_statement,
-            tmp_dir,
-            model,
-            cwd=wt,
-            planner_backend=planner_backend,
-        )
+        # Run planning in a sub-thread to enforce planning_timeout
+        _plan_result: list[str] = []
+        _plan_exc: list[Exception] = []
+
+        def _run_planning():
+            try:
+                content = run_planning_phase(
+                    problem_statement,
+                    tmp_dir,
+                    model,
+                    cwd=wt,
+                    planner_backend=planner_backend,
+                )
+                _plan_result.append(content)
+            except Exception as exc:
+                _plan_exc.append(exc)
+
+        plan_worker = threading.Thread(target=_run_planning, daemon=True)
+        plan_worker.start()
+        plan_worker.join(timeout=planning_timeout)
+
+        _planning_elapsed = time.time() - _planning_start
         if timing_bucket is not None:
-            timing_bucket.append({"planning_time": time.time() - _planning_start})
+            timing_bucket.append({"planning_time": _planning_elapsed})
+
+        if plan_worker.is_alive():
+            print(f"  Planning timeout after {planning_timeout}s — using raw problem statement",
+                  file=sys.stderr)
+            if timing_bucket is not None:
+                timing_bucket[0]["planning_timed_out"] = True
+            issue_content = (
+                f"# SWE-bench Task\n\n"
+                f"## Problem Statement\n\n{problem_statement}\n\n"
+                f"## Instructions\n\nImplement the fix. Make minimal changes.\n"
+            )
+        elif _plan_exc:
+            print(f"  Planning error: {_plan_exc[0]}", file=sys.stderr)
+            issue_content = (
+                f"# SWE-bench Task\n\n"
+                f"## Problem Statement\n\n{problem_statement}\n\n"
+                f"## Instructions\n\nImplement the fix. Make minimal changes.\n"
+            )
+        else:
+            issue_content = _plan_result[0] if _plan_result else ""
+
     issue_file.write_text(issue_content, encoding="utf-8")
 
     # Ensure subprocesses default to the worktree so Claude's tools

--- a/python/agentize/eval/eval_harness.py
+++ b/python/agentize/eval/eval_harness.py
@@ -758,7 +758,6 @@ def run_full_impl(
 
     def _run_pipeline():
         try:
-            planning_start = time.time()
             status = _run_full_impl_body(
                 wt_path, overrides_path, instance_id,
                 problem_statement, model,
@@ -766,11 +765,8 @@ def run_full_impl(
                 skip_planning=skip_planning,
                 planner_backend=planner_backend,
                 impl_backend=impl_backend,
+                timing_bucket=timing_bucket,
             )
-            # Record phase timing — planning ends when FSM starts (approximated
-            # by total time minus impl time; the split point is inside
-            # _run_full_impl_body which we can't instrument without changing its
-            # return type, so we use wall_time as the authoritative total)
             status_bucket.append(status)
         except Exception as exc:
             exc_bucket.append(exc)
@@ -790,6 +786,11 @@ def run_full_impl(
     else:
         result["status"] = status_bucket[0] if status_bucket else "error"
         result["wall_time"] = time.time() - start_time
+
+    # Extract phase timing from daemon thread
+    if timing_bucket:
+        result["planning_time"] = timing_bucket[0].get("planning_time", 0.0)
+        result["impl_time"] = result["wall_time"] - result["planning_time"]
 
     # Compute cost from NEW JSONL files only (created during this run)
     files_after = _list_jsonl_files()
@@ -819,6 +820,7 @@ def _run_full_impl_body(
     plan_override: str | None = None,
     planner_backend: str | None = None,
     impl_backend: str | None = None,
+    timing_bucket: list[dict] | None = None,
 ) -> str:
     """Inner body of run_full_impl — runs planning + FSM, returns status string.
 
@@ -858,6 +860,7 @@ def _run_full_impl_body(
             f"## Instructions\n\nImplement the fix. Make minimal changes.\n"
         )
     else:
+        _planning_start = time.time()
         issue_content = run_planning_phase(
             problem_statement,
             tmp_dir,
@@ -865,6 +868,8 @@ def _run_full_impl_body(
             cwd=wt,
             planner_backend=planner_backend,
         )
+        if timing_bucket is not None:
+            timing_bucket.append({"planning_time": time.time() - _planning_start})
     issue_file.write_text(issue_content, encoding="utf-8")
 
     # Ensure subprocesses default to the worktree so Claude's tools
@@ -1464,8 +1469,11 @@ def _cmd_run(args) -> int:
             )
         results.append(result)
         cost_str = f", Cost: ${result['cost_usd']:.4f}" if result.get("cost_usd") else ""
+        phase_str = ""
+        if result.get("planning_time", 0) > 0:
+            phase_str = f" (plan: {result['planning_time']:.0f}s, impl: {result['impl_time']:.0f}s)"
         print(f"  Status: {result['status']}, "
-              f"Time: {result['wall_time']:.1f}s, "
+              f"Time: {result['wall_time']:.1f}s{phase_str}, "
               f"Tokens: {result['tokens']}{cost_str}")
 
         # Extract patch

--- a/python/agentize/eval/eval_harness.py
+++ b/python/agentize/eval/eval_harness.py
@@ -1534,11 +1534,15 @@ def _cmd_run(args) -> int:
             else:
                 print(f"  No changes detected")
 
-        # Incremental save: write predictions after each task so progress survives crashes
+        # Incremental save: write predictions and results after each task
         if predictions:
             with open(predictions_path, "w", encoding="utf-8") as f:
                 for pred in predictions:
                     f.write(json.dumps(pred) + "\n")
+        results_path = output_dir / "results.jsonl"
+        with open(results_path, "w", encoding="utf-8") as f:
+            for r in results:
+                f.write(json.dumps(r) + "\n")
 
         # Cleanup worktree to save disk space
         if getattr(args, "cleanup", False) and not is_nginx:
@@ -1555,8 +1559,14 @@ def _cmd_run(args) -> int:
                 f.write(json.dumps(pred) + "\n")
         print(f"\nPredictions written to {predictions_path}")
 
-    # Write metrics
+    # Write per-task results and metrics
     if results:
+        results_path = output_dir / "results.jsonl"
+        with open(results_path, "w", encoding="utf-8") as f:
+            for r in results:
+                f.write(json.dumps(r) + "\n")
+        print(f"Results written to {results_path}")
+
         metrics = aggregate_metrics(results)
         metrics_path.write_text(
             json.dumps(metrics, indent=2) + "\n", encoding="utf-8",

--- a/python/tests/test_eval_harness.md
+++ b/python/tests/test_eval_harness.md
@@ -7,7 +7,9 @@ Tests for `agentize.eval.eval_harness` pure functions.
 - `_compute_cost`: Cache-tier-aware pricing with `cache_read` and `cache_write` parameters
 - `_parse_claude_usage`: Cache token extraction from `claude -p` JSON output
 - `_sum_jsonl_usage`: Deduplication by `message.id` to avoid counting streamed content blocks
-- `aggregate_metrics`: Cost aggregation across task results
+- `aggregate_metrics`: Cost + per-phase timing aggregation across task results
+- `run_nlcmd_impl`: Planning-timeout status handling
+- `_make_result`: Default timing fields (`planning_time`, `impl_time`)
 - `extract_patch`: Git diff extraction from worktrees
 - `write_overrides`: Shell override generation for eval isolation
 

--- a/python/tests/test_eval_harness.py
+++ b/python/tests/test_eval_harness.py
@@ -369,6 +369,12 @@ class TestMakeResult:
         assert result["tokens"] == 0
         assert result["status"] == "error"
 
+    def test_has_timing_fields(self):
+        result = _make_result("test-timing")
+        assert result["planning_time"] == 0.0
+        assert result["impl_time"] == 0.0
+        assert result["wall_time"] == 0.0
+
 
 class TestParseClaudeUsage:
     def test_valid_json_with_usage(self):
@@ -552,6 +558,49 @@ class TestAggregateMetricsCost:
         assert metrics["cost_mean_usd"] == 0.0
 
 
+class TestAggregateMetricsPhaseTimming:
+    def test_planning_impl_time_aggregation(self):
+        results = [
+            {
+                "instance_id": "a", "status": "completed",
+                "tokens": 100, "wall_time": 100.0,
+                "planning_time": 60.0, "impl_time": 40.0,
+            },
+            {
+                "instance_id": "b", "status": "completed",
+                "tokens": 200, "wall_time": 200.0,
+                "planning_time": 120.0, "impl_time": 80.0,
+            },
+        ]
+        metrics = aggregate_metrics(results)
+        assert metrics["planning_time_total"] == pytest.approx(180.0)
+        assert metrics["planning_time_mean"] == pytest.approx(90.0)
+        assert metrics["impl_time_total"] == pytest.approx(120.0)
+        assert metrics["impl_time_mean"] == pytest.approx(60.0)
+
+    def test_planning_timeouts_counted(self):
+        results = [
+            {"instance_id": "a", "status": "planning_timeout",
+             "tokens": 0, "wall_time": 600.0,
+             "planning_time": 600.0, "impl_time": 0.0},
+            {"instance_id": "b", "status": "completed",
+             "tokens": 100, "wall_time": 100.0,
+             "planning_time": 50.0, "impl_time": 50.0},
+        ]
+        metrics = aggregate_metrics(results)
+        assert metrics["planning_timeouts"] == 1
+
+    def test_zero_timing_when_not_present(self):
+        results = [
+            {"instance_id": "a", "status": "completed",
+             "tokens": 100, "wall_time": 10.0},
+        ]
+        metrics = aggregate_metrics(results)
+        assert metrics["planning_time_total"] == 0.0
+        assert metrics["impl_time_total"] == 0.0
+        assert metrics["planning_timeouts"] == 0
+
+
 class TestPlannerCmdTemplates:
     def test_ultra_planner_template(self):
         """ultra-planner template should include --force-full and --dry-run."""
@@ -689,6 +738,50 @@ class TestNlcmdImpl:
         assert result["cache_write_tokens"] == 20
         assert result["tokens"] == 300
         assert result["cost_usd"] == 1.50
+
+    def test_planning_timeout_status(self, tmp_path, monkeypatch):
+        """run_nlcmd_impl should emit 'planning_timeout' when planning exceeds limit."""
+        def _slow_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", _slow_run)
+        monkeypatch.setattr(
+            "agentize.eval.eval_harness._list_jsonl_files", lambda: set()
+        )
+
+        overrides = write_overrides(tmp_path, "nlcmd-ptimeout")
+        result = run_nlcmd_impl(
+            wt_path=str(tmp_path),
+            overrides_path=overrides,
+            instance_id="nlcmd-ptimeout",
+            problem_statement="test",
+            timeout=4,
+            planning_timeout=1,
+        )
+        assert result["status"] == "planning_timeout"
+        assert result["planning_time"] > 0.0
+
+    def test_planning_time_recorded(self, tmp_path, monkeypatch):
+        """run_nlcmd_impl should record planning_time even on timeout."""
+        def _slow_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", _slow_run)
+        monkeypatch.setattr(
+            "agentize.eval.eval_harness._list_jsonl_files", lambda: set()
+        )
+
+        overrides = write_overrides(tmp_path, "nlcmd-ptime")
+        result = run_nlcmd_impl(
+            wt_path=str(tmp_path),
+            overrides_path=overrides,
+            instance_id="nlcmd-ptime",
+            problem_statement="test",
+            timeout=4,
+            planning_timeout=1,
+        )
+        assert "planning_time" in result
+        assert result["planning_time"] >= 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_eval_harness.py
+++ b/python/tests/test_eval_harness.py
@@ -662,7 +662,7 @@ class TestNlcmdImpl:
             problem_statement="test problem",
             timeout=2,
         )
-        assert result["status"] == "timeout"
+        assert result["status"] == "planning_timeout"
 
     def test_unknown_planner_returns_error(self, tmp_path):
         overrides = write_overrides(tmp_path, "nlcmd-bad")


### PR DESCRIPTION
## Summary

- Add `planning_time` and `impl_time` per-task fields to eval harness results
- Add `--planning-timeout` CLI flag (default 600s) replacing hardcoded `timeout // 2`
- New `planning_timeout` status when planning exceeds the configured limit
- Extend `aggregate_metrics` with `planning_time_total/mean`, `impl_time_total/mean`, `planning_timeouts`
- Phase timing breakdown in `_print_summary` output
- New `python/agentize/eval/README.md` folder description

## Test plan

- [x] 68/68 Python tests pass
- [x] New tests: timing field defaults, planning_timeout status, phase timing aggregation
- [x] Updated existing nlcmd timeout test for new planning_timeout status
- [x] Backward compatible: raw/impl modes have planning_time=0.0

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
